### PR TITLE
added DELETE type to Expense Claim Status Codes

### DIFF
--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -19207,6 +19207,7 @@ components:
           - AUTHORISED
           - PAID
           - VOIDED
+          - DELETED
         Payments:
           description: See Payments
           type: array


### PR DESCRIPTION
When testing with Demo Company (AU) a type of "DELETE" was returned in Expense Claim Status. Hence the pull request. 

        Status:
          description: Current status of an expense claim – see status types
          type: string
          enum:
          - SUBMITTED  
          - AUTHORISED
          - PAID
          - VOIDED
          **- DELETED** <= this is found missing