### PR TITLE
Change casing of AssetStatus enums

### DIFF
--- a/assets-yaml/xero_assets.yaml
+++ b/assets-yaml/xero_assets.yaml
@@ -673,9 +673,9 @@ components:
       description: "See Asset Status Codes."
       example: "DRAFT"
       enum:
-        - DRAFT  
-        - REGISTERED  
-        - DISPOSED
+        - Draft
+        - Registered
+        - Disposed
     AssetType:
       type: object
       required:


### PR DESCRIPTION
The Xero API returns status with initial caps not all caps.  For example the API returns "Draft".  You could POST with DRAFT, but the response is Draft.  As ENUMS this causes a mis-match.