### PR TITLE
Changed Error Object Name to AssetError

### DIFF
--- a/assets-yaml/xero_assets.yaml
+++ b/assets-yaml/xero_assets.yaml
@@ -855,7 +855,7 @@ components:
           description: "opt in for tax calculation"
           example: false
       type: object
-    Error:
+    AssetError:
       externalDocs:
         url: "https://developer.xero.com/documentation/api/http-response-codes"
       properties:


### PR DESCRIPTION
@SidneyAllen The error object name could not be resolved when I tried to incorporate Assets API into Accounting API .NET SDK. 

I want to change the object name from Error to AssetError to avoid having a complicated walk-around solution. 