### PR TITLE
Payroll nz add is money vendor extension

### DIFF
--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -4740,6 +4740,7 @@ components:
           description: Special tax rate percentage.
           type: number
           format: double
+          x-is-money: true
           example: 17.5
         hasSpecialStudentLoanRate:
           description: Does the employee has a special student loan rate?
@@ -4749,6 +4750,7 @@ components:
           description: The employee student loan rate percentage.
           type: number
           format: double
+          x-is-money: true
           example: 2.0
         isEligibleForKiwiSaver:
           description: The employee eligibility for KiwiSaver.
@@ -4758,6 +4760,7 @@ components:
           description: Employer superannuation contribution tax rate.
           type: number
           format: double
+          x-is-money: true
           example: 1.0
         kiwiSaverContributions:
           description: Contribution Option which can be 'MakeContributions' 'OptOut', 'OnAContributionsHoliday', 'OnASavingsSuspension', 'NotCurrentlyAKiwiSaverMember' for employees without a KiwiSaver membership
@@ -4773,16 +4776,19 @@ components:
           description: Employee Contribution percentage.
           type: number
           format: double
+          x-is-money: true
           example: 4.0
         kiwiSaverEmployerContributionRatePercentage:
           description: Employer Contribution percentage.
           type: number
           format: double
+          x-is-money: true
           example: 10.0       
         kiwiSaverEmployerSalarySacrificeContributionRatePercentage:
           description: Employer Contribution through Salary Sacrifice percentage.
           type: number
           format: double
+          x-is-money: true
           example: 2.0
         kiwiSaverOptOutDate:
           description: Opt Out Date.
@@ -4804,6 +4810,7 @@ components:
           description: The employee's student loan balance shown on the letter from IR.
           type: number
           format: double
+          x-is-money: true
           example: 30.0000
         studentLoanAsAt:
           description: The date of the letter from IR.
@@ -4870,6 +4877,7 @@ components:
           description: The gross earnings during the period.
           type: number
           format: double
+          x-is-money: true
     EmployeeLeaves:
       type: object
       properties:
@@ -4957,6 +4965,7 @@ components:
           description: The Number of Units for the leave
           type: number
           format: double
+          x-is-money: true
         periodStatus:
           description: Period Status
           type: string
@@ -4989,6 +4998,7 @@ components:
           description: The employees current balance for the corresponding leave type.
           type: number
           format: double
+          x-is-money: true
         typeOfUnits:
           description: The type of the units of the leave.
           type: string
@@ -5018,6 +5028,7 @@ components:
           description: The balance remaining for the corresponding leave type as of specified date.
           type: number
           format: double
+          x-is-money: true
         units:
           description: The units will be "Hours"
           type: string
@@ -5153,14 +5164,17 @@ components:
           description: The amount of requested time (in weeks)  
           type: number
           format: double
+          x-is-money: true
         entitlementWeeksQualified:
           description: The amount of statutory sick leave time off (in weeks) that is available to take at the time the leave was requested  
           type: number
           format: double
+          x-is-money: true
         entitlementWeeksRemaining:
           description: A calculated amount of time (in weeks) that remains for the statutory sick leave period  
           type: number
           format: double
+          x-is-money: true
         overlapsWithOtherLeave:
           description: Whether another leave (Paternity, Shared Parental specifically) occurs during the requested leave's period. While this is allowed it could affect payment amounts
           type: boolean
@@ -5207,31 +5221,37 @@ components:
           description: Initial holiday pay balance. A percentage — usually 8% — of gross earnings since their last work anniversary.
           type: number
           format: double
+          x-is-money: true
           example: 10.5
         annualLeaveOpeningBalance:
           description: Initial annual leave balance. The balance at their last anniversary, less any leave taken since then and excluding accrued annual leave.
           type: number
           format: double
+          x-is-money: true
           example: 25.89
         negativeAnnualLeaveBalancePaidAmount:
           description: The dollar value of annual leave opening balance if negative.
           type: number
           format: double
+          x-is-money: true
           example: 10.0
         sickLeaveHoursToAccrueAnnually:
           description: Number of hours accrued annually for sick leave. Multiply the number of days they're entitled to by the hours worked per day
           type: number
           format: double
+          x-is-money: true
           example: 100.5
         sickLeaveMaximumHoursToAccrue:
           description: Maximum number of hours accrued annually for sick leave. Multiply the maximum days they can accrue by the hours worked per day
           type: number
           format: double
