### PR TITLE
Fix payrollau payitem leaveloadingrate not double

### DIFF
--- a/accounting-yaml/xero_accounting.yaml
+++ b/accounting-yaml/xero_accounting.yaml
@@ -18330,7 +18330,7 @@ components:
           example: "image/jpg"
         ContentLength:
           description: Length of the file content
-          type: number
+          type: integer
         IncludeOnline:
           description: Include the file with the online invoice
           type: boolean

--- a/payroll-au-yaml/xero-payroll-au.yaml
+++ b/payroll-au-yaml/xero-payroll-au.yaml
@@ -3292,10 +3292,8 @@ components:
           example: 1.5
         AccrueLeave:
           description: Indicates that this earnings rate should accrue leave. Only applicable if RateType is MULTIPLE
-          type: number
-          format: double
-          x-is-money: true
-          example: 1.5
+          type: boolean
+          example: false
         Amount:
           description: Optional Amount for FIXEDAMOUNT RateType EarningsRate
           type: number

--- a/payroll-au-yaml/xero-payroll-au.yaml
+++ b/payroll-au-yaml/xero-payroll-au.yaml
@@ -3383,8 +3383,9 @@ components:
           example: 152.0000
         LeaveLoadingRate:
           description: Enter an amount here if your organisation pays an additional percentage on top of ordinary earnings when your employees take leave (typically 17.5%)
-          type: integer
-          example: 12
+          type: number
+          format: double
+          example: 2.0000
         UpdatedDateUTC:
           description: Last modified timestamp
           type: string


### PR DESCRIPTION
This PR corrects the type of LeaveLoadingRate to "double" under LeaveType schema.

This is an [issue](https://github.com/XeroAPI/Xero-NetStandard/issues/196) reported by .NET SDK repo. 