### PR TITLE
Added "ARCHIEVED" Status to Manual Journal Object

### DIFF
--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -19509,6 +19509,7 @@ components:
           - POSTED
           - DELETED
           - VOIDED
+          - ARCHIVED
         Url:
           description:  Url link to a source document – shown as “Go to [appName]” in the
             Xero app


### PR DESCRIPTION
Thanks to @lukesawyer, a missing enum in Manual Journal Object is discovered. 

Instructions to create an archived manual journal entry: 
https://central.xero.com/s/article/Void-archive-or-delete-multiple-journals#Archiveorrestorepostedmanualjournals

An example of an "ARCHIEVED" manual journal returned via API:
```
    <ManualJournal>
      <Date>2019-07-24T00:00:00</Date>
      <Status>ARCHIVED</Status>
      <LineAmountTypes>Exclusive</LineAmountTypes>
      <UpdatedDateUTC>2020-02-12T01:04:32.277</UpdatedDateUTC>
      <ManualJournalID>bb6cfcfc-4500-4475-bd3a-93ee512428e0</ManualJournalID>
      <Narration>Being depreciation on office equipment</Narration>
      <ShowOnCashBasisReports>true</ShowOnCashBasisReports>
      <HasAttachments>false</HasAttachments>
    </ManualJournal>
```
