### PR TITLE
file upload x- to not add json true to headers

### DIFF
--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -557,6 +557,7 @@ paths:
         - Accounting
       operationId: createAccountAttachmentByFileName
       summary: Allows you to create Attachment on Account
+      x-isAttachmentUpload: true
       parameters:
         - required: true
           in: path
@@ -6941,6 +6942,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
         - Accounting
       operationId: createInvoiceAttachmentByFileName
       summary: Allows you to create an Attachment on invoices or purchase bills by it's filename
+      x-isAttachmentUpload: true
       parameters:
         - required: true
           in: path


### PR DESCRIPTION
Adds `x-isAttachmentUpload` - then mustache template won't add `json: true` for file uploading functions so the image data can be serialized correctly