### PR TITLE
Fix a few OpenAPI validation errors bankfeeds API

### DIFF
--- a/bankfeeds-json/Xero_bankfeeds_1.0.0_swagger.json
+++ b/bankfeeds-json/Xero_bankfeeds_1.0.0_swagger.json
@@ -15,7 +15,7 @@
   },
   "servers" : [ {
     "description" : "Xero Bank Feeds API base url",
-    "url" : "https://api.xero.com/bankfeeds.xro/1.0/"
+    "url" : "https://api.xero.com/bankfeeds.xro/1.0"
   } ],
   "paths" : {
     "/FeedConnections" : {
@@ -42,7 +42,7 @@
           }
         } ],
         "security" : [ {
-          "apiKey" : [ ]
+          "ApiKeyAuth" : [ ]
         } ],
         "responses" : {
           "201" : {
@@ -89,7 +89,7 @@
         "operationId" : "createFeedConnections",
         "description" : "By passing in the appropriate body, you can create one or more new feed connections in the system\n",
         "security" : [ {
-          "apiKey" : [ ]
+          "ApiKeyAuth" : [ ]
         } ],
         "requestBody" : {
           "required" : true,
@@ -166,7 +166,7 @@
           }
         } ],
         "security" : [ {
-          "apiKey" : [ ]
+          "ApiKeyAuth" : [ ]
         } ],
         "responses" : {
           "200" : {
@@ -200,7 +200,7 @@
         "operationId" : "deleteFeedConnections",
         "description" : "By passing in the appropriate body, you can create a new feed connections in the system\n",
         "security" : [ {
-          "apiKey" : [ ]
+          "ApiKeyAuth" : [ ]
         } ],
         "requestBody" : {
           "required" : true,
@@ -256,6 +256,7 @@
       "get" : {
         "tags" : [ "BankFeeds" ],
         "operationId" : "getStatements",
+        "description": "Retrieve all statements for an organisation",
         "parameters" : [ {
           "in" : "query",
           "name" : "page",
@@ -353,6 +354,7 @@
       "post" : {
         "tags" : [ "BankFeeds" ],
         "operationId" : "createStatements",
+        "description": "Create bank statements for one or more feed connections",
         "responses" : {
           "202" : {
             "description" : "Success",
@@ -553,6 +555,7 @@
       "get" : {
         "tags" : [ "BankFeeds" ],
         "operationId" : "getStatement",
+        "description": "Retrieve a single Statement by ID",
         "parameters" : [ {
           "name" : "statementId",
           "in" : "path",

--- a/bankfeeds-yaml/Xero_bankfeeds_1.0.0_swagger.yaml
+++ b/bankfeeds-yaml/Xero_bankfeeds_1.0.0_swagger.yaml
@@ -11,7 +11,7 @@ info:
     url: 'https://github.com/XeroAPI/Xero-OpenAPI/blob/master/LICENSE'
 servers:
   - description: Xero Bank Feeds API base url
-    url: https://api.xero.com/bankfeeds.xro/1.0/
+    url: https://api.xero.com/bankfeeds.xro/1.0
 paths:
   /FeedConnections:
     get:
@@ -36,7 +36,7 @@ paths:
             type: integer
             example: 100
       security:
-       - apiKey: []
+       - ApiKeyAuth: []
       responses:
         '201':
           description: search results matching criteria
@@ -81,7 +81,7 @@ paths:
         description: |
           By passing in the appropriate body, you can create one or more new feed connections in the system
         security:
-         - apiKey: []
+         - ApiKeyAuth: []
         requestBody:
           required: true
           content:
@@ -153,7 +153,7 @@ paths:
             type: string 
             example: xxxx
       security:
-       - apiKey: []
+       - ApiKeyAuth: []
       responses:
         '200':
           description: search results matching criteria
@@ -181,7 +181,7 @@ paths:
       description: |
         By passing in the appropriate body, you can create a new feed connections in the system
       security:
-       - apiKey: []
+       - ApiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -229,6 +229,7 @@ paths:
       tags:
         - BankFeeds
       operationId: getStatements
+      description: Retrieve all statements for an organisation
       parameters:
         - in: query
           name: page
@@ -310,6 +311,7 @@ paths:
       tags:
         - BankFeeds
       operationId: createStatements
+      description: Create bank statements for one or more feed connections
       responses:
         '202':
           description: Success
@@ -490,6 +492,7 @@ paths:
       tags:
         - BankFeeds
       operationId: getStatement
+      description: Retrieve a single Statement by ID
       parameters:
         - name: statementId
           in: path


### PR DESCRIPTION
* Server URL should not have a trailing slash.
* Description fields need to be just about everywhere.
* Security scheme for endpoints must match the scheme defined.

Nothing here should change functionality, but removes validation errors and warnings in OpenAPI editors.