### PR TITLE
Add assets error schema

### DIFF
--- a/assets-yaml/xero_assets.yaml
+++ b/assets-yaml/xero_assets.yaml
@@ -874,6 +874,22 @@ components:
     ResourceValidationErrorsElement:
       externalDocs:
         url: "https://developer.xero.com/documentation/api/http-response-codes"
+      properties:
+        resourceName:
+          description: The field name of the erroneous field
+          type: string
+        localisedMessage:
+          description: Explaination of the resource validation error
+          type: string
+        type:
+          description: Internal type of the resource error message
+          type: string
+        title:
+          description: Title of the resource validation error
+          type: string
+        detail:
+          description: Detail of the resource validation error
+          type: string
       type: object
     FieldValidationErrorsElement:
       externalDocs:
@@ -889,7 +905,7 @@ components:
           description: Explaination of the field validation error
           type: string
         type:
-          description: Internal type of the fieldvalidation error message
+          description: Internal type of the field validation error message
           type: string
         title:
           description: Title of the field validation error

--- a/assets-yaml/xero_assets.yaml
+++ b/assets-yaml/xero_assets.yaml
@@ -2,187 +2,187 @@ openapi: 3.0.0
 info:
   version: "2.0.6"
   title: Xero Assets API
-  description: This is the Xero Assets API 
+  description: This is the Xero Assets API
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:
     name: "Xero Platform Team"
     email: "api@xero.com"
     url: "https://developer.xero.com"
   license:
-    name: MIT 
-    url: 'https://github.com/XeroAPI/Xero-OpenAPI/blob/master/LICENSE'
+    name: MIT
+    url: "https://github.com/XeroAPI/Xero-OpenAPI/blob/master/LICENSE"
 servers:
   - description: Xero API servers
     url: https://api.xero.com/assets.xro/1.0
 paths:
   /Assets:
     parameters:
-      - $ref: '#/components/parameters/requiredHeader'
+      - $ref: "#/components/parameters/requiredHeader"
     get:
       security:
         - OAuth2: [assets.read]
       tags:
         - Asset
-      summary: searches fixed asset 
+      summary: searches fixed asset
       operationId: getAssets
       description: By passing in the appropriate options, you can search for
         available fixed asset in the system
-      parameters: 
+      parameters:
         - name: status
           in: query
           description: Required when retrieving a collection of assets. See Asset Status Codes
-          schema: 
-            $ref: '#/components/schemas/AssetStatus'
+          schema:
+            $ref: "#/components/schemas/AssetStatus"
           required: true
         - name: page
           in: query
           description: Results are paged. This specifies which page of the results to return. The default page is 1.
-          schema: 
+          schema:
             type: integer
             example: 1
         - name: pageSize
           in: query
           description: The number of records returned per page. By default the number of records returned is 10.
-          schema: 
+          schema:
             type: integer
             example: 5
         - name: orderBy
           in: query
           description: Requests can be ordered by AssetType, AssetName, AssetNumber, PurchaseDate and PurchasePrice. If the asset status is DISPOSED it also allows DisposalDate and DisposalPrice.
-          schema: 
+          schema:
             type: string
-            enum: 
-            - AssetType
-            - AssetName
-            - AssetNumber
-            - PurchaseDate
-            - PurchasePrice
-            - DisposalDate
-            - DisposalPrice
+            enum:
+              - AssetType
+              - AssetName
+              - AssetNumber
+              - PurchaseDate
+              - PurchasePrice
+              - DisposalDate
+              - DisposalPrice
             example: AssetName
         - name: sortDirection
           in: query
           description: ASC or DESC
-          schema: 
+          schema:
             type: string
-            enum: 
-            - asc
-            - desc
+            enum:
+              - asc
+              - desc
             example: ASC
         - name: filterBy
           in: query
           description: A string that can be used to filter the list to only return assets containing the text. Checks it against the AssetName, AssetNumber, Description and AssetTypeName fields.
-          schema: 
+          schema:
             type: string
             example: Draft
             enum:
-            - AssetName
-            - AssetNumber
-            - Description
-            - AssetTypeName
+              - AssetName
+              - AssetNumber
+              - Description
+              - AssetTypeName
       responses:
