### PR TITLE
Add x-path vendor extension // docs // dup ENUM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -19869,7 +19869,6 @@ components:
           - ACCREC
           - ACCRECCREDIT
           - AROVERPAYMENT
-          - APPREPAYMENT
         Contact:
           $ref: '#/components/schemas/Contact'
         LineItems:

--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -1002,7 +1002,7 @@ paths:
             type: integer
         - in: query
           name: unitdp
-          description: e.g. unitdp=4 – You can opt in to use four decimal places for unit amounts
+          description: e.g. unitdp=4 – (Unit Decimal Places) You can opt in to use four decimal places for unit amounts
           schema:
             type: integer
       responses:
@@ -6462,7 +6462,7 @@ paths:
             type: boolean
         - in: query
           name: unitdp
-          description: e.g. unitdp=4 – You can opt in to use four decimal places for unit amounts
+          description: e.g. unitdp=4 – (Unit Decimal Places) You can opt in to use four decimal places for unit amounts
           schema:
             type: integer
       responses:
@@ -7784,7 +7784,7 @@ paths:
             type: string
         - in: query
           name: unitdp
-          description: e.g. unitdp=4 – You can opt in to use four decimal places for unit amounts
+          description: e.g. unitdp=4 – (Unit Decimal Places) You can opt in to use four decimal places for unit amounts
           schema:
             type: integer
       responses:
@@ -9512,7 +9512,7 @@ paths:
             type: integer
         - in: query
           name: unitdp
-          description: e.g. unitdp=4 – You can opt in to use four decimal places for unit amounts
+          description: e.g. unitdp=4 – (Unit Decimal Places) You can opt in to use four decimal places for unit amounts
           schema:
             type: integer
       responses:
@@ -10868,7 +10868,7 @@ paths:
             type: integer
         - in: query
           name: unitdp
-          description: e.g. unitdp=4 – You can opt in to use four decimal places for unit amounts
+          description: e.g. unitdp=4 – (Unit Decimal Places) You can opt in to use four decimal places for unit amounts
           schema:
             type: integer
       responses:
@@ -12401,7 +12401,7 @@ paths:
             type: string
         - in: query
           name: unitdp
-          description: e.g. unitdp=4 – You can opt in to use four decimal places for unit amounts
+          description: e.g. unitdp=4 – (Unit Decimal Places) You can opt in to use four decimal places for unit amounts
           schema:
             type: integer
       responses:

--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -6439,7 +6439,8 @@ paths:
         - in: query
           name: Statuses
           description: Filter by a comma-separated list Statuses. For faster response times we recommend using these explicit parameters instead of passing OR conditions into the Where filter.
-          style: simple
+          simple: true
+          style: form
           explode: false
           schema:
             type: array

--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -6439,7 +6439,7 @@ paths:
         - in: query
           name: Statuses
           description: Filter by a comma-separated list Statuses. For faster response times we recommend using these explicit parameters instead of passing OR conditions into the Where filter.
-          style: form
+          style: simple
           explode: false
           schema:
             type: array

--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -6439,8 +6439,7 @@ paths:
         - in: query
           name: Statuses
           description: Filter by a comma-separated list Statuses. For faster response times we recommend using these explicit parameters instead of passing OR conditions into the Where filter.
-          simple: true
-          style: form
+          style: simple
           explode: false
           schema:
             type: array


### PR DESCRIPTION
This is to address the edge case where we want a method to "getInvoiceAsPDF and have it return binary data and not a JSON object.

It has the same path as "getInvoice" and in order to get this edge case into the spec we used /Invoices/{InvoiceId}/pdf as the path.

This will require each language to override the path value with x-path if x-path exists.

This is how it looks in the typescript-node mustache template

const localVarPath = this.basePath + '{{#vendorExtensions}}{{#x-path}}{{{x-path}}}{{/x-path}}{{^x-path}}{{{path}}}{{/x-path}}{{/vendorExtensions}}'{{#pathParams}}

---------

Remove a duplicate Enum

-------

Explain unitdp