### PR TITLE
Update identity with new vendorExtension

### DIFF
--- a/identity-yaml/xero-identity.yaml
+++ b/identity-yaml/xero-identity.yaml
@@ -86,12 +86,12 @@ components:
         createdDateUTC:
           description: The date when the user connected this tenant to your app
           type: string
-          x-java-format: "LocalDateTime" 
+          x-is-datetime: true
           x-php-format: '\DateTime'
         updatedDateUtc:
           description: The date when the user most recently connected this tenant to your app. May differ to the created date if the user has disconnected and subsequently reconnected this tenant to your app.
           type: string
-          x-java-format: "LocalDateTime"
+          x-is-datetime: true
           x-php-format: '\DateTime'
     RefreshToken:
       externalDocs:


### PR DESCRIPTION
Add x-is-datetime:true to use in models to define stings as Local Date Time object without timezone offset.