-        '200':
+        "200":
           description: search results matching criteria
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Assets'
-              example: '{ 
-                          "pagination":{ 
-                            "page":1,
-                            "pageSize":10,
-                            "pageCount":2,
-                            "itemCount":11,
-                            "links":{ 
-                              "first":{ 
-                                "href":"http://asset.favorit.xero.com/v1/assets?status=DRAFT&page=1"
-                              },
-                              "next":{ 
-                                "href":"http://asset.favorit.xero.com/v1/assets?status=DRAFT&page=2"
-                              },
-                              "last":{ 
-                                "href":"http://asset.favorit.xero.com/v1/assets?status=DRAFT&page=2"
-                              }
-                            }
-                          },
-                          "items":[ 
-                            { 
-                              "assetId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
-                              "assetName":"Computer47822",
-                              "assetNumber":"123478074",
-                              "purchaseDate":"2020-01-01T00:00:00",
-                              "purchasePrice":100.0000,
-                              "disposalPrice":0.0,
-                              "assetStatus":"DRAFT",
-                              "trackingItems":[ 
-                            ],
-                            "bookDepreciationSetting":{ 
-                              "depreciableObjectId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
-                              "depreciableObjectType":"Asset",
-                              "bookEffectiveDateOfChangeId":"5da77739-7f22-4109-b0a0-67480fb89af0",
-                              "depreciationMethod":"StraightLine",
-                              "averagingMethod":"ActualDays",
-                              "depreciationRate":0.50,
-                              "depreciationCalculationMethod":"None"
-                            },
-                            "bookDepreciationDetail":{ 
-                              "depreciationStartDate":"2020-01-02T00:00:00",
-                              "priorAccumDepreciationAmount":0.000000,
-                              "currentAccumDepreciationAmount":0.000000,
-                              "currentCapitalGain":0.000000,
-                              "currentGainLoss":0.000000
-                            },
-                            "taxDepreciationSettings":[ 
-                            ],
-                            "taxDepreciationDetails":[ 
-                            ],
-                            "canRollback":true,
-                            "accountingBookValue":100.000000,
-                            "taxValues":[ 
-                            ],
-                            "isDeleteEnabledForDate":false
-                          },
-                          { 
-                            "assetId":"52ea3adf-f04a-4577-8fd2-43c52a256bd5",
-                            "assetName":"Computer4148",
-                            "assetNumber":"123466620",
-                            "purchaseDate":"2020-01-01T00:00:00",
-                            "purchasePrice":100.0000,
-                            "disposalPrice":0.0,
-                            "assetStatus":"DRAFT",
-                            "trackingItems":[ 
+                $ref: "#/components/schemas/Assets"
+              example: '{
+                "pagination":{
+                "page":1,
+                "pageSize":10,
+                "pageCount":2,
+                "itemCount":11,
+                "links":{
+                "first":{
+                "href":"http://asset.favorit.xero.com/v1/assets?status=DRAFT&page=1"
+                },
+                "next":{
+                "href":"http://asset.favorit.xero.com/v1/assets?status=DRAFT&page=2"
+                },
+                "last":{
+                "href":"http://asset.favorit.xero.com/v1/assets?status=DRAFT&page=2"
+                }
+                }
+                },
+                "items":[
+                {
+                "assetId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
+                "assetName":"Computer47822",
+                "assetNumber":"123478074",
+                "purchaseDate":"2020-01-01T00:00:00",
+                "purchasePrice":100.0000,
+                "disposalPrice":0.0,
+                "assetStatus":"DRAFT",
+                "trackingItems":[
+                ],
+                "bookDepreciationSetting":{
+                "depreciableObjectId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
+                "depreciableObjectType":"Asset",
+                "bookEffectiveDateOfChangeId":"5da77739-7f22-4109-b0a0-67480fb89af0",
+                "depreciationMethod":"StraightLine",
+                "averagingMethod":"ActualDays",
+                "depreciationRate":0.50,
+                "depreciationCalculationMethod":"None"
+                },
+                "bookDepreciationDetail":{
+                "depreciationStartDate":"2020-01-02T00:00:00",
+                "priorAccumDepreciationAmount":0.000000,
+                "currentAccumDepreciationAmount":0.000000,
+                "currentCapitalGain":0.000000,
+                "currentGainLoss":0.000000
+                },
+                "taxDepreciationSettings":[
+                ],
+                "taxDepreciationDetails":[
+                ],
+                "canRollback":true,
+                "accountingBookValue":100.000000,
+                "taxValues":[
+                ],
+                "isDeleteEnabledForDate":false
+                },
+                {
+                "assetId":"52ea3adf-f04a-4577-8fd2-43c52a256bd5",
+                "assetName":"Computer4148",
+                "assetNumber":"123466620",
+                "purchaseDate":"2020-01-01T00:00:00",
+                "purchasePrice":100.0000,
+                "disposalPrice":0.0,
+                "assetStatus":"DRAFT",
+                "trackingItems":[
 
-                            ],
-                            "bookDepreciationSetting":{ 
-                              "depreciableObjectId":"52ea3adf-f04a-4577-8fd2-43c52a256bd5",
-                              "depreciableObjectType":"Asset",
-                              "bookEffectiveDateOfChangeId":"c0d5280f-28b6-4329-b5b7-36e08c662010",
-                              "depreciationMethod":"StraightLine",
-                              "averagingMethod":"ActualDays",
-                              "depreciationRate":0.50,
-                              "depreciationCalculationMethod":"None"
-                            },
-                            "bookDepreciationDetail":{ 
-                              "depreciationStartDate":"2020-01-02T00:00:00",
-                              "priorAccumDepreciationAmount":0.000000,
-                              "currentAccumDepreciationAmount":0.000000,
-                              "currentCapitalGain":0.000000,
-                              "currentGainLoss":0.000000
-                            },
-                            "taxDepreciationSettings":[ 
-                            ],
-                            "taxDepreciationDetails":[ 
-                            ],
-                            "canRollback":true,
-                            "accountingBookValue":100.000000,
-                            "taxValues":[ 
+                ],
+                "bookDepreciationSetting":{
+                "depreciableObjectId":"52ea3adf-f04a-4577-8fd2-43c52a256bd5",
+                "depreciableObjectType":"Asset",
+                "bookEffectiveDateOfChangeId":"c0d5280f-28b6-4329-b5b7-36e08c662010",
+                "depreciationMethod":"StraightLine",
+                "averagingMethod":"ActualDays",
+                "depreciationRate":0.50,
+                "depreciationCalculationMethod":"None"
+                },
+                "bookDepreciationDetail":{
+                "depreciationStartDate":"2020-01-02T00:00:00",
+                "priorAccumDepreciationAmount":0.000000,
+                "currentAccumDepreciationAmount":0.000000,
+                "currentCapitalGain":0.000000,
+                "currentGainLoss":0.000000
+                },
+                "taxDepreciationSettings":[
+                ],
+                "taxDepreciationDetails":[
+                ],
+                "canRollback":true,
+                "accountingBookValue":100.000000,
+                "taxValues":[
 
-                            ],
-                            "isDeleteEnabledForDate":false
-                          }
-                        ]
-                      }'
-        '400':
+                ],
+                "isDeleteEnabledForDate":false
+                }
+                ]
+                }'
+        "400":
           description: bad input parameter
     post:
       security:
