### PR TITLE
removed a x-money type that might be off

### DIFF
--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -18490,7 +18490,6 @@ components:
           description: LineItem Quantity
           type: number
           format: double
-          x-is-money: true
         UnitAmount:
           description: LineItem Unit Amount
           type: number
@@ -20153,7 +20152,6 @@ components:
           description: The quantity of the item on hand
           type: number
           format: double
-          x-is-money: true
         UpdatedDateUTC:
           description: Last modified date in UTC format
           type: string


### PR DESCRIPTION
`LineItem` had quantity generating as x-is-money which seemed like a bug?

# LineItem quantity
https://developer.xero.com/documentation/api/invoices#LineItems
In our docs we have it as a 4 decimal place, `"Quantity": "1.0000"` so maybe this is why?

If we represent as a money type might confuse folks downstream versus keeping it as up to a 4 decimal place number?