### PR TITLE
fix typo in TenNinetyNineContact

### DIFF
--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -22130,8 +22130,8 @@ components:
         Contacts:
           type: array
           items:
-            $ref: '#/components/schemas/TenNinteyNineContact'
-    TenNinteyNineContact:
+            $ref: '#/components/schemas/TenNinetyNineContact'
+    TenNinetyNineContact:
       properties:
         Box1: 
           description: Box 1 on 1099 Form


### PR DESCRIPTION
was previously `TenNinteyNineContact`.
also needs to be updated in the SDKs eg https://github.com/XeroAPI/xero-php-oauth2/blob/master/lib/Models/Accounting/TenNinteyNineContact.php