@@ -193,169 +193,169 @@ paths:
       operationId: createAsset
       description: Adds an asset to the system
       responses:
-        '200':
+        "200":
           description: return single object - create new asset
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Asset'
-              example: '{ 
-                          "assetId":"2257c64a-77ca-444c-a5ea-fa9a588c7039",
-                          "assetName":"Computer74863",
-                          "assetNumber":"123477544",
-                          "purchaseDate":"2020-01-01T00:00:00",
-                          "purchasePrice":100.0000,
-                          "disposalPrice":23.2300,
-                          "assetStatus":"DRAFT",
-                          "trackingItems":[],
-                          "bookDepreciationSetting":{ 
-                            "depreciableObjectId":"2257c64a-77ca-444c-a5ea-fa9a588c7039",
-                            "depreciableObjectType":"Asset",
-                            "bookEffectiveDateOfChangeId":"b58a2ace-1213-4681-9f11-2e30f57b5b8c",
-                            "depreciationMethod":"StraightLine",
-                            "averagingMethod":"ActualDays",
-                            "depreciationRate":0.50,
-                            "depreciationCalculationMethod":"None"
-                          },
-                          "bookDepreciationDetail":{ 
-                            "depreciationStartDate":"2020-01-02T00:00:00",
-                            "priorAccumDepreciationAmount":0.000000,
-                            "currentAccumDepreciationAmount":0.000000,
-                            "currentCapitalGain":0.000000,
-                            "currentGainLoss":0.000000
-                          },
-                          "taxDepreciationSettings":[ 
-                          ],
-                          "taxDepreciationDetails":[],
-                          "canRollback":true,
-                          "accountingBookValue":76.770000,
-                          "taxValues":[],
-                          "isDeleteEnabledForDate":true
-                        }'
-        '400':
-          description: 'invalid input, object invalid'
+                $ref: "#/components/schemas/Asset"
+              example: '{
+                "assetId":"2257c64a-77ca-444c-a5ea-fa9a588c7039",
+                "assetName":"Computer74863",
+                "assetNumber":"123477544",
+                "purchaseDate":"2020-01-01T00:00:00",
+                "purchasePrice":100.0000,
+                "disposalPrice":23.2300,
+                "assetStatus":"DRAFT",
+                "trackingItems":[],
+                "bookDepreciationSetting":{
+                "depreciableObjectId":"2257c64a-77ca-444c-a5ea-fa9a588c7039",
+                "depreciableObjectType":"Asset",
+                "bookEffectiveDateOfChangeId":"b58a2ace-1213-4681-9f11-2e30f57b5b8c",
+                "depreciationMethod":"StraightLine",
+                "averagingMethod":"ActualDays",
+                "depreciationRate":0.50,
+                "depreciationCalculationMethod":"None"
+                },
+                "bookDepreciationDetail":{
+                "depreciationStartDate":"2020-01-02T00:00:00",
+                "priorAccumDepreciationAmount":0.000000,
+                "currentAccumDepreciationAmount":0.000000,
+                "currentCapitalGain":0.000000,
+                "currentGainLoss":0.000000
+                },
+                "taxDepreciationSettings":[
+                ],
+                "taxDepreciationDetails":[],
+                "canRollback":true,
+                "accountingBookValue":76.770000,
+                "taxValues":[],
+                "isDeleteEnabledForDate":true
+                }'
+        "400":
+          description: "invalid input, object invalid"
           content:
             application/json:
-              example: '{ 
-                          "resourceValidationErrors":[ ],
-                          "fieldValidationErrors":[ 
-                            { 
-                              "fieldName":"BookDepreciationSetting.DepreciationRate",
-                              "valueProvided":"",
-                              "localisedMessage":"Can''t have both Depreciation Rate and Effective Life",
-                              "type":"http://common.service.xero.com/errors/validation/field",
-                              "title":"Validation Error",
-                              "detail":"Can''t have both Depreciation Rate and Effective Life"
-                            }
-                          ],
-                          "type":"http://common.service.xero.com/errors/validation",
-                          "title":"The resource update failed validation.",
-                          "detail":"Validation Errors"
-                        }'
+              example: '{
+                "resourceValidationErrors":[ ],
+                "fieldValidationErrors":[
+                {
+                "fieldName":"BookDepreciationSetting.DepreciationRate",
+                "valueProvided":"",
+                "localisedMessage":"Can''t have both Depreciation Rate and Effective Life",
+                "type":"http://common.service.xero.com/errors/validation/field",
+                "title":"Validation Error",
+                "detail":"Can''t have both Depreciation Rate and Effective Life"
+                }
+                ],
+                "type":"http://common.service.xero.com/errors/validation",
+                "title":"The resource update failed validation.",
+                "detail":"Validation Errors"
+                }'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Asset'
-            example: '{ 
-                        "assetName":"Computer74863",
-                        "assetNumber":"123477544",
-                        "purchaseDate":"2020-01-01",
-                        "purchasePrice":100.0,
-                        "disposalPrice":23.23,
-                        "assetStatus":"DRAFT",
-                        "bookDepreciationSetting":{ 
-                          "depreciationMethod":"StraightLine",
-                          "averagingMethod":"ActualDays",
-                          "depreciationRate":0.5,
-                          "depreciationCalculationMethod":"None"
-                        },
-                        "bookDepreciationDetail":{ 
-                          "currentCapitalGain":5.32,
-                          "currentGainLoss":3.88,
-                          "depreciationStartDate":"2020-01-02",
-                          "costLimit":100.0,
-                          "currentAccumDepreciationAmount":2.25
-                        },
-                        "AccountingBookValue":99.5
-                      }'
+              $ref: "#/components/schemas/Asset"
+            example: '{
+              "assetName":"Computer74863",
+              "assetNumber":"123477544",
+              "purchaseDate":"2020-01-01",
+              "purchasePrice":100.0,
+              "disposalPrice":23.23,
+              "assetStatus":"DRAFT",
+              "bookDepreciationSetting":{
+              "depreciationMethod":"StraightLine",
+              "averagingMethod":"ActualDays",
+              "depreciationRate":0.5,
+              "depreciationCalculationMethod":"None"
+              },
+              "bookDepreciationDetail":{
+              "currentCapitalGain":5.32,
+              "currentGainLoss":3.88,
+              "depreciationStartDate":"2020-01-02",
+              "costLimit":100.0,
+              "currentAccumDepreciationAmount":2.25
+              },
+              "AccountingBookValue":99.5
+              }'
         description: Fixed asset you are creating
   /Assets/{id}:
     parameters:
-      - $ref: '#/components/parameters/requiredHeader'
+      - $ref: "#/components/parameters/requiredHeader"
     get:
       security:
         - OAuth2: [assets.read]
       tags:
         - Asset
-      summary: retrieves fixed asset by id 
+      summary: retrieves fixed asset by id
       operationId: getAssetById
       description: |
         By passing in the appropriate asset id, you can search for
         a specific fixed asset in the system
-      parameters: 
+      parameters:
         - name: id
           in: path
           required: true
           description: fixed asset id for single object
-          schema: 
+          schema:
             type: string
             format: uuid
             example: "4f7bcdcb-5ec1-4258-9558-19f662fccdfe"
       responses:
-        '200':
+        "200":
           description: search results matching criteria
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Asset'
-              example: '{ 
-                          "assetId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
-                          "assetName":"Computer47822",
-                          "assetNumber":"123478074",
-                          "purchaseDate":"2020-01-01T00:00:00",
-                          "purchasePrice":100.0000,
-                          "disposalPrice":23.0000,
-                          "assetStatus":"DRAFT",
-                          "trackingItems":[ 
+                $ref: "#/components/schemas/Asset"
+              example: '{
+                "assetId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
+                "assetName":"Computer47822",
+                "assetNumber":"123478074",
+                "purchaseDate":"2020-01-01T00:00:00",
+                "purchasePrice":100.0000,
+                "disposalPrice":23.0000,
+                "assetStatus":"DRAFT",
+                "trackingItems":[
 
-                          ],
-                          "bookDepreciationSetting":{ 
-                            "depreciableObjectId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
-                            "depreciableObjectType":"Asset",
-                            "bookEffectiveDateOfChangeId":"5da77739-7f22-4109-b0a0-67480fb89af0",
-                            "depreciationMethod":"StraightLine",
-                            "averagingMethod":"ActualDays",
-                            "depreciationRate":0.50,
-                            "depreciationCalculationMethod":"None"
-                          },
-                          "bookDepreciationDetail":{ 
-                            "depreciationStartDate":"2020-01-02T00:00:00",
-                            "priorAccumDepreciationAmount":0.000000,
-                            "currentAccumDepreciationAmount":0.000000,
-                            "currentCapitalGain":0.000000,
-                            "currentGainLoss":0.000000
-                          },
-                          "taxDepreciationSettings":[ 
-                          ],
-                          "taxDepreciationDetails":[ 
-                          ],
-                          "canRollback":true,
-                          "metaData":{ 
-                          "bookDepreciationDetailsCanChange":true,
-                          "taxDepreciationDetailsCanChange":true
-                          },
-                          "accountingBookValue":77.000000,
-                          "taxValues":[ 
-                          ],
-                          "isDeleteEnabledForDate":true
-                        }'
-        '400':
+                ],
+                "bookDepreciationSetting":{
+                "depreciableObjectId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
+                "depreciableObjectType":"Asset",
+                "bookEffectiveDateOfChangeId":"5da77739-7f22-4109-b0a0-67480fb89af0",
+                "depreciationMethod":"StraightLine",
+                "averagingMethod":"ActualDays",
+                "depreciationRate":0.50,
+                "depreciationCalculationMethod":"None"
+                },
+                "bookDepreciationDetail":{
+                "depreciationStartDate":"2020-01-02T00:00:00",
+                "priorAccumDepreciationAmount":0.000000,
+                "currentAccumDepreciationAmount":0.000000,
+                "currentCapitalGain":0.000000,
+                "currentGainLoss":0.000000
+                },
+                "taxDepreciationSettings":[
+                ],
+                "taxDepreciationDetails":[
+                ],
+                "canRollback":true,
+                "metaData":{
+                "bookDepreciationDetailsCanChange":true,
+                "taxDepreciationDetailsCanChange":true
+                },
+                "accountingBookValue":77.000000,
+                "taxValues":[
+                ],
+                "isDeleteEnabledForDate":true
+                }'
+        "400":
           description: bad input parameter
   /AssetTypes:
     parameters:
