### PR TITLE
add EmployerIdentificationNumber to Organisation

### DIFF
--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -20599,6 +20599,9 @@ components:
         RegistrationNumber:
           description: Shows for New Zealand, Australian and UK organisations
           type: string
+        EmployerIdentificationNumber:
+          description: Shown if set. US Only.
+          type: string
         TaxNumber:
           description: Shown if set. Displays in the Xero UI as Tax File Number (AU), GST
             Number (NZ), VAT Number (UK) and Tax ID Number (US & Global).


### PR DESCRIPTION
This attribute was missing from https://github.com/XeroAPI/xero-ruby but is shown in https://developer.xero.com/documentation/api/organisation, which is where I got the description text.