### PR TITLE
Swaggerhub

### DIFF
--- a/accounting-json/Xero_accounting_2.0.0_swagger.json
+++ b/accounting-json/Xero_accounting_2.0.0_swagger.json
@@ -9312,7 +9312,7 @@
             "type" : "string"
           },
           "PaymentTerms" : {
-            "$ref" : "#/components/schemas/PaymentTermType"
+            "$ref" : "#/components/schemas/PaymentTerm"
           },
           "UpdatedDateUTC" : {
             "description" : "UTC timestamp of last update to contact",

--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -6683,7 +6683,7 @@ components:
             SalesTrackingCategories and PurchasesTrackingCategories
           type: string
         PaymentTerms:
-          $ref: '#/components/schemas/PaymentTermType'
+          $ref: '#/components/schemas/PaymentTerm'
         UpdatedDateUTC:
           description: UTC timestamp of last update to contact
           type: string


### PR DESCRIPTION
Fix paymentTerm on contact was set to ENUM PaymentTermType when it should be the PaymentTerm object.