### PR TITLE
Updated getInvoiceAttachmentByFileName to handle binary response

### DIFF
--- a/spec/v3/Xero_accounting_2.0.0_swagger.json
+++ b/spec/v3/Xero_accounting_2.0.0_swagger.json
@@ -4115,14 +4115,10 @@
           "200" : {
             "description" : "A successful request",
             "content" : {
-              "text/xml" : {
+              "application/octet-stream" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Attachments"
-                }
-              },
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Attachments"
+                  "type" : "string",
+                  "format" : "binary"
                 }
               }
             }

--- a/spec/v3/Xero_accounting_2.0.0_swagger.yaml
+++ b/spec/v3/Xero_accounting_2.0.0_swagger.yaml
@@ -2884,12 +2884,10 @@ paths:
         '200':
           description: A successful request
           content:
-            text/xml:
+            application/octet-stream:
               schema:
-                $ref: '#/components/schemas/Attachments'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Attachments'
+                type: string
+                format: binary
       parameters:
         - required: true
           in: path


### PR DESCRIPTION
According to the documentation, this endpoint should return a binary response containing the raw content, updated the spec for this endpoint to adjust the response type.

See: https://developer.xero.com/documentation/api/attachments (GET Attachment Content)