-      - $ref: '#/components/parameters/requiredHeader'
+      - $ref: "#/components/parameters/requiredHeader"
     get:
       security:
         - OAuth2: [assets.read]
@@ -366,57 +366,57 @@ paths:
       description: By passing in the appropriate options, you can search for
         available fixed asset types in the system
       responses:
-        '200':
+        "200":
           description: search results matching criteria
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AssetType'
-              example: '[ 
-                          { 
-                            "assetTypeId":"710255c6-d2ed-4463-b992-06c8685add5e",
-                            "assetTypeName":"Computer Equipment",
-                            "fixedAssetAccountId":"37c35de7-8df0-44bf-8e7c-f1f67cf6a278",
-                            "depreciationExpenseAccountId":"0fbd1820-9dd0-454a-9515-6ec076a84cf7",
-                            "accumulatedDepreciationAccountId":"512eac06-6894-47cd-b421-673b4ca2693a",
-                            "bookDepreciationSetting":{ 
-                              "depreciableObjectId":"710255c6-d2ed-4463-b992-06c8685add5e",
-                              "depreciableObjectType":"AssetType",
-                              "bookEffectiveDateOfChangeId":"39b9c2e9-62b1-4efc-ab75-fa9152ffaa5f",
-                              "depreciationMethod":"StraightLine",
-                              "averagingMethod":"FullMonth",
-                              "depreciationRate":25.00,
-                              "depreciationCalculationMethod":"None"
-                            },
-                            "taxDepreciationSettings":[ 
-                            ],
-                            "locks":0,
-                            "lockPrivateUseAccount":false
-                            },
-                            { 
-                            "assetTypeId":"1a398a67-9d9d-4783-8689-14a8efce89d9",
-                            "assetTypeName":"Machinery97704",
-                            "fixedAssetAccountId":"5c93f577-c48f-44cd-8593-01489e319c2b",
-                            "depreciationExpenseAccountId":"adc14376-c960-43f0-b7f3-4063e5098039",
-                            "accumulatedDepreciationAccountId":"9195cadd-8645-41e6-9f67-7bcd421defe8",
-                            "bookDepreciationSetting":{ 
-                              "depreciableObjectId":"1a398a67-9d9d-4783-8689-14a8efce89d9",
-                              "depreciableObjectType":"AssetType",
-                              "bookEffectiveDateOfChangeId":"6d09a96d-7768-4f28-95e8-c9ac870fe36e",
-                              "depreciationMethod":"DiminishingValue100",
-                              "averagingMethod":"ActualDays",
-                              "depreciationRate":40.00,
-                              "depreciationCalculationMethod":"None"
-                            },
-                            "taxDepreciationSettings":[ 
-                            ],
-                            "locks":0,
-                            "lockPrivateUseAccount":false
-                          }
-                        ]'
-        '400':
+                  $ref: "#/components/schemas/AssetType"
+              example: '[
+                {
+                "assetTypeId":"710255c6-d2ed-4463-b992-06c8685add5e",
+                "assetTypeName":"Computer Equipment",
+                "fixedAssetAccountId":"37c35de7-8df0-44bf-8e7c-f1f67cf6a278",
+                "depreciationExpenseAccountId":"0fbd1820-9dd0-454a-9515-6ec076a84cf7",
+                "accumulatedDepreciationAccountId":"512eac06-6894-47cd-b421-673b4ca2693a",
+                "bookDepreciationSetting":{
+                "depreciableObjectId":"710255c6-d2ed-4463-b992-06c8685add5e",
+                "depreciableObjectType":"AssetType",
+                "bookEffectiveDateOfChangeId":"39b9c2e9-62b1-4efc-ab75-fa9152ffaa5f",
+                "depreciationMethod":"StraightLine",
+                "averagingMethod":"FullMonth",
+                "depreciationRate":25.00,
+                "depreciationCalculationMethod":"None"
+                },
+                "taxDepreciationSettings":[
+                ],
+                "locks":0,
+                "lockPrivateUseAccount":false
+                },
+                {
+                "assetTypeId":"1a398a67-9d9d-4783-8689-14a8efce89d9",
+                "assetTypeName":"Machinery97704",
+                "fixedAssetAccountId":"5c93f577-c48f-44cd-8593-01489e319c2b",
+                "depreciationExpenseAccountId":"adc14376-c960-43f0-b7f3-4063e5098039",
+                "accumulatedDepreciationAccountId":"9195cadd-8645-41e6-9f67-7bcd421defe8",
+                "bookDepreciationSetting":{
+                "depreciableObjectId":"1a398a67-9d9d-4783-8689-14a8efce89d9",
+                "depreciableObjectType":"AssetType",
+                "bookEffectiveDateOfChangeId":"6d09a96d-7768-4f28-95e8-c9ac870fe36e",
+                "depreciationMethod":"DiminishingValue100",
+                "averagingMethod":"ActualDays",
+                "depreciationRate":40.00,
+                "depreciationCalculationMethod":"None"
+                },
+                "taxDepreciationSettings":[
+                ],
+                "locks":0,
+                "lockPrivateUseAccount":false
+                }
+                ]'
+        "400":
           description: bad input parameter
     post:
       security:
