### PR TITLE
Uncommenting History and Notes specs

### DIFF
--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -6116,6 +6116,7 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
                               "HasErrors": false,
                               "IsDiscounted": false,
                               "HasAttachments": false,
+                              "RepeatingInvoiceID": "428c0d75-909f-4b04-8403-a48dc27283b0",
                               "Contact": {
                                 "ContactID": "a3675fc4-f8dd-4f03-ba5b-f1870566bcd7",
                                 "Name": "Barney Rubble-83203",

--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -2427,29 +2427,29 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/HistoryRetrieved'
-    #put:
-    #  security:
-    #    - OAuth2: [accounting.transactions]
-    #  tags:
-    #    - Accounting
-    #  operationId: createBankTransferHistoryRecord
-    #  x-hasAccountingValidationError: true
-    #  parameters:
-    #    - required: true
-    #      in: path
-    #      name: BankTransferID
-    #      description: Xero generated unique identifier for a bank transfer
-    #      example: "00000000-0000-0000-000-000000000000"
-    #      schema:
-    #        type: string
-    #        format: uuid
-    #  responses:
-    #    '200':
-    #      $ref: '#/components/responses/HistoryRecordCreated'
-    #    '400':
-    #      $ref: '#/components/responses/400Error'
-    #  requestBody:
-    #    $ref: '#/components/requestBodies/historyRecords'
+    put:
+      security:
+        - OAuth2: [accounting.transactions]
+      tags:
+        - Accounting
+      operationId: createBankTransferHistoryRecord
+      x-hasAccountingValidationError: true
+      parameters:
+        - required: true
+          in: path
+          name: BankTransferID
+          description: Xero generated unique identifier for a bank transfer
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/HistoryRecordCreated'
+        '400':
+          $ref: '#/components/responses/400Error'
+      requestBody:
+        $ref: '#/components/requestBodies/historyRecords'
   /BrandingThemes:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -3858,30 +3858,30 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/HistoryRetrieved'
-    #put:
-    #  security:
-    #    - OAuth2: [accounting.contacts]
-    #  tags:
-    #    - Accounting
-    #  operationId: createContactHistory
-    #  x-hasAccountingValidationError: true
-    #  summary: Allows you to retrieve a history records of an Contact
-    #  parameters:
-    #    - required: true
-    #      in: path
-    #      name: ContactID
-    #      description: Unique identifier for a Contact
-    #      example: "00000000-0000-0000-000-000000000000"
-    #      schema:
-    #        type: string
-    #        format: uuid
-    #  requestBody:
-    #    $ref: '#/components/requestBodies/historyRecords'
-    #  responses:
-    #    '200':
-    #      $ref: '#/components/responses/HistoryRecordCreated'
-    #    '400':
-    #      $ref: '#/components/responses/400Error'
+    put:
+      security:
+        - OAuth2: [accounting.contacts]
+      tags:
+        - Accounting
+      operationId: createContactHistory
+      x-hasAccountingValidationError: true
+      summary: Allows you to retrieve a history records of an Contact
+      parameters:
+        - required: true
+          in: path
+          name: ContactID
+          description: Unique identifier for a Contact
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        $ref: '#/components/requestBodies/historyRecords'
+      responses:
+        '200':
+          $ref: '#/components/responses/HistoryRecordCreated'
+        '400':
+          $ref: '#/components/responses/400Error'
   /ContactGroups:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -5980,28 +5980,28 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           $ref: '#/components/responses/HistoryRetrieved'
-    #put:
-    #  security:
-    #    - OAuth2: [accounting.transactions]
-    #  tags:
-    #    - Accounting
-    #  operationId: createExpenseClaimHistory
-    #  x-hasAccountingValidationError: true
-    #  summary: Allows you to create a history records of an ExpenseClaim
-    #  parameters:
-    #    - required: true
-    #      in: path
-    #      name: ExpenseClaimID
-    #      description: Unique identifier for a ExpenseClaim
-    #      example: "00000000-0000-0000-000-000000000000"
-    #      schema:
-    #        type: string
-    #        format: uuid
-    #  responses:
-    #    '200':
-    #      $ref: '#/components/responses/HistoryRecordCreated'
-    #  requestBody:
-    #    $ref: '#/components/requestBodies/historyRecords'
+    put:
+      security:
+        - OAuth2: [accounting.transactions]
+      tags:
+        - Accounting
+      operationId: createExpenseClaimHistory
+      x-hasAccountingValidationError: true
+      summary: Allows you to create a history records of an ExpenseClaim
+      parameters:
+        - required: true
+          in: path
+          name: ExpenseClaimID
+          description: Unique identifier for a ExpenseClaim
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/HistoryRecordCreated'
+      requestBody:
+        $ref: '#/components/requestBodies/historyRecords'
   /Invoices:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -7611,28 +7611,28 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           $ref: '#/components/responses/HistoryRetrieved'
-    #put:
-    #  security:
-    #    - OAuth2: [accounting.settings]
-    #  tags:
-    #    - Accounting
-    #  operationId: createItemHistory
-    #  x-hasAccountingValidationError: true
-    #  summary: Allows you to create a history record for items
-    #  parameters:
-    #    - required: true
-    #      in: path
-    #      name: ItemID
-    #      description: Unique identifier for an Item
-    #      example: "00000000-0000-0000-000-000000000000"
-    #      schema:
-    #        type: string
-    #        format: uuid
-    #  responses:
-    #    '200':
-    #      $ref: '#/components/responses/HistoryRecordCreated'
-    #  requestBody:
-    #    $ref: '#/components/requestBodies/historyRecords'
+    put:
+      security:
+        - OAuth2: [accounting.settings]
+      tags:
+        - Accounting
+      operationId: createItemHistory
+      x-hasAccountingValidationError: true
+      summary: Allows you to create a history record for items
+      parameters:
+        - required: true
+          in: path
+          name: ItemID
+          description: Unique identifier for an Item
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/HistoryRecordCreated'
+      requestBody:
+        $ref: '#/components/requestBodies/historyRecords'
   /Journals:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -9391,51 +9391,51 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           $ref: '#/components/responses/HistoryRetrieved'
-    #put:
-    #  security:
-    #    - OAuth2: [accounting.transactions]
-    #  tags:
-    #    - Accounting
-    #  operationId: createOverpaymentHistory
-    #  x-hasAccountingValidationError: true
-    #  summary: Allows you to create history records of an Overpayment
-    #  parameters:
-    #    - required: true
-    #      in: path
-    #      name: OverpaymentID
-    #      description: Unique identifier for a Overpayment
-    #      example: "00000000-0000-0000-000-000000000000"
-    #      schema:
-    #        type: string
-    #        format: uuid
-    #  responses:
-    #    '200':
-    ##      $ref: '#/components/responses/HistoryRecordCreated'
-    #    '400':
-    #      description: A failed request due to validation error - API is not able to create HistoryRecord for Overpayments
-    #      content:
-    #        application/json:
-    #          schema:
-    #            $ref: '#/components/schemas/Error'
-    #          example: '{
-    #                      "ErrorNumber": 10,
-    #                      "Type": "ValidationException",
-    #                      "Message": "A validation exception occurred",
-    #                      "Elements": [
-    #                        {
-    #                          "DateUTCString": "2019-03-12T22:30:13",
-    #                         "DateUTC": "\/Date(1552429813667)\/",
-    #                          "Details": "Hello World",
-    #                          "ValidationErrors": [
-    #                            {
-    #                              "Message": "The document with the supplied id was not found for this endpoint."
-    #                            }
-    #                          ]
-    #                        }
-    #                      ]
-    #                    }'
-    #  requestBody:
-    #    $ref: '#/components/requestBodies/historyRecords'
+    put:
+      security:
+        - OAuth2: [accounting.transactions]
+      tags:
+        - Accounting
+      operationId: createOverpaymentHistory
+      x-hasAccountingValidationError: true
+      summary: Allows you to create history records of an Overpayment
+      parameters:
+        - required: true
+          in: path
+          name: OverpaymentID
+          description: Unique identifier for a Overpayment
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/HistoryRecordCreated'
+        '400':
+          description: A failed request due to validation error - API is not able to create HistoryRecord for Overpayments
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example: '{
+                          "ErrorNumber": 10,
+                          "Type": "ValidationException",
+                          "Message": "A validation exception occurred",
+                          "Elements": [
+                            {
+                              "DateUTCString": "2019-03-12T22:30:13",
+                             "DateUTC": "\/Date(1552429813667)\/",
+                              "Details": "Hello World",
+                              "ValidationErrors": [
+                                {
+                                  "Message": "The document with the supplied id was not found for this endpoint."
+                                }
+                              ]
+                            }
+                          ]
+                        }'
+      requestBody:
+        $ref: '#/components/requestBodies/historyRecords'
   /Payments:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -10030,51 +10030,51 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           $ref: '#/components/responses/HistoryRetrieved'
