### PR TITLE
Move x-isAttachment to response venderExtensions - and add it for all attachment related inquiries that require binary response data

### DIFF
--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -497,6 +497,7 @@ paths:
       tags:
         - Accounting
       operationId: updateAccountAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to update Attachment on Account by Filename
       parameters:
         - required: true
@@ -556,8 +557,8 @@ paths:
       tags:
         - Accounting
       operationId: createAccountAttachmentByFileName
-      summary: Allows you to create Attachment on Account
       x-isAttachmentUpload: true
+      summary: Allows you to create Attachment on Account
       parameters:
         - required: true
           in: path
@@ -1786,6 +1787,7 @@ paths:
       tags:
         - Accounting
       operationId: updateBankTransactionAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to update an Attachment on BankTransaction by Filename
       parameters:
         - required: true
@@ -1841,6 +1843,7 @@ paths:
       tags:
         - Accounting
       operationId: createBankTransactionAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to createa an Attachment on BankTransaction by Filename
       parameters:
         - required: true
@@ -2273,6 +2276,7 @@ paths:
       tags:
         - Accounting
       operationId: updateBankTransferAttachmentByFileName
+      x-isAttachmentUpload: true
       parameters:
         - required: true
           in: path
@@ -2327,6 +2331,7 @@ paths:
       tags:
         - Accounting
       operationId: createBankTransferAttachmentByFileName
+      x-isAttachmentUpload: true
       parameters:
         - required: true
           in: path
@@ -3518,6 +3523,7 @@ paths:
       tags:
         - Accounting
       operationId: updateContactAttachmentByFileName
+      x-isAttachmentUpload: true
       parameters:
         - required: true
           in: path
@@ -3572,6 +3578,7 @@ paths:
       tags:
         - Accounting
       operationId: createContactAttachmentByFileName
+      x-isAttachmentUpload: true
       parameters:
         - required: true
           in: path
@@ -4847,6 +4854,7 @@ paths:
       tags:
         - Accounting
       operationId: updateCreditNoteAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to update Attachments on CreditNote by file name
       parameters:
         - required: true
@@ -4902,6 +4910,7 @@ paths:
       tags:
         - Accounting
       operationId: createCreditNoteAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to create Attachments on CreditNote by file name
       parameters:
         - required: true
@@ -6886,6 +6895,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: updateInvoiceAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to update Attachment on invoices or purchase bills by it's filename
       parameters:
         - required: true
@@ -6941,8 +6951,8 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: createInvoiceAttachmentByFileName
-      summary: Allows you to create an Attachment on invoices or purchase bills by it's filename
       x-isAttachmentUpload: true
+      summary: Allows you to create an Attachment on invoices or purchase bills by it's filename
       parameters:
         - required: true
           in: path
@@ -8598,6 +8608,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: updateManualJournalAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to update a specified Attachment on ManualJournal by file name
       parameters:
         - required: true
@@ -8653,6 +8664,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: createManualJournalAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to create a specified Attachment on ManualJournal by file name
       parameters:
         - required: true
@@ -12305,6 +12317,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: updateReceiptAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to update Attachment on expense claim receipts by file name
       parameters:
         - required: true
@@ -12360,6 +12373,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: createReceiptAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to create Attachment on expense claim receipts by file name
       parameters:
         - required: true
@@ -12810,6 +12824,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: updateRepeatingInvoiceAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to update specified attachment on repeating invoices by file name
       parameters:
         - required: true
@@ -12865,6 +12880,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: createRepeatingInvoiceAttachmentByFileName
+      x-isAttachmentUpload: true
       summary: Allows you to create attachment on repeating invoices by file name
       parameters:
         - required: true

--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -387,6 +387,7 @@ paths:
       responses:
         '200':
           description: Success - return response of type Attachments array of Attachment 
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -497,7 +498,6 @@ paths:
       tags:
         - Accounting
       operationId: updateAccountAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to update Attachment on Account by Filename
       parameters:
         - required: true
@@ -518,6 +518,7 @@ paths:
       responses:
         '200':
           description: Success - return response of type Attachments array of Attachment 
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -557,7 +558,6 @@ paths:
       tags:
         - Accounting
       operationId: createAccountAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to create Attachment on Account
       parameters:
         - required: true
@@ -578,6 +578,7 @@ paths:
       responses:
         '200':
           description: Success - return response of type Attachments array of Attachment 
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -1670,6 +1671,7 @@ paths:
       responses:
         '200':
           description: Success - return response of type Attachments array with 0 to n Attachment 
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -1787,7 +1789,6 @@ paths:
       tags:
         - Accounting
       operationId: updateBankTransactionAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to update an Attachment on BankTransaction by Filename
       parameters:
         - required: true
@@ -1808,6 +1809,7 @@ paths:
       responses:
         '200':
           description: Success - return response of Attachments array of Attachment 
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -1843,7 +1845,6 @@ paths:
       tags:
         - Accounting
       operationId: createBankTransactionAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to createa an Attachment on BankTransaction by Filename
       parameters:
         - required: true