@@ -427,81 +427,81 @@ paths:
       operationId: createAssetType
       description: Adds an fixed asset type to the system
       responses:
-        '200':
+        "200":
           description: results single object -  created fixed type
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AssetType'
-              example: '{ 
-                          "assetTypeId":"85509b5d-308e-420d-9532-b85105058916",
-                          "assetTypeName":"Machinery11004",
-                          "fixedAssetAccountId":"3d8d063a-c148-4bb8-8b3c-a5e2ad3b1e82",
-                          "depreciationExpenseAccountId":"d1602f69-f900-4616-8d34-90af393fa368",
-                          "accumulatedDepreciationAccountId":"9195cadd-8645-41e6-9f67-7bcd421defe8",
-                          "bookDepreciationSetting":{ 
-                            "depreciableObjectId":"00000000-0000-0000-0000-000000000000",
-                            "depreciableObjectType":"None",
-                            "depreciationMethod":"DiminishingValue100",
-                            "averagingMethod":"ActualDays",
-                            "depreciationRate":0.05,
-                            "depreciationCalculationMethod":"None"
-                          },
-                          "locks":0,
-                          "lockPrivateUseAccount":false
-                        }'
-        '400':
-          description: 'invalid input, object invalid'
+                $ref: "#/components/schemas/AssetType"
+              example: '{
+                "assetTypeId":"85509b5d-308e-420d-9532-b85105058916",
+                "assetTypeName":"Machinery11004",
+                "fixedAssetAccountId":"3d8d063a-c148-4bb8-8b3c-a5e2ad3b1e82",
+                "depreciationExpenseAccountId":"d1602f69-f900-4616-8d34-90af393fa368",
+                "accumulatedDepreciationAccountId":"9195cadd-8645-41e6-9f67-7bcd421defe8",
+                "bookDepreciationSetting":{
+                "depreciableObjectId":"00000000-0000-0000-0000-000000000000",
+                "depreciableObjectType":"None",
+                "depreciationMethod":"DiminishingValue100",
+                "averagingMethod":"ActualDays",
+                "depreciationRate":0.05,
+                "depreciationCalculationMethod":"None"
+                },
+                "locks":0,
+                "lockPrivateUseAccount":false
+                }'
+        "400":
+          description: "invalid input, object invalid"
           content:
             application/json:
