### PR TITLE
added Tax Report Types

### DIFF
--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -21441,6 +21441,18 @@ components:
           - OUTPUT
           - PURCHASESINPUT
           - SALESOUTPUT
+          - EXEMPTCAPITAL
+          - EXEMPTEXPORT
+          - CAPITALEXINPUT
+          - GSTONCAPIMPORTS
+          - REVERSECHARGES
+          - PAYMENTS
+          - INVOICE
+          - CASH
+          - ACCRUAL
+          - FLATRATECASH
+          - FLATRATEACCRUAL
+          - ACCRUALS
         CanApplyToAssets:
           description: Boolean to describe if tax rate can be used for asset accounts i.e.  true,false
           readOnly: true


### PR DESCRIPTION
When testing with Demo Company (AU) to get tax rates, a few missing Report Tax Types were discovered. I have compared & added following Report Tax Types to OAS spec as per our documentation on dev portal:
          - EXEMPTCAPITAL
          - EXEMPTEXPORT
          - CAPITALEXINPUT
          - GSTONCAPIMPORTS
          - REVERSECHARGES
          - PAYMENTS
          - INVOICE
          - CASH
          - ACCRUAL
          - FLATRATECASH
          - FLATRATEACCRUAL
          - ACCRUALS

A report on missing Report Tax Types:
![image](https://user-images.githubusercontent.com/41350731/67179584-775a9000-f422-11e9-9921-87a97158f5f6.png)