### PR TITLE
Fix unit decimal point issue in objects

### DIFF
--- a/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+++ b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
@@ -17889,11 +17889,11 @@ components:
         Quantity:
           description: LineItem Quantity
           type: number
-          format: double
+          format: float
         UnitAmount:
           description: LineItem Unit Amount
           type: number
-          format: double
+          format: float
         ItemCode:
           description: See Items
           type: string
@@ -19229,7 +19229,7 @@ components:
         QuantityOnHand:
           description: The quantity of the item on hand
           type: number
-          format: double
+          format: float
         UpdatedDateUTC:
           description: Last modified date in UTC format
           type: string
@@ -19258,7 +19258,7 @@ components:
             decimal places. You can use 4 decimal places by adding the unitdp=4
             querystring parameter to your request.
           type: number
-          format: double
+          format: float
         AccountCode:
           description:  Default account code to be used for purchased/sale. Not applicable to the purchase details of tracked items
           type: string


### PR DESCRIPTION
To address the use case where a queryString includes the unitdp=4 param we need to change objects with attributes that support more than two decimal points to to change the number datatype from double to float.

Objects that use LineItems are impacted
- BankTransations
- CreditNotes
- Invoices
- Receipts

the two properties that changed from double to float
- Quantity
- UnitAmount

The item object has two properties that chagned from double to float
- UnitPrice
- QuantityOnHand