### PR TITLE
Capitalisation of `createdDateUtc` property

### DIFF
--- a/identity-yaml/xero-identity.yaml
+++ b/identity-yaml/xero-identity.yaml
@@ -100,7 +100,7 @@ components:
         tenantName:
           description: Xero tenant name
           type: string
-        createdDateUTC:
+        createdDateUtc:
           description: The date when the user connected this tenant to your app
           type: string
           format: date-time


### PR DESCRIPTION
The setter method name cannot be found when deserialising the response
when `UTC` is capitalised.

---

I found that the PHP SDK does not populate the `created_date_utc` property for `Connection`s because of the capitalisation mis-match in the `$attributeMap` [array](https://github.com/XeroAPI/xero-php-oauth2/blob/33f67315b1a358a31c834ffe9f7b516771445ef6/lib/Models/Identity/Connection.php#L110-L118).

I hope this is the correct place to make this change.