-    #put:
-    #  security:
-    #    - OAuth2: [accounting.transactions]
-    #  tags:
-    #    - Accounting
-    #  operationId: createPaymentHistory
-    #  x-hasAccountingValidationError: true
-    #  summary: Allows you to create a history record for a payment
-    #  parameters:
-    #    - required: true
-    #      in: path
-    #      name: PaymentID
-    #      description: Unique identifier for a Payment
-    #      example: "00000000-0000-0000-000-000000000000"
-    #      schema:
-    #        type: string
-    #        format: uuid
-    #  responses:
-    #    '200':
-    #      $ref: '#/components/responses/HistoryRecordCreated'
-    #    '400':
-    #      description: A failed request due to validation error - API is not able to create HistoryRecord for Payments
-    #      content:
-    #        application/json:
-    #          schema:
-    #            $ref: '#/components/schemas/Error'
-    #          example: '{
-    #                      "ErrorNumber": 10,
-    #                      "Type": "ValidationException",
-    #                      "Message": "A validation exception occurred",
-    #                      "Elements": [
-    #                        {
-    #                          "DateUTCString": "2019-03-12T22:30:13",
-    #                          "DateUTC": "\/Date(1552429813667)\/",
-    #                          "Details": "Hello World",
-    #                          "ValidationErrors": [
-    #                            {
-    #                              "Message": "The document with the supplied id was not found for this endpoint."
-    #                            }
-    #                          ]
-    #                        }
-    #                      ]
-    #                    }'
-    #  requestBody:
-    #    $ref: '#/components/requestBodies/historyRecords'
+    put:
+      security:
+        - OAuth2: [accounting.transactions]
+      tags:
+        - Accounting
+      operationId: createPaymentHistory
+      x-hasAccountingValidationError: true
+      summary: Allows you to create a history record for a payment
+      parameters:
+        - required: true
+          in: path
+          name: PaymentID
+          description: Unique identifier for a Payment
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/HistoryRecordCreated'
+        '400':
+          description: A failed request due to validation error - API is not able to create HistoryRecord for Payments
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example: '{
+                          "ErrorNumber": 10,
+                          "Type": "ValidationException",
+                          "Message": "A validation exception occurred",
+                          "Elements": [
+                            {
+                              "DateUTCString": "2019-03-12T22:30:13",
+                              "DateUTC": "\/Date(1552429813667)\/",
+                              "Details": "Hello World",
+                              "ValidationErrors": [
+                                {
+                                  "Message": "The document with the supplied id was not found for this endpoint."
+                                }
+                              ]
+                            }
+                          ]
+                        }'
+      requestBody:
+        $ref: '#/components/requestBodies/historyRecords'
   /PaymentServices:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -10476,51 +10476,51 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           $ref: '#/components/responses/HistoryRetrieved'
