### PR TITLE
Add DELETED enum to QuoteStatusCode in Quote schema

### DIFF
--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -21783,6 +21783,7 @@ components:
         - DECLINED
         - ACCEPTED
         - INVOICED
+        - DELETED
     Receipts:
       type: object
       x-isObjectArray: true


### PR DESCRIPTION
Reported by @ThirstyJarek from [a .NET SDK issue](https://github.com/XeroAPI/Xero-NetStandard/issues/200): 

Line 21777: 
    QuoteStatusCodes:
      description: The status of the quote. 
      type: string
      enum:
        - DRAFT
        - SENT
        - DECLINED
        - ACCEPTED
        - INVOICED
        **- DELETED**



