### PR TITLE
removed duplicated PrivateUsePayments enum from Deduction schema

### DIFF
--- a/payroll-uk-yaml/xero-payroll-uk.yaml
+++ b/payroll-uk-yaml/xero-payroll-uk.yaml
@@ -5177,7 +5177,6 @@ components:
             - MakingGood
             - PrivateUsePayments
             - PostgraduateLoanDeductions
-            - PrivateUsePayments
             - SalarySacrifice
             - StakeholderPension
             - StakeholderPensionPostTax


### PR DESCRIPTION
Found duplication in payroll UK spec for Deduction schema: 
https://github.com/XeroAPI/Xero-OpenAPI/blob/master/payroll-uk-yaml/xero-payroll-uk.yaml#L5180