-    #put:
-    #  security:
-    #    - OAuth2: [accounting.transactions]
-    #  tags:
-    #    - Accounting
-    #  operationId: createPrepaymentHistory
-    #  x-hasAccountingValidationError: true
-    #  summary: Allows you to create a history record for an Prepayment
-    #  parameters:
-    #    - required: true
-    #      in: path
-    #      name: PrepaymentID
-    #      description: Unique identifier for a PrePayment
-    #      example: "00000000-0000-0000-000-000000000000"
-    #      schema:
-    #        type: string
-    #        format: uuid
-    #  responses:
-    #    '200':
-    #      $ref: '#/components/responses/HistoryRecordCreated'
-    #    '400':
-    #      description: Unsupported - return response incorrect exception, API is not able to create HistoryRecord for Expense Claims
-    #      content:
-    #        application/json:
-    #          schema:
-    #            $ref: '#/components/schemas/Error'
-    #          example: ' {
-    #                        "ErrorNumber": 10,
-    #                        "Type": "ValidationException",
-    #                        "Message": "A validation exception occurred",
-    #                        "Elements": [
-    #                          {
-    #                            "DateUTCString": "2019-03-14T00:15:35",
-    #                            "DateUTC": "\/Date(1552522535440)\/",
-    #                            "Details": "Hello World",
-    #                            "ValidationErrors": [
-    #                              {
-    #                                "Message": "The document with the supplied id was not found for this endpoint."
-    #                              }
-    #                            ]
-    #                          }
-    #                        ]
-    #                      }'
-    #  requestBody:
-    #    $ref: '#/components/requestBodies/historyRecords'
+    put:
+      security:
+        - OAuth2: [accounting.transactions]
+      tags:
+        - Accounting
+      operationId: createPrepaymentHistory
+      x-hasAccountingValidationError: true
+      summary: Allows you to create a history record for an Prepayment
+      parameters:
+        - required: true
+          in: path
+          name: PrepaymentID
+          description: Unique identifier for a PrePayment
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/HistoryRecordCreated'
+        '400':
+          description: Unsupported - return response incorrect exception, API is not able to create HistoryRecord for Expense Claims
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example: ' {
+                            "ErrorNumber": 10,
+                            "Type": "ValidationException",
+                            "Message": "A validation exception occurred",
+                            "Elements": [
+                              {
+                                "DateUTCString": "2019-03-14T00:15:35",
+                                "DateUTC": "\/Date(1552522535440)\/",
+                                "Details": "Hello World",
+                                "ValidationErrors": [
+                                  {
+                                    "Message": "The document with the supplied id was not found for this endpoint."
+                                  }
+                                ]
+                              }
+                            ]
+                          }'
+      requestBody:
+        $ref: '#/components/requestBodies/historyRecords'
   /PurchaseOrders:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -13012,51 +13012,51 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           $ref: '#/components/responses/HistoryRetrieved'