+          x-is-money: true
           example: 200.5
         sickLeaveOpeningBalance:
           description: Initial sick leave balance. This will be positive unless they've taken sick leave in advance
           type: number
           format: double
+          x-is-money: true
           example: 10.5
     EmployeeLeaveTypeObject:
       type: object
@@ -5261,22 +5281,27 @@ components:
           description: The number of hours accrued for the leave annually. This is 0 when the scheduleOfAccrual chosen is "OnHourWorked"
           type: number
           format: double
+          x-is-money: true
         maximumToAccrue:
           description: The maximum number of hours that can be accrued for the leave  
           type: number
           format: double
+          x-is-money: true
         openingBalance:
           description: The initial number of hours assigned when the leave was added to the employee  
           type: number
           format: double
+          x-is-money: true
         rateAccruedHourly:
           description: The number of hours added to the leave balance for every hour worked by the employee. This is normally 0, unless the scheduleOfAccrual chosen is "OnHourWorked"
           type: number
           format: double
+          x-is-money: true
         percentageOfGrossEarnings:
           description: Specific for scheduleOfAccrual having percentage of gross earnings. Identifies how much percentage of gross earnings is accrued per pay period.
           type: number
           format: double
+          x-is-money: true
         includeHolidayPayEveryPay:
           description: Specific to Holiday pay. Flag determining if pay for leave type is added on each pay run.
           type: boolean
@@ -5287,6 +5312,7 @@ components:
           description: Specific to Annual Leave. Annual leave balance in dollars
           type: number
           format: double
+          x-is-money: true
     EmployeePayTemplateObject:
       type: object
       properties:
@@ -5351,14 +5377,17 @@ components:
           description: The rate per unit  
           type: number
           format: double
+          x-is-money: true
         numberOfUnits:
           description: The rate per unit  
           type: number
           format: double
+          x-is-money: true
         fixedAmount:
           description: The fixed amount per period  
           type: number
           format: double
+          x-is-money: true
         earningsRateID:
           description: The corresponding earnings rate identifier  
           type: string
@@ -5426,14 +5455,17 @@ components:
           description: Standard amount of the superannuation
           type: number
           format: double
+          x-is-money: true
         percentage:
           description: Percentage of Taxable Earnings of the superannuation
           type: number
           format: double
+          x-is-money: true
         companyMax:
           description: Company Maximum amount of the superannuation
           type: number
           format: double
+          x-is-money: true
         currentRecord:
           description: Identifier of a record is active or not.
           type: boolean
@@ -5491,6 +5523,7 @@ components:
           description: Standard amount of the deduction.
           type: number
           format: double
+          x-is-money: true
     StatutoryDeductions:
       type: object
       properties:
@@ -5658,14 +5691,17 @@ components:
           description: Default rate per unit (optional). Only applicable if RateType is RatePerUnit
           type: number
           format: double
+          x-is-money: true
         multipleOfOrdinaryEarningsRate:
           description: This is the multiplier used to calculate the rate per unit, based on the employee’s ordinary earnings rate. For example, for time and a half enter 1.5. Only applicable if RateType is MultipleOfOrdinaryEarningsRate
           type: number
           format: double
+          x-is-money: true
         fixedAmount:
           description: Optional Fixed Rate Amount. Applicable for FixedAmount Rate
           type: number
           format: double
+          x-is-money: true
     LeaveTypes:
       type: object
       properties:
@@ -5781,6 +5817,7 @@ components:
           description: Optional Rate Per Unit. Applicable when calculation type is Rate Per Unit
           type: number
           format: double
+          x-is-money: true
     Timesheets:
       type: object
       properties:
@@ -5841,7 +5878,8 @@ components:
         totalHours:
           description: The Total Hours of the Timesheet
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         updatedDateUTC:
           description: The UTC date time that the Timesheet was last updated
           type: string
@@ -5889,7 +5927,8 @@ components:
         numberOfUnits:
           description: The Number of Units of the Timesheet Line
           type: number
-          format: double 
+          format: double
+          x-is-money: true
     PayRunCalendars:
       type: object
       properties:
@@ -6023,15 +6062,18 @@ components:
         numberOfUnitsPerWeek:
           description: The Number of Units per week for the corresponding salary and wages
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         ratePerUnit:
           description: The rate of each unit for the corresponding salary and wages
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         numberOfUnitsPerDay:
           description: The Number of Units per day for the corresponding salary and wages
           type: number
-          format: double 
+          format: double
+          x-is-money: true 
         daysPerWeek:
           description: The days per week for the salary.
           type: integer