@@ -1864,6 +1865,7 @@ paths:
       responses:
         '200':
           description: Success - return response of Attachments array of Attachment 
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -2166,6 +2168,7 @@ paths:
       responses:
         '200':
           description: Success - return response of Attachments array of 0 to N Attachment for a Bank Transfer 
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -2276,7 +2279,6 @@ paths:
       tags:
         - Accounting
       operationId: updateBankTransferAttachmentByFileName
-      x-isAttachmentUpload: true
       parameters:
         - required: true
           in: path
@@ -2296,6 +2298,7 @@ paths:
       responses:
         '200':
           description: Success - return response of Attachments array of 0 to N Attachment for a Bank Transfer 
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -2331,7 +2334,6 @@ paths:
       tags:
         - Accounting
       operationId: createBankTransferAttachmentByFileName
-      x-isAttachmentUpload: true
       parameters:
         - required: true
           in: path
@@ -2351,6 +2353,7 @@ paths:
       responses:
         '200':
           description: Success - return response of Attachments array of 0 to N Attachment for a Bank Transfer 
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -3404,6 +3407,7 @@ paths:
       responses:
         '200':
           description: Success - return response of type Attachments array with 0 to N Attachment
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -3523,7 +3527,6 @@ paths:
       tags:
         - Accounting
       operationId: updateContactAttachmentByFileName
-      x-isAttachmentUpload: true
       parameters:
         - required: true
           in: path
@@ -3543,6 +3546,7 @@ paths:
       responses:
         '200':
           description: Success - return response of type Attachments array with an updated Attachment
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -3578,7 +3582,6 @@ paths:
       tags:
         - Accounting
       operationId: createContactAttachmentByFileName
-      x-isAttachmentUpload: true
       parameters:
         - required: true
           in: path
@@ -3598,6 +3601,7 @@ paths:
       responses:
         '200':
           description: Success - return response of type Attachments array with an newly created Attachment
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -4744,6 +4748,7 @@ paths:
       responses:
         '200':
           description: Success - return response of type Attachments array with all Attachment for specific Credit Note
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -4854,7 +4859,6 @@ paths:
       tags:
         - Accounting
       operationId: updateCreditNoteAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to update Attachments on CreditNote by file name
       parameters:
         - required: true
@@ -4875,6 +4879,7 @@ paths:
       responses:
         '200':
           description: Success - return response of type Attachments array with updated Attachment for specific Credit Note
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -4910,7 +4915,6 @@ paths:
       tags:
         - Accounting
       operationId: createCreditNoteAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to create Attachments on CreditNote by file name
       parameters:
         - required: true
@@ -4937,6 +4941,7 @@ paths:
       responses:
         '200':
           description: Success - return response of type Attachments array with newly created Attachment for specific Credit Note
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -6777,6 +6782,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array of Attachments for specified Invoices
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -6895,7 +6901,6 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: updateInvoiceAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to update Attachment on invoices or purchase bills by it's filename
       parameters:
         - required: true
@@ -6916,6 +6921,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array with updated Attachment
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -6951,7 +6957,6 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: createInvoiceAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to create an Attachment on invoices or purchase bills by it's filename
       parameters:
         - required: true
@@ -6978,6 +6983,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array with newly created Attachment
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -8491,6 +8497,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array with all Attachments for a ManualJournals
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -8608,7 +8615,6 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: updateManualJournalAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to update a specified Attachment on ManualJournal by file name
       parameters:
         - required: true
@@ -8629,6 +8635,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array with an update Attachment for a ManualJournals
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -8664,7 +8671,6 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: createManualJournalAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to create a specified Attachment on ManualJournal by file name
       parameters:
         - required: true
@@ -8685,6 +8691,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array with a newly created Attachment for a ManualJournals
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -12207,6 +12214,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array of Attachments for a specified Receipt   
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -12317,7 +12325,6 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: updateReceiptAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to update Attachment on expense claim receipts by file name
       parameters:
         - required: true
@@ -12338,6 +12345,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array with updated Attachment for a specified Receipt   
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -12373,7 +12381,6 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: createReceiptAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to create Attachment on expense claim receipts by file name
       parameters:
         - required: true
@@ -12394,6 +12401,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array with newly created Attachment for a specified Receipt   
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -12700,6 +12708,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array with all Attachments for a specified Repeating Invoice   
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -12824,7 +12833,6 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: updateRepeatingInvoiceAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to update specified attachment on repeating invoices by file name
       parameters:
         - required: true
@@ -12845,6 +12853,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array with specified Attachment for a specified Repeating Invoice   
+          x-isAttachment: true
           content:
             application/json:
               schema:
@@ -12880,7 +12889,6 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       tags:
         - Accounting
       operationId: createRepeatingInvoiceAttachmentByFileName
-      x-isAttachmentUpload: true
       summary: Allows you to create attachment on repeating invoices by file name
       parameters:
         - required: true
@@ -12901,6 +12909,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           description: Success - return response of type Attachments array with updated Attachment for a specified Repeating Invoice   
+          x-isAttachment: true
           content:
             application/json:
               schema:


### PR DESCRIPTION
All attachment creates / updates / gets use `x-isAttachment` to ensure request data is not malformed into json.