-    #put:
-    # security:
-    #    - OAuth2: [accounting.transactions]
-    #  tags:
-    #    - Accounting
-    #  operationId: createReceiptHistory
-    #  x-hasAccountingValidationError: true
-    #  summary: Allows you to retrieve a history records of an Receipt
-    #  parameters:
-    #    - required: true
-    #      in: path
-    #      name: ReceiptID
-    #      description: Unique identifier for a Receipt
-    #      example: "00000000-0000-0000-000-000000000000"
-    #      schema:
-    #        type: string
-    #        format: uuid
-    #  responses:
-    #    '200':
-    #      $ref: '#/components/responses/HistoryRecordCreated'
-    #    '400':
-    #      description: Unsupported - return response incorrect exception, API is not able to create HistoryRecord for Receipts
-    #      content:
-    #        application/json:
-    #          schema:
-    #            $ref: '#/components/schemas/Error'
-    #          example: '{
-    #                      "ErrorNumber": 10,
-    #                      "Type": "ValidationException",
-    #                      "Message": "A validation exception occurred",
-    #                      "Elements": [
-    #                        {
-    #                          "DateUTCString": "2019-03-15T21:51:50",
-    #                          "DateUTC": "\/Date(1552686710791)\/",
-    #                          "Details": "Hello World",
-    #                          "ValidationErrors": [
-    #                            {
-    #                              "Message": "The document with the supplied id was not found for this endpoint."
-    #                            }
-    #                          ]
-    #                        }
-    #                      ]
-    #                    }'
-    #  requestBody:
-    #    $ref: '#/components/requestBodies/historyRecords'
+    put:
+      security:
+          - OAuth2: [accounting.transactions]
+      tags:
+        - Accounting
+      operationId: createReceiptHistory
+      x-hasAccountingValidationError: true
+      summary: Allows you to retrieve a history records of an Receipt
+      parameters:
+        - required: true
+          in: path
+          name: ReceiptID
+          description: Unique identifier for a Receipt
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/HistoryRecordCreated'
+        '400':
+          description: Unsupported - return response incorrect exception, API is not able to create HistoryRecord for Receipts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example: '{
+                          "ErrorNumber": 10,
+                          "Type": "ValidationException",
+                          "Message": "A validation exception occurred",
+                          "Elements": [
+                            {
+                              "DateUTCString": "2019-03-15T21:51:50",
+                              "DateUTC": "\/Date(1552686710791)\/",
+                              "Details": "Hello World",
+                              "ValidationErrors": [
+                                {
+                                  "Message": "The document with the supplied id was not found for this endpoint."
+                                }
+                              ]
+                            }
+                          ]
+                        }'
+      requestBody:
+        $ref: '#/components/requestBodies/historyRecords'
   /RepeatingInvoices:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -13523,30 +13523,30 @@ contact: {}, date:"2020-01-01", user:{} } ] } ] }'
       responses:
         '200':
           $ref: '#/components/responses/HistoryRetrieved'