-              example: '{ 
-                          "resourceValidationErrors":[ 
-                          ],
-                          "fieldValidationErrors":[ 
-                            { 
-                              "fieldName":"FixedAssetAccountId",
-                              "valueProvided":"",
-                              "localisedMessage":"Fixed Asset Account Id is invalid",
-                              "type":"http://common.service.xero.com/errors/validation/field",
-                              "title":"Validation Error",
-                              "detail":"Fixed Asset Account Id is invalid"
-                            },
-                            { 
-                              "fieldName":"DepreciationExpenseAccountId",
-                              "valueProvided":"",
-                              "localisedMessage":"Depreciation Expense Account Id is invalid",
-                              "type":"http://common.service.xero.com/errors/validation/field",
-                              "title":"Validation Error",
-                              "detail":"Depreciation Expense Account Id is invalid"
-                            }
-                          ],
-                          "type":"http://common.service.xero.com/errors/validation",
-                          "title":"The resource update failed validation.",
-                          "detail":"Validation Errors"
-                        }'
-        '409':
+              example: '{
+                "resourceValidationErrors":[
+                ],
+                "fieldValidationErrors":[
+                {
+                "fieldName":"FixedAssetAccountId",
+                "valueProvided":"",
+                "localisedMessage":"Fixed Asset Account Id is invalid",
+                "type":"http://common.service.xero.com/errors/validation/field",
+                "title":"Validation Error",
+                "detail":"Fixed Asset Account Id is invalid"
+                },
+                {
+                "fieldName":"DepreciationExpenseAccountId",
+                "valueProvided":"",
+                "localisedMessage":"Depreciation Expense Account Id is invalid",
+                "type":"http://common.service.xero.com/errors/validation/field",
+                "title":"Validation Error",
+                "detail":"Depreciation Expense Account Id is invalid"
+                }
+                ],
+                "type":"http://common.service.xero.com/errors/validation",
+                "title":"The resource update failed validation.",
+                "detail":"Validation Errors"
+                }'
+        "409":
           description: a type already exists
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AssetType'
-            example: '{ 
-                        "assetTypeName":"Machinery11004",
-                        "fixedAssetAccountId":"3d8d063a-c148-4bb8-8b3c-a5e2ad3b1e82",
-                        "depreciationExpenseAccountId":"d1602f69-f900-4616-8d34-90af393fa368",
-                        "accumulatedDepreciationAccountId":"9195cadd-8645-41e6-9f67-7bcd421defe8",
-                        "bookDepreciationSetting":{ 
-                          "depreciationMethod":"DiminishingValue100",
-                          "averagingMethod":"ActualDays",
-                          "depreciationRate":0.05,
-                          "depreciationCalculationMethod":"None"
-                        }
-                      }'
+              $ref: "#/components/schemas/AssetType"
+            example: '{
+              "assetTypeName":"Machinery11004",
+              "fixedAssetAccountId":"3d8d063a-c148-4bb8-8b3c-a5e2ad3b1e82",
+              "depreciationExpenseAccountId":"d1602f69-f900-4616-8d34-90af393fa368",
+              "accumulatedDepreciationAccountId":"9195cadd-8645-41e6-9f67-7bcd421defe8",
+              "bookDepreciationSetting":{
+              "depreciationMethod":"DiminishingValue100",
+              "averagingMethod":"ActualDays",
+              "depreciationRate":0.05,
+              "depreciationCalculationMethod":"None"
+              }
+              }'
         description: Asset type to add
   /Settings:
     parameters:
-      - $ref: '#/components/parameters/requiredHeader'
+      - $ref: "#/components/parameters/requiredHeader"
     get:
       security:
         - OAuth2: [assets.read]
@@ -512,29 +512,29 @@ paths:
       description: By passing in the appropriate options, you can search for
         available fixed asset types in the system
       responses:
-        '200':
+        "200":
           description: search results matching criteria
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Setting'
-              example: '{ 
-                          "assetNumberPrefix":"FA-",
-                          "assetNumberSequence":"0007",
-                          "assetStartDate":"2016-01-01T00:00:00",
-                          "optInForTax":false
-                        }'
-        '400':
+                $ref: "#/components/schemas/Setting"
+              example: '{
+                "assetNumberPrefix":"FA-",
+                "assetNumberSequence":"0007",
+                "assetStartDate":"2016-01-01T00:00:00",
+                "optInForTax":false
+                }'
+        "400":
           description: bad input parameter
 components:
   securitySchemes:
     OAuth2:
       type: oauth2
       description: For more information
-      flows: 
+      flows:
         authorizationCode:
-          authorizationUrl: 'https://login.xero.com/identity/connect/authorize'
-          tokenUrl: 'https://identity.xero.com/connect/token'
+          authorizationUrl: "https://login.xero.com/identity/connect/authorize"
+          tokenUrl: "https://identity.xero.com/connect/token"
           scopes:
             email: Grant read-only access to your email
             openid: Grant read-only access to your open id
@@ -550,7 +550,7 @@ components:
             accounting.attachments: Grant read-write access to attachments
             accounting.attachments.read: Grant read-only access to attachments
             assets assets.read: Grant read-only access to fixed assets
-            bankfeeds: Grant read-write access to bankfeeds 
+            bankfeeds: Grant read-write access to bankfeeds
             files: Grant read-write access to files and folders
             files.read: Grant read-only access to files and folders
             payroll: Grant read-write access to payroll
@@ -577,23 +577,23 @@ components:
             projects: Grant read-write access to projects
             projects.read: Grant read-only access to projects
   parameters:
-    requiredHeader: 
+    requiredHeader:
       in: header
       name: Xero-Tenant-Id
       description: Xero identifier for Tenant
       schema:
         type: string
-      required: true 
+      required: true
   schemas:
     Assets:
       type: object
       properties:
         pagination:
-          $ref: '#/components/schemas/Pagination'
+          $ref: "#/components/schemas/Pagination"
         items:
           type: array
           items:
-            $ref: '#/components/schemas/Asset'
+            $ref: "#/components/schemas/Asset"
     Pagination:
       properties:
         page:
@@ -642,7 +642,7 @@ components:
           description: "The price the asset was disposed at"
           example: "1.0000"
         assetStatus:
-          $ref: '#/components/schemas/AssetStatus'
+          $ref: "#/components/schemas/AssetStatus"
         warrantyExpiryDate:
           type: string
           description: "The date the asset’s warranty expires (if needed) YYYY-MM-DD"
