### PR TITLE
BankTransfer Amount to number

### DIFF
--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -18488,7 +18488,8 @@ components:
           $ref: '#/components/schemas/Account'
         Amount:
           description: 'amount of the transaction'
-          type: string
+          type: number
+          format: double
         Date:
           description: The date of the Transfer YYYY-MM-DD
           type: string

--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -18489,7 +18489,7 @@ components:
         Amount:
           description: 'amount of the transaction'
           type: number
-          format: double
+          format: float
         Date:
           description: The date of the Transfer YYYY-MM-DD
           type: string


### PR DESCRIPTION
Had this typed as string. 

I've already fixed a bug in xero-node `deserialize` function which was not able to handle an integer coming back as a typed string but figured we should update spec for accuracy.