@@ -6044,7 +6086,8 @@ components:
         annualSalary:
           description: The annual salary
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         status:
           description: The current status of the corresponding salary and wages
           type: string
@@ -6106,11 +6149,13 @@ components:
         totalCost:
           description: Total cost of the pay run
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         totalPay:
           description: Total pay of the pay run
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         payRunStatus:
           description: Pay run status
           type: string
@@ -6192,39 +6237,48 @@ components:
         totalEarnings:
           description: Total earnings before any deductions. Same as gross earnings for NZ.
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         grossEarnings:
           description: Total earnings before any deductions. Same as total earnings for NZ.
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         totalPay:
           description: The employee net pay
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         totalEmployerTaxes:
           description: The employer's tax obligation
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         totalEmployeeTaxes:
           description: The part of an employee's earnings that is deducted for tax purposes
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         totalDeductions:
           description: Total amount subtracted from an employee's earnings to reach total pay
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         totalReimbursements:
           description: Total reimbursements are nontaxable payments to an employee used to repay out-of-pocket expenses when the person incurs those expenses through employment
           type: number
           format: double
+          x-is-money: true
         totalStatutoryDeductions:
           description: Total amounts required by law to subtract from the employee's earnings
           type: number
           format: double
+          x-is-money: true
         totalSuperannuation:
           description: Benefits (also called fringe benefits, perquisites or perks) are various non-earnings compensations provided to employees in addition to their normal earnings or salaries
           type: number
           format: double
+          x-is-money: true
         bacsHash:
           description: BACS Service User Number
           type: string 
@@ -6282,19 +6336,23 @@ components:
         ratePerUnit:
           description: Rate per unit for earnings line
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         numberOfUnits:
           description: Earnings number of units
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         fixedAmount:
           description: Earnings fixed amount. Only applicable if the EarningsRate RateType is Fixed
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         amount:
           description: The amount of the earnings line.
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         isLinkedToTimesheet:
           description: Identifies if the earnings is taken from the timesheet. False for earnings line
           type: boolean
@@ -6325,19 +6383,23 @@ components:
         ratePerUnit:
           description: Rate per unit for leave earnings line
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         numberOfUnits:
           description: Leave earnings number of units
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         fixedAmount:
           description: Leave earnings fixed amount. Only applicable if the EarningsRate RateType is Fixed
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         amount:
           description: The amount of the earnings line.
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         isLinkedToTimesheet:
           description: Identifies if the leave earnings is taken from the timesheet. False for leave earnings line
           type: boolean
@@ -6368,19 +6430,23 @@ components:
         ratePerUnit:
           description: Rate per unit for leave earnings line
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         numberOfUnits:
           description: Leave earnings number of units
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         fixedAmount:
           description: Leave earnings fixed amount. Only applicable if the EarningsRate RateType is Fixed
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         amount:
           description: The amount of the earnings line.
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         isLinkedToTimesheet:
           description: Identifies if the leave earnings is taken from the timesheet. False for leave earnings line
           type: boolean
@@ -6407,14 +6473,16 @@ components:
         amount:
           description: The amount of the deduction line
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         subjectToTax:
           description: Identifies if the deduction is subject to tax
           type: boolean
         percentage:
           description: Deduction rate percentage
           type: number
-          format: double 
+          format: double
+          x-is-money: true
     ReimbursementLines:
       type: array
       items:
@@ -6433,14 +6501,17 @@ components:
           description: Reimbursement amount
           type: number
           format: double
+          x-is-money: true
         ratePerUnit:
           description: Rate per unit for leave earnings line
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         numberOfUnits:
           description: Leave earnings number of units
           type: number
-          format: double 
+          format: double
+          x-is-money: true
     LeaveAccrualLines:
       type: array
       items:
@@ -6455,7 +6526,8 @@ components:
         numberOfUnits:
           description: Leave accrual number of units
           type: number
-          format: double 
+          format: double
+          x-is-money: true
     SuperannuationLines:
       type: array
       items:
@@ -6473,15 +6545,18 @@ components:
         amount:
           description: The amount of the superannuation line
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         fixedAmount:
           description: Superannuation fixed amount
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         percentage:
           description: Superannuation rate percentage
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         manualAdjustment:
           description: manual adjustment made
           type: boolean 
@@ -6499,7 +6574,8 @@ components:
         amount:
           description: The amount of the payment line
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         accountNumber:
           description: The account number
           type: string
@@ -6526,7 +6602,8 @@ components:
         amount:
           description: The amount of the tax line
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         globalTaxTypeID: 
           description: Tax type ID
           type: string
