### PR TITLE
Add x-path vendor extension

### DIFF
--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -7300,6 +7300,7 @@ paths:
       tags:
         - Accounting
       operationId: getInvoiceAsPdf
+      x-path: '/Invoices/{InvoiceID}'
       summary: Allows you to retrieve invoices or purchase bills as PDF files
       parameters:
         - required: true


### PR DESCRIPTION
This is to address the edge case where we want a method to "getInvoiceAsPDF and have it return binary data and not a JSON object.

It has the same path as "getInvoice" and in order to get this edge case into the spec we used /Invoices/{InvoiceId}/pdf as the path.

This will require each language to override the path value with x-path if x-path exists.

This is how it looks in the typescript-node mustache template

const localVarPath = this.basePath + '{{#vendorExtensions}}{{#x-path}}{{{x-path}}}{{/x-path}}{{^x-path}}{{{path}}}{{/x-path}}{{/vendorExtensions}}'{{#pathParams}}