### PR TITLE
change Accounting Attachment ContentLength data type to integer

### DIFF
--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -18330,7 +18330,7 @@ components:
           example: "image/jpg"
         ContentLength:
           description: Length of the file content
-          type: number
+          type: integer
         IncludeOnline:
           description: Include the file with the online invoice
           type: boolean


### PR DESCRIPTION
The datatype of Attachment ContentLength is "number" which result in a float/decimal in generated SDKs. 

Our API will return 500 error if a number with decimal is sent. 

Changing this to "integer" will set the type to int for all SDKs.

Reported here in .NET SDK issue [205](https://github.com/XeroAPI/Xero-NetStandard/issues/205). 