### PR TITLE
Update Xero_accounting_2.0.0_swagger.yaml

### DIFF
--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -21303,8 +21303,7 @@ components:
           type: string
           format: uuid
         CurrencyRate:
-          description: The currency rate for a multicurrency purchase order. As no rate can  be specified, the XE.com day rate is used.
-          readOnly: true
+          description: The currency rate for a multicurrency purchase order. If no rate is specified, the XE.com day rate is used.
           type: number
           format: double
         SubTotal:


### PR DESCRIPTION
Remove readonly attribute from PurchaseOrder:CurrencyRate to align with Invoice & Credit Note (and to replicate the API1.0 design).