### PR TITLE
Add BatchPayment object to BankTransactions and Payments e/p response

### DIFF
--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -985,6 +985,18 @@ paths:
                                   "Code":"088",
                                   "Name":"Business Wells Fargo"
                                },
+                               "BatchPayment": {
+                                  "Account": {
+                                    "AccountID": "6f7594f2-f059-4d56-9e67-47ac9733bfe9"
+                                  },
+                                  "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
+                                  "Date": "\/Date(1476316800000+0000)\/",
+                                  "Type": "RECBATCH",
+                                  "Status": "AUTHORISED",
+                                  "TotalAmount": "12.00",
+                                  "UpdatedDateUTC": "\/Date(1476392487037+0000)\/",
+                                  "IsReconciled": "false"
+                                },
                                "Type":"RECEIVE",
                                "IsReconciled":false,
                                "PrepaymentID":"cb62750f-b49c-464b-a45b-e2e2c514c8a9",
@@ -1414,6 +1426,18 @@ paths:
                                 "Code": "088",
                                 "Name": "Business Wells Fargo"
                               },
+                              "BatchPayment": {
+                                  "Account": {
+                                    "AccountID": "6f7594f2-f059-4d56-9e67-47ac9733bfe9"
+                                  },
+                                  "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
+                                  "Date": "\/Date(1476316800000+0000)\/",
+                                  "Type": "RECBATCH",
+                                  "Status": "AUTHORISED",
+                                  "TotalAmount": "12.00",
+                                  "UpdatedDateUTC": "\/Date(1476392487037+0000)\/",
+                                  "IsReconciled": "false"
+                                },
                               "Type": "RECEIVE",
                               "IsReconciled": false,
                               "CurrencyRate": 1.000000,
@@ -9458,6 +9482,19 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
                           "Payments": [
                             {
                               "PaymentID": "99ea7f6b-c513-4066-bc27-b7c65dcd76c2",
+                              "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
+                              "BatchPayment": {
+                                "Account": {
+                                  "AccountID": "5690f1e8-1d02-4893-90c2-ee1a69eff942"
+                                },
+                                "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
+                                "Date": "\/Date(1552521600000+0000)\/",
+                                "Type": "RECBATCH",
+                                "Status": "AUTHORISED",
+                                "TotalAmount": "50.00",
+                                "UpdatedDateUTC": "\/Date(1541176592690+0000)\/",
+                                "IsReconciled": "false"
+                              },
                               "Date": "\/Date(1543449600000+0000)\/",
                               "BankAmount": 46.00,
                               "Amount": 46.00,
@@ -9779,6 +9816,19 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
                           "Payments": [
                             {
                               "PaymentID": "99ea7f6b-c513-4066-bc27-b7c65dcd76c2",
+                              "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
+                              "BatchPayment": {
+                                "Account": {
+                                  "AccountID": "5690f1e8-1d02-4893-90c2-ee1a69eff942"
+                                },
+                                "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
+                                "Date": "\/Date(1543449600000+0000)\/",
+                                "Type": "RECBATCH",
+                                "Status": "AUTHORISED",
+                                "TotalAmount": "50.00",
+                                "UpdatedDateUTC": "\/Date(1541176592690+0000)\/",
+                                "IsReconciled": "false"
+                              },
                               "Date": "\/Date(1543449600000+0000)\/",
                               "BankAmount": 46.00,
                               "Amount": 46.00,


### PR DESCRIPTION
Adding the 'BatchPayment' object to the response of:
GET /Payments
GET /Payments/{PaymentID}
GET /BankTransactions
GET /BankTransactions/{BankTransactionID}

This will be returned only when a payment/transaction is part of a batch. 