### PR TITLE
adds QuoteNumber param to getQuotes

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -11483,6 +11483,11 @@ paths:
           example: ASC
           schema:
             type: string
+        - in: query
+          name: QuoteNumber
+          description: Filter by quote number (e.g. GET https://.../Quotes?QuoteNumber=QU-0001)
+          schema:
+            type: string
       responses:
         '200':
           description: Success - return response of type quotes array with all quotes
@@ -11691,91 +11696,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Quotes'
               example: '{ quotes: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "12775" }], date: "2020-02-01" }]}'
-  '/Quotes/{QuoteNumber}':
-    parameters:
-      - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Quote
-    get:
-      security:
-        - OAuth2: ['accounting.transactions.read']
-      tags:
-        - Accounting
-      operationId: getQuoteByNumber
-      summary: Allows you to retrieve a specified quote by the quote number
-      parameters:
-        - required: true
-          in: path
-          name: QuoteNumber
-          description: Unique identifier for a Quote
-          example: "QU01234"
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Success - return response of type Quote array for specified Quote
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Quotes'
-              example: '{ 
-                        "SummarizeErrors":true,
-                        "Id":"e3626c45-77f1-4ab0-ba9b-3593c7bcd25c",
-                        "Status":"OK",
-                        "ProviderName":"java-sdk-oauth2-dev-02",
-                        "DateTimeUTC":"\/Date(1580607864786)\/",
-                        "Quotes":[ 
-                            { 
-                              "QuoteID":"1f90e77a-7b88-4462-874f-1aa675be8fef",
-                              "QuoteNumber":"QU-0007",
-                              "Reference":"MyQuote",
-                              "Terms":"These are my terms",
-                              "Contact":{ 
-                                  "ContactID":"4bc3ecb2-8e2a-4267-a171-0e0ce7e5ac2a",
-                                  "Name":"ABC Limited",
-                                  "EmailAddress":"john.smith@gmail.com",
-                                  "FirstName":"John",
-                                  "LastName":"Smith"
-                              },
-                              "LineItems":[ 
-                                  { 
-                                    "LineItemID":"09b47d9f-f78d-4bab-b226-957f55bfb1b5",
-                                    "AccountCode":"400",
-                                    "Description":"Half day training - Microsoft Office",
-                                    "UnitAmount":500.0000,
-                                    "LineAmount":500.00,
-                                    "ItemCode":"Train-MS",
-                                    "Quantity":1.0000,
-                                    "TaxAmount":0.00,
-                                    "TaxType":"NONE",
-                                    "Tracking":[ 
-                                        { 
-                                          "TrackingCategoryID":"9bd3f506-6d91-4625-81f0-0f9147f099f4",
-                                          "TrackingOptionID":"d30e2a0d-ae6f-4806-88ca-d8ebdba2af73",
-                                          "Name":"Avengers",
-                                          "Option":"IronMan"
-                                        }
-                                    ]
-                                  }
-                              ],
-                              "Date":"\/Date(1580515200000)\/",
-                              "DateString":"2020-02-01T00:00:00",
-                              "ExpiryDate":"\/Date(1581724800000)\/",
-                              "ExpiryDateString":"2020-02-15T00:00:00",
-                              "Status":"DRAFT",
-                              "CurrencyRate":1.547150,
-                              "CurrencyCode":"NZD",
-                              "SubTotal":500.00,
-                              "TotalTax":0.00,
-                              "Total":500.00,
-                              "TotalDiscount":0.00,
-                              "Title":"",
-                              "Summary":"",
-                              "BrandingThemeID":"324587a9-7eed-46c0-ad64-fa941a1b5b3e",
-                              "UpdatedDateUTC":"\/Date(1580607757040)\/",
-                              "LineAmountTypes":"EXCLUSIVE"
-                            }
-                        ]
-                      }'
   '/Quotes/{QuoteID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'


### PR DESCRIPTION
@Arcath @SidneyAllen 

GET https://.../Quotes/{identifier} only works with uuid quote ID unlike PurchaseOrders which accepts either PO Number or uuid.

QuoteNumber must instead be used as parameter GET https://.../Quotes?QuoteNumber=QU-0001.

https://developer.xero.com/documentation/api/quotes
https://developer.xero.com/documentation/api/purchase-orders

This PR removes getQuoteByNumber and adds QuoteNumber as a parameter to getQuotes.