@@ -652,9 +652,9 @@ components:
           description: "The asset's serial number"
           example: "ca4c6b39-4f4f-43e8-98da-5e1f350a6694"
         bookDepreciationSetting:
-          $ref: '#/components/schemas/BookDepreciationSetting'
+          $ref: "#/components/schemas/BookDepreciationSetting"
         bookDepreciationDetail:
-          $ref: '#/components/schemas/BookDepreciationDetail'
+          $ref: "#/components/schemas/BookDepreciationDetail"
         canRollback:
           type: boolean
           description: "Boolean to indicate whether depreciation can be rolled back for this asset individually. This is true if it doesn't have 'legacy' journal entries and if there is no lock period that would prevent this asset from rolling back."
@@ -673,8 +673,8 @@ components:
       description: "See Asset Status Codes."
       example: "DRAFT"
       enum:
-        - DRAFT  
-        - REGISTERED  
+        - DRAFT
+        - REGISTERED
         - DISPOSED
     AssetType:
       type: object
@@ -708,7 +708,7 @@ components:
           example: "ca4c6b39-4f4f-43e8-98da-5e1f350a6694"
           description: "The account for accumulated depreciation of fixed assets of this type"
         bookDepreciationSetting:
-          $ref: '#/components/schemas/BookDepreciationSetting'
+          $ref: "#/components/schemas/BookDepreciationSetting"
         locks:
           type: integer
           example: 33
@@ -719,20 +719,20 @@ components:
       properties:
         depreciationMethod:
           type: string
-          enum: 
-          - NoDepreciation
-          - StraightLine
-          - DiminishingValue100
-          - DiminishingValue150
-          - DiminishingValue200
-          - FullDepreciation
+          enum:
+            - NoDepreciation
+            - StraightLine
+            - DiminishingValue100
+            - DiminishingValue150
+            - DiminishingValue200
+            - FullDepreciation
           example: "StraightLine"
           description: "The method of depreciation applied to this asset. See Depreciation Methods"
         averagingMethod:
           type: string
-          enum: 
-          - FullMonth
-          - ActualDays
+          enum:
+            - FullMonth
+            - ActualDays
           example: "ActualDays"
           description: "The method of averaging applied to this asset. See Averaging Methods"
         depreciationRate:
@@ -746,10 +746,10 @@ components:
           description: "Effective life of the asset in years (e.g. 5)"
         depreciationCalculationMethod:
           type: string
-          enum: 
-          - Rate
-          - Life
-          - None
+          enum:
+            - Rate
+            - Life
+            - None
           example: "None"
           description: "See Depreciation Calculation Methods"
         depreciableObjectId:
@@ -807,7 +807,7 @@ components:
           description: "All depreciation occurring in the current financial year."
     Setting:
       required:
-       - name
+        - name
       properties:
         assetNumberPrefix:
           type: string
@@ -846,4 +846,55 @@ components:
           type: boolean
           description: "opt in for tax calculation"
           example: false
+      type: object
+    Error:
+      externalDocs:
+        url: "https://developer.xero.com/documentation/api/http-response-codes"
+      properties:
+        resourceValidationErrors:
+          description: Array of elements of resource validation errors
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceValidationErrorsElement"
+        fieldValidationErrors:
+          description: Array of elements of field validation errors
+          type: array
+          items:
+            $ref: "#/components/schemas/FieldValidationErrorsElement"
+        type:
+          description: The internal type of error, not accessible externally
+          type: string
+        title:
+          description: Title of the error
+          type: string
+        detail:
+          description: Detail of the error
+          type: string
+      type: object
+    ResourceValidationErrorsElement:
+      externalDocs:
+        url: "https://developer.xero.com/documentation/api/http-response-codes"
+      type: object
+    FieldValidationErrorsElement:
+      externalDocs:
+        url: "https://developer.xero.com/documentation/api/http-response-codes"
+      properties:
+        fieldName:
+          description: The field name of the erroneous field
+          type: string
+        valueProvided:
+          description: The provided value
+          type: string
+        localisedMessage:
+          description: Explaination of the field validation error
+          type: string
+        type:
+          description: Internal type of the fieldvalidation error message
+          type: string
+        title:
+          description: Title of the field validation error
+          type: string
+        detail:
+          description: Detail of the field validation error
+          type: string
       type: object


### PR DESCRIPTION
In this PR, the error schema of Assets API is added:

- Error:
 ResourceValidationErrorsElement ( I have made an assumption of the data type)
 FieldValidationErrorsElement

Example: 
```              example: '{
                "resourceValidationErrors":[ ],
                "fieldValidationErrors":[
                {
                "fieldName":"BookDepreciationSetting.DepreciationRate",
                "valueProvided":"",
                "localisedMessage":"Can''t have both Depreciation Rate and Effective Life",
                "type":"http://common.service.xero.com/errors/validation/field",
                "title":"Validation Error",
                "detail":"Can''t have both Depreciation Rate and Effective Life"
                }
                ],
                "type":"http://common.service.xero.com/errors/validation",
                "title":"The resource update failed validation.",
                "detail":"Validation Errors"
                }'
```