-    #put:
-    #  security:
-    #    - OAuth2: [accounting.transactions]
-    #  tags:
-    #    - Accounting
-    #  operationId: createRepeatingInvoiceHistory
-    #  x-hasAccountingValidationError: true
-    #  summary: Allows you to create history for a repeating invoice
-    #  parameters:
-    #    - required: true
-    #      in: path
-    #      name: RepeatingInvoiceID
-    #      description: Unique identifier for a Repeating Invoice
-    #      example: "00000000-0000-0000-000-000000000000"
-    #      schema:
-    #        type: string
-    #        format: uuid
-    #  responses:
-    #    '200':
-    #      $ref: '#/components/responses/HistoryRecordCreated'
-    #    '400':
-    #      $ref: '#/components/responses/400Error'
-    #  requestBody:
-    #    $ref: '#/components/requestBodies/historyRecords'
+    put:
+      security:
+        - OAuth2: [accounting.transactions]
+      tags:
+        - Accounting
+      operationId: createRepeatingInvoiceHistory
+      x-hasAccountingValidationError: true
+      summary: Allows you to create history for a repeating invoice
+      parameters:
+        - required: true
+          in: path
+          name: RepeatingInvoiceID
+          description: Unique identifier for a Repeating Invoice
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/HistoryRecordCreated'
+        '400':
+          $ref: '#/components/responses/400Error'
+      requestBody:
+        $ref: '#/components/requestBodies/historyRecords'
   '/Reports/TenNinetyNine':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'


### PR DESCRIPTION
With the latest release, we have extended the create notes feature to more document types. These were commented out in the specs as they weren't supported before. So undoing that.
Also adding the newly added 'RepeatingInvoiceID' returned with Get/invoices to the specifications.

Thanks