@@ -6547,11 +6624,13 @@ components:
         amount:
           description: The amount of the statutory deduction line
           type: number
-          format: double 
+          format: double
+          x-is-money: true
         fixedAmount:
           description: Fixed Amount
           type: number
           format: double
+          x-is-money: true
         manualAdjustment: 
           description: Identifies if the tax line is a manual adjustment
           type: boolean
@@ -6689,6 +6768,7 @@ components:
           description: Dollar amount of a transaction.
           type: number
           format: double
+          x-is-money: true
         reference:
           description: Statement Text/reference for a transaction that appear on the statement.
           type: string

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -11422,6 +11422,266 @@ paths:
           $ref: '#/components/responses/400Error'
       requestBody:
         $ref: '#/components/requestBodies/historyRecords'
+  '/PurchaseOrders/{PurchaseOrderID}/Attachments':
+    parameters:
+      - $ref: '#/components/parameters/requiredHeader'
+    x-related-model: Account
+    get:
+      security:
+        - OAuth2: [accounting.attachments.read]
+      tags:
+        - Accounting
+      operationId: getPurchaseOrdersAttachments
+      summary: Allows you to retrieve attachments for purchase orders
+      parameters:
+        - required: true
+          in: path
+          name: PurchaseOrderID
+          description: Unique identifier for Purchase Orders object
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Success - return response of type Attachments array of Purchase Orders 
+          x-isAttachment: true
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Attachments'
+              example: '{
+                  "Id": "dfc29f55-8ddd-4921-a82c-bcc0798d207f",
+                  "Status": "OK",
+                  "ProviderName": "Xero API Partner",
+                  "DateTimeUTC": "/Date(1602100184437)/",
+                  "Attachments": [
+                      {
+                          "AttachmentID": "dce4eaa7-c8a9-4867-9434-95832b427d3b",
+                          "FileName": "xero-dev1.png",
+                          "Url": "https://api.xero.com/api.xro/2.0/PurchaseOrders/93369c9b-c481-4e21-aaab-bb19e9a26efe/Attachments/2D_2.png",
+                          "MimeType": "image/png",
+                          "ContentLength": 98715
+                      },
+                      {
+                          "AttachmentID": "e58bd37b-e47f-451a-a42c-f946ef229c3e",
+                          "FileName": "xero-dev2.png",
+                          "Url": "https://api.xero.com/api.xro/2.0/PurchaseOrders/93369c9b-c481-4e21-aaab-bb19e9a26efe/Attachments/2D.png",
+                          "MimeType": "image/png",
+                          "ContentLength": 82529
+                      },
+                      {
+                          "AttachmentID": "c8faa564-223f-45e4-a5a1-94430a5b52c1",
+                          "FileName": "xero-dev3.png",
+                          "Url": "https://api.xero.com/api.xro/2.0/PurchaseOrders/93369c9b-c481-4e21-aaab-bb19e9a26efe/Attachments/Screen%20Shot%202020-09-12%20at%204.31.14%20pm.png",
+                          "MimeType": "image/png",
+                          "ContentLength": 146384
+                      }
+                  ]
+              }'
+  '/PurchaseOrders/{PurchaseOrderID}/Attachments/{AttachmentID}':
+    parameters:
+      - $ref: '#/components/parameters/requiredHeader'
+    x-related-model: Account
+    get:
+      security:
+        - OAuth2: [accounting.attachments.read]
+      tags:
+        - Accounting
+      operationId: getPurchaseOrderAttachmentById
+      summary: Allows you to retrieve specific Attachment on purchase order
+      parameters:
+        - required: true
+          in: path
+          name: PurchaseOrderID
+          description: Unique identifier for Purchase Order object
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+        - required: true
+          in: path
+          name: AttachmentID
+          description: Unique identifier for Attachment object
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+        - required: true
+          in: header
+          name: contentType
+          description: The mime type of the attachment file you are retrieving i.e image/jpg, application/pdf 
+          example: image/jpg
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success - return response of attachment for Account as binary data 
+          content:
+             application/octet-stream:
+              schema:
+                type: string
+                format: binary
+  '/PurchaseOrders/{PurchaseOrderID}/Attachments/{FileName}':
+    parameters:
+      - $ref: '#/components/parameters/requiredHeader'
+    x-related-model: Account
+    get:
+      security:
+        - OAuth2: [accounting.attachments.read]
+      tags:
+        - Accounting
+      operationId: getPurchaseOrder≠AttachmentByFileName
+      summary: Allows you to retrieve Attachment on a Purchase Order by Filename
+      parameters:
+        - required: true
+          in: path
+          name: PurchaseOrderID
+          description: Unique identifier for Purchase Order object
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+        - required: true
+          in: path
+          name: FileName
+          description: Name of the attachment
+          example: "xero-dev.jpg"
+          schema:
+            type: string
+        - required: true
+          in: header
+          name: contentType
+          description: The mime type of the attachment file you are retrieving i.e image/jpg, application/pdf 
+          example: image/jpg
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success - return response of attachment for Purchase Order as binary data 
+          content:
+             application/octet-stream:
+              schema:
+                type: string
+                format: binary
+    post:
+      security:
+        - OAuth2: [accounting.attachments]
+      tags:
+        - Accounting
+      operationId: updatePurchaseOrderAttachmentByFileName
+      x-hasAccountingValidationError: true
+      summary: Allows you to update Attachment on Purchase Order by Filename
+      parameters:
+        - required: true
+          in: path
+          name: PurchaseOrderID
+          description: Unique identifier for Purchase Order object
+          example: "00000000-0000-0000-000-000000000000"
+          schema:
+            type: string
+            format: uuid
+        - required: true
+          in: path
+          name: FileName
+          description: Name of the attachment
+          example: "xero-dev.png"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success - return response of type Attachments array of Attachment 
+          x-isAttachment: true
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Attachments'
+              example: '{
+                    "Id": "aeff9be0-54c2-45dd-8e3d-aa4f8af0fbd7",
+                    "Status": "OK",
+                    "ProviderName": "Xero API Partner",
+                    "DateTimeUTC": "/Date(1602100086197)/",
+                    "Attachments": [
+                        {
+                            "AttachmentID": "dce4eaa7-c8a9-4867-9434-95832b427d3b",
+                            "FileName": "xero-dev.png",
+                            "Url": "https://api.xero.com/api.xro/2.0/PurchaseOrders/93369c9b-c481-4e21-aaab-bb19e9a26efe/Attachments/2D_2.png",
+                            "MimeType": "image/png",
+                            "ContentLength": 98715
+                        }
+                    ]
+                }'
+        '400':
+          description: Validation Error - some data was incorrect returns response of type Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        required: true
+        description: Byte array of file in body of request
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: byte
+    put:
+      security:
+        - OAuth2: [accounting.attachments]
+      tags:
+        - Accounting
+      operationId: createPurchaseOrderAttachmentByFileName
+      x-hasAccountingValidationError: true
+      summary: Allows you to create Attachment on Purchase Order
+      parameters:
+        - required: true
+          in: path
+          name: PurchaseOrderID
+          description: Unique identifier for Purchase Order object
+          example: 00000000-0000-0000-000-000000000000
+          schema:
+            type: string
+            format: uuid
+        - required: true
+          in: path
+          name: FileName
+          description: Name of the attachment
+          example: xero-dev.png
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success - return response of type Attachments array of Attachment 
+          x-isAttachment: true
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Attachments'
+              example: '{
+                    "Id": "c728a4a4-179e-4bbd-a2d5-63e7f9ceba92",
+                    "Status": "OK",
+                    "ProviderName": "Xero API Partner",
+                    "DateTimeUTC": "/Date(1602099934723)/",
+                    "Attachments": [
+                        {
+                            "AttachmentID": "e58bd37b-e47f-451a-a42c-f946ef229c3e",
+                            "FileName": "xero-dev.png",
+                            "Url": "https://api.xero.com/api.xro/2.0/PurchaseOrders/93369c9b-c481-4e21-aaab-bb19e9a26efe/Attachments/2D.png",
+                            "MimeType": "image/png",
+                            "ContentLength": 82529
+                        }
+                    ]
+                }'
+        '400':
+          $ref: '#/components/responses/400Error'
+      requestBody:
+        required: true
+        description: Byte array of file in body of request
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: byte
   /Quotes:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -11431,7 +11431,7 @@ paths:
         - OAuth2: [accounting.attachments.read]
       tags:
         - Accounting
-      operationId: getPurchaseOrdersAttachments
+      operationId: getPurchaseOrderAttachments
       summary: Allows you to retrieve attachments for purchase orders
       parameters:
         - required: true


### PR DESCRIPTION
Added is-money vendor extension to all field that is related to monetary calculation so the SDKs which support Decimal type can be used. 

NumberofHours and NumberofUnit could be integers but I have made them decimal just to be safe.

I will be reaching out to NZ payroll team next week to confirm the exact type number used in the system. 