### PR TITLE
Revert json examples

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,31 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from expected behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Browser Name and version:
+* Operating System and version (desktop or mobile):
+* Link to your project:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Release Notes
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## Screenshots (if appropriate):
+
+## Types of Changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

--- a/README.md
+++ b/README.md
@@ -58,3 +58,10 @@ This software is published under the [MIT License](http://en.wikipedia.org/wiki/
 	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 	FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 	OTHER DEALINGS IN THE SOFTWARE.
+
+
+https://github.com/XeroAPI/Xero-OpenAPI/blob/b69c3d350b915786a8de96c5838a7bb8b9a4f99b/accounting-yaml/Xero_accounting_2.0.0_swagger.yaml
+
+
+better:
+https://github.com/XeroAPI/Xero-OpenAPI/commit/9ac8b996c156145c7b4ebc78a5735771759191a6

--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ https://github.com/XeroAPI/Xero-OpenAPI/blob/b69c3d350b915786a8de96c5838a7bb8b9a
 
 better:
 https://github.com/XeroAPI/Xero-OpenAPI/commit/9ac8b996c156145c7b4ebc78a5735771759191a6
+
+x-ruby-param ? should I change that example: to `x-node-param:` ?

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -5498,7 +5498,7 @@ paths:
         - Accounting
       operationId: createCreditNoteAllocation
       x-hasAccountingValidationError: true
-      x-node-requestBody: '{ allocations: [{ amount: 1.0, date: "2019-03-05", invoice: { invoiceID: "c45720a1-ade3-4a38-a064-d15489be6841", lineItems:[], type: Invoice.TypeEnum.ACCPAY, contact: {}}}]}'
+      x-node-requestBody: '{ allocations: [{ amount: 1.0, date: "2019-03-05", invoice: { invoiceID: "c45720a1-ade3-4a38-a064-d15489be6841", lineItems: [], type: Invoice.TypeEnum.ACCPAY, contact: {} }}]}'
       x-ruby-requestBody: 'allocations = { allocations: [{ amount: 1.0, date: "2019-03-05", invoice: { invoice_id: "c45720a1-ade3-4a38-a064-d15489be6841", line_items: [], type: XeroRuby::Accounting::Invoice::ACCPAY, contact: {} }}]}'
       summary: Allows you to create Allocation on CreditNote
       parameters:

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -19090,7 +19090,7 @@ components:
           schema:
             $ref: '#/components/schemas/HistoryRecords'
           example: '{  
-                      "HistoryRecords":[  
+                      "HistoryRecords": [  
                         {  
                           "Details": "Hello World"
                         }

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -74,6 +74,7 @@ paths:
       operationId: createAccount
       x-hasAccountingValidationError: true
       x-ruby-requestBody: 'account = { code: "123456", name: "Foobar", type: XeroRuby::Accounting::AccountType::EXPENSE, description: "Hello World" }'
+      x-node-requestBody: '{ code: "123456", name: "Foobar", type: AccountType.EXPENSE, description: "Hello World" }'
       summary: Allows you to create a new chart of accounts
       x-php:
           - '$account = new XeroAPI\XeroPHP\Models\Accounting\Account;'
@@ -144,7 +145,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Account'
-            example: '{ code: "123456", name: "Foobar", type: AccountType.EXPENSE, description: "Hello World" }'
+            example: '{
+                        "Code":"123456",
+                        "Name":"Foobar",
+                        "Type":"EXPENSE",
+                        "Description":"Hello World"
+                      }'
   '/Accounts/{AccountID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -202,6 +208,8 @@ paths:
         - Accounting
       operationId: updateAccount
       x-hasAccountingValidationError: true
+      x-ruby-requestBody: '{ accounts: [{ code: "123456", name: "BarFoo", account_id: "00000000-0000-0000-000-000000000000", type: XeroRuby::Accounting::Account::EXPENSE, description: "GoodBye World", tax_type: XeroRuby::Accounting::TaxType::NONE }]}'
+      x-node-requestBody: '{ accounts: [{ code: "123456", name: "BarFoo", accountID: "00000000-0000-0000-000-000000000000", type: AccountType.EXPENSE, description: "GoodBye World", taxType: TaxType.INPUT }]}'
       summary: Allows you to update a chart of accounts
       parameters:
         - required: true
@@ -274,7 +282,24 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Accounts'
-            example: '{ accounts: [{ code: "123456", name: "BarFoo", accountID: "00000000-0000-0000-000-000000000000", type: AccountType.EXPENSE, description: "GoodBye World", taxType: TaxType.INPUT }]}'
+            example: '{  
+                        "Accounts":[  
+                          {  
+                              "Code":"123456",
+                              "Name":"BarFoo",
+                              "AccountID":"99ce6032-0678-4aa0-8148-240c75fee33a",
+                              "Type":"EXPENSE",
+                              "Description":"GoodBye World",
+                              "TaxType":"INPUT",
+                              "EnablePaymentsToAccount":false,
+                              "ShowInExpenseClaims":false,
+                              "Class":"EXPENSE",
+                              "ReportingCode":"EXP",
+                              "ReportingCodeName":"Expense",
+                              "UpdatedDateUTC":"2019-02-21T16:29:47.96-08:00"
+                          }
+                        ]
+                      }'
     delete:
       security:
         - OAuth2: [accounting.settings]
@@ -740,71 +765,71 @@ paths:
               schema:
                 $ref: '#/components/schemas/BatchPayments'
               example: '{
-                        "Id": "424745ed-6356-46ad-87d4-3585f9062fb4",
-                        "Status": "OK",
-                        "ProviderName": "Xero API Partner",
-                        "DateTimeUTC": "\/Date(1550865988111)\/",
-                        "BatchPayments": [
-                          {
-                            "Account": {
-                              "AccountID": "5ec2f302-cd60-4f8b-a915-9229dd45e6fa"
-                            },
-                            "Reference": "Foobar123",
-                            "BatchPaymentID": "d318c343-208e-49fe-b04a-45642349bcf1",
-                            "DateString": "2019-02-22T00:00:00",
-                            "Date": "\/Date(1550793600000+0000)\/",
-                            "Payments": [
-                              {
-                                "Invoice": {
-                                  "InvoiceID": "3323652c-155e-433b-8a73-4dde7cfbf410",
-                                  "Payments": [],
-                                  "CreditNotes": [],
-                                  "Prepayments": [],
-                                  "Overpayments": [],
-                                  "HasErrors": false,
-                                  "IsDiscounted": false,
-                                  "LineItems": []
-                                },
-                                "PaymentID": "c05098fa-ae3c-4f00-80ec-0a9df07dedff",
-                                "Amount": 1.00
+                          "Id": "424745ed-6356-46ad-87d4-3585f9062fb4",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "\/Date(1550865988111)\/",
+                          "BatchPayments": [
+                            {
+                              "Account": {
+                                "AccountID": "5ec2f302-cd60-4f8b-a915-9229dd45e6fa"
                               },
-                              {
-                                "Invoice": {
-                                  "InvoiceID": "e4abafb4-1f5b-4d9f-80b3-9a7b815bc302",
-                                  "Payments": [],
-                                  "CreditNotes": [],
-                                  "Prepayments": [],
-                                  "Overpayments": [],
-                                  "HasErrors": false,
-                                  "IsDiscounted": false,
-                                  "LineItems": []
+                              "Reference": "Foobar123",
+                              "BatchPaymentID": "d318c343-208e-49fe-b04a-45642349bcf1",
+                              "DateString": "2019-02-22T00:00:00",
+                              "Date": "\/Date(1550793600000+0000)\/",
+                              "Payments": [
+                                {
+                                  "Invoice": {
+                                    "InvoiceID": "3323652c-155e-433b-8a73-4dde7cfbf410",
+                                    "Payments": [],
+                                    "CreditNotes": [],
+                                    "Prepayments": [],
+                                    "Overpayments": [],
+                                    "HasErrors": false,
+                                    "IsDiscounted": false,
+                                    "LineItems": []
+                                  },
+                                  "PaymentID": "c05098fa-ae3c-4f00-80ec-0a9df07dedff",
+                                  "Amount": 1.00
                                 },
-                                "PaymentID": "96409489-2f7d-4804-9a6d-6b939b0e038a",
-                                "Amount": 1.00
-                              },
-                              {
-                                "Invoice": {
-                                  "InvoiceID": "e6039672-b161-40cd-b07b-a0178e7186ad",
-                                  "Payments": [],
-                                  "CreditNotes": [],
-                                  "Prepayments": [],
-                                  "Overpayments": [],
-                                  "HasErrors": false,
-                                  "IsDiscounted": false,
-                                  "LineItems": []
+                                {
+                                  "Invoice": {
+                                    "InvoiceID": "e4abafb4-1f5b-4d9f-80b3-9a7b815bc302",
+                                    "Payments": [],
+                                    "CreditNotes": [],
+                                    "Prepayments": [],
+                                    "Overpayments": [],
+                                    "HasErrors": false,
+                                    "IsDiscounted": false,
+                                    "LineItems": []
+                                  },
+                                  "PaymentID": "96409489-2f7d-4804-9a6d-6b939b0e038a",
+                                  "Amount": 1.00
                                 },
-                                "PaymentID": "d2796067-bf71-4f06-b386-81f1454fa866",
-                                "Amount": 1.00
-                              }
-                            ],
-                            "Type": "RECBATCH",
-                            "Status": "AUTHORISED",
-                            "TotalAmount": 3.00,
-                            "UpdatedDateUTC": "\/Date(1550865987783+0000)\/",
-                            "IsReconciled": false
-                          }
-                        ]
-                      }'
+                                {
+                                  "Invoice": {
+                                    "InvoiceID": "e6039672-b161-40cd-b07b-a0178e7186ad",
+                                    "Payments": [],
+                                    "CreditNotes": [],
+                                    "Prepayments": [],
+                                    "Overpayments": [],
+                                    "HasErrors": false,
+                                    "IsDiscounted": false,
+                                    "LineItems": []
+                                  },
+                                  "PaymentID": "d2796067-bf71-4f06-b386-81f1454fa866",
+                                  "Amount": 1.00
+                                }
+                              ],
+                              "Type": "RECBATCH",
+                              "Status": "AUTHORISED",
+                              "TotalAmount": 3.00,
+                              "UpdatedDateUTC": "\/Date(1550865987783+0000)\/",
+                              "IsReconciled": false
+                            }
+                          ]
+                        }'
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -815,26 +840,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/BatchPayments'
               example: '{
-                          batchPayments: [
+                          "BatchPayments": [
                             {
-                            account: {
-                              accountID: "00000000-0000-0000-000-000000000000"
-                            },
-                            reference: "ref",
-                            date: "2018-08-01",
-                            payments: [
-                              { 
-                                account: { code: "001" },
-                                date: "2019-12-31",
-                                amount: 500,
-                                invoice: {
-                                  invoiceID: "00000000-0000-0000-000-000000000000",
-                                  lineItems: [],
-                                  contact: {},
-                                  type: Invoice.TypeEnum.ACCPAY
+                              "Account": {
+                                "AccountID": "00000000-0000-0000-000-000000000000"
+                              },
+                              "Reference": "ref",
+                              "Date": "2018-08-01",
+                              "Payments": [
+                                {
+                                  "Account": {
+                                    "Code": "001"
+                                  },
+                                  "Date": "2019-12-31",
+                                  "Amount": 500,
+                                  "Invoice": {
+                                    "InvoiceID": "00000000-0000-0000-000-000000000000",
+                                    "LineItems": [],
+                                    "Contact": {},
+                                    "Type": "ACCPAY"
+                                  }
                                 }
-                                }
-                            ]
+                              ]
                             }
                           ]
                         }'
@@ -866,20 +893,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/HistoryRecords'
               example: '{
-                        "Id": "c58e2f9c-baad-42a4-8bb7-f32b6f88fa04",
-                        "Status": "OK",
-                        "ProviderName": "Xero API Partner",
-                        "DateTimeUTC": "\/Date(1550898452503)\/",
-                        "HistoryRecords": [
-                          {
-                            "Changes": "Approved",
-                            "DateUTCString": "2017-11-28T18:29:52",
-                            "DateUTC": "\/Date(1511893792813+0000)\/",
-                            "User": "Sidney Maestre",
-                            "Details": ""
-                          }
-                        ]
-                      }'
+                          "Id": "c58e2f9c-baad-42a4-8bb7-f32b6f88fa04",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "\/Date(1550898452503)\/",
+                          "HistoryRecords": [
+                            {
+                              "Changes": "Approved",
+                              "DateUTCString": "2017-11-28T18:29:52",
+                              "DateUTC": "\/Date(1511893792813+0000)\/",
+                              "User": "Buzz Lightyear",
+                              "Details": ""
+                            }
+                          ]
+                        }'
     put:
       security:
         - OAuth2: [accounting.transactions]
@@ -905,19 +932,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/HistoryRecords'
               example: '{
-                      "Id": "d7525479-3392-44c0-bb37-ff4a0b5df5bd",
-                      "Status": "OK",
-                      "ProviderName": "Xero API Partner",
-                      "DateTimeUTC": "\/Date(1550899400362)\/",
-                      "HistoryRecords": [
-                        {
-                          "DateUTCString": "2019-02-23T05:23:20",
-                          "DateUTC": "\/Date(1550899400362)\/",
-                          "Details": "Hello World",
-                          "ValidationErrors": []
-                        }
-                      ]
-                    }'
+                          "Id": "d7525479-3392-44c0-bb37-ff4a0b5df5bd",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "\/Date(1550899400362)\/",
+                          "HistoryRecords": [
+                            {
+                              "DateUTCString": "2019-02-23T05:23:20",
+                              "DateUTC": "\/Date(1550899400362)\/",
+                              "Details": "Hello World",
+                              "ValidationErrors": []
+                            }
+                          ]
+                        }'
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -961,146 +988,116 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BankTransactions'
-              example: '{  
-                         "Id":"18e7e80c-5dca-4a57-974e-8b572cc5efe8",
-                         "Status":"OK",
-                         "ProviderName":"Xero API Partner",
-                         "DateTimeUTC":"\/Date(1551212901659)\/",
-                         "BankTransactions":[  
-                            {  
-                               "BankTransactionID":"db54aab0-ad40-4ced-bcff-0940ba20db2c",
-                               "BankAccount":{  
-                                  "AccountID":"6f7594f2-f059-4d56-9e67-47ac9733bfe9",
-                                  "Code":"088",
-                                  "Name":"Business Wells Fargo"
-                               },
-                               "BatchPayment": {
-                                  "Account": {
-                                    "AccountID": "6f7594f2-f059-4d56-9e67-47ac9733bfe9"
-                                  },
-                                  "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
-                                  "Date": "\/Date(1476316800000+0000)\/",
-                                  "Type": "RECBATCH",
-                                  "Status": "AUTHORISED",
-                                  "TotalAmount": "12.00",
-                                  "UpdatedDateUTC": "\/Date(1476392487037+0000)\/",
-                                  "IsReconciled": "false"
+              example: '{
+                          "Id": "18e7e80c-5dca-4a57-974e-8b572cc5efe8",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "/Date(1551212901659)/",
+                          "BankTransactions": [
+                            {
+                              "BankTransactionID": "db54aab0-ad40-4ced-bcff-0940ba20db2c",
+                              "BankAccount": {
+                                "AccountID": "6f7594f2-f059-4d56-9e67-47ac9733bfe9",
+                                "Code": "088",
+                                "Name": "Business Wells Fargo"
+                              },
+                              "BatchPayment": {
+                                "Account": {
+                                  "AccountID": "6f7594f2-f059-4d56-9e67-47ac9733bfe9"
                                 },
-                               "Type":"RECEIVE",
-                               "IsReconciled":false,
-                               "PrepaymentID":"cb62750f-b49c-464b-a45b-e2e2c514c8a9",
-                               "HasAttachments":true,
-                               "Contact":{  
-                                  "ContactID":"9c2c64de-12c9-4167-b503-e2c0e1aa1f49",
-                                  "Name":"sam",
-                                  "Addresses":[  
-
-                                  ],
-                                  "Phones":[  
-
-                                  ],
-                                  "ContactGroups":[  
-
-                                  ],
-                                  "ContactPersons":[  
-
-                                  ],
-                                  "HasValidationErrors":false
-                               },
-                               "DateString":"2016-10-13T00:00:00",
-                               "Date":"\/Date(1476316800000+0000)\/",
-                               "Status":"AUTHORISED",
-                               "LineAmountTypes":"Exclusive",
-                               "LineItems":[  
-
-                               ],
-                               "SubTotal":10.00,
-                               "TotalTax":0.00,
-                               "Total":10.00,
-                               "UpdatedDateUTC":"\/Date(1476389616437+0000)\/",
-                               "CurrencyCode":"USD"
+                                "BatchPaymentID": "b54aa50c-794c-461b-89d1-846e1b84d9c0",
+                                "Date": "/Date(1476316800000+0000)/",
+                                "Type": "RECBATCH",
+                                "Status": "AUTHORISED",
+                                "TotalAmount": "12.00",
+                                "UpdatedDateUTC": "/Date(1476392487037+0000)/",
+                                "IsReconciled": "false"
+                              },
+                              "Type": "RECEIVE",
+                              "IsReconciled": false,
+                              "PrepaymentID": "cb62750f-b49c-464b-a45b-e2e2c514c8a9",
+                              "HasAttachments": true,
+                              "Contact": {
+                                "ContactID": "9c2c64de-12c9-4167-b503-e2c0e1aa1f49",
+                                "Name": "sam",
+                                "Addresses": [],
+                                "Phones": [],
+                                "ContactGroups": [],
+                                "ContactPersons": [],
+                                "HasValidationErrors": false
+                              },
+                              "DateString": "2016-10-13T00:00:00",
+                              "Date": "/Date(1476316800000+0000)/",
+                              "Status": "AUTHORISED",
+                              "LineAmountTypes": "Exclusive",
+                              "LineItems": [],
+                              "SubTotal": 10,
+                              "TotalTax": 0,
+                              "Total": 10,
+                              "UpdatedDateUTC": "/Date(1476389616437+0000)/",
+                              "CurrencyCode": "USD"
                             },
-                            {  
-                               "BankTransactionID":"29a69c45-64ca-4805-a1cc-34990de837b3",
-                               "BankAccount":{  
-                                  "AccountID":"6f7594f2-f059-4d56-9e67-47ac9733bfe9",
-                                  "Code":"088",
-                                  "Name":"Business Wells Fargo"
-                               },
-                               "Type":"SPEND-OVERPAYMENT",
-                               "IsReconciled":false,
-                               "OverpaymentID":"7d457db3-3b0a-47e9-8b79-81252a7bcdcb",
-                               "HasAttachments":false,
-                               "Contact":{  
-                                  "ContactID":"9c2c64de-12c9-4167-b503-e2c0e1aa1f49",
-                                  "Name":"sam",
-                                  "Addresses":[  
-
-                                  ],
-                                  "Phones":[  
-
-                                  ],
-                                  "ContactGroups":[  
-
-                                  ],
-                                  "ContactPersons":[  
-
-                                  ],
-                                  "HasValidationErrors":false
-                               },
-                               "DateString":"2016-10-13T00:00:00",
-                               "Date":"\/Date(1476316800000+0000)\/",
-                               "Status":"AUTHORISED",
-                               "LineAmountTypes":"NoTax",
-                               "LineItems":[  
-
-                               ],
-                               "SubTotal":9.00,
-                               "TotalTax":0.00,
-                               "Total":9.00,
-                               "UpdatedDateUTC":"\/Date(1476389930500+0000)\/",
-                               "CurrencyCode":"USD"
+                            {
+                              "BankTransactionID": "29a69c45-64ca-4805-a1cc-34990de837b3",
+                              "BankAccount": {
+                                "AccountID": "6f7594f2-f059-4d56-9e67-47ac9733bfe9",
+                                "Code": "088",
+                                "Name": "Business Wells Fargo"
+                              },
+                              "Type": "SPEND-OVERPAYMENT",
+                              "IsReconciled": false,
+                              "OverpaymentID": "7d457db3-3b0a-47e9-8b79-81252a7bcdcb",
+                              "HasAttachments": false,
+                              "Contact": {
+                                "ContactID": "9c2c64de-12c9-4167-b503-e2c0e1aa1f49",
+                                "Name": "sam",
+                                "Addresses": [],
+                                "Phones": [],
+                                "ContactGroups": [],
+                                "ContactPersons": [],
+                                "HasValidationErrors": false
+                              },
+                              "DateString": "2016-10-13T00:00:00",
+                              "Date": "/Date(1476316800000+0000)/",
+                              "Status": "AUTHORISED",
+                              "LineAmountTypes": "NoTax",
+                              "LineItems": [],
+                              "SubTotal": 9,
+                              "TotalTax": 0,
+                              "Total": 9,
+                              "UpdatedDateUTC": "/Date(1476389930500+0000)/",
+                              "CurrencyCode": "USD"
                             },
-                            {  
-                               "BankTransactionID":"0b89bf5c-d40b-4514-96be-36a739fb0188",
-                               "BankAccount":{  
-                                  "AccountID":"6f7594f2-f059-4d56-9e67-47ac9733bfe9",
-                                  "Code":"088",
-                                  "Name":"Business Wells Fargo"
-                               },
-                               "Type":"SPEND-OVERPAYMENT",
-                               "IsReconciled":false,
-                               "OverpaymentID":"bf9b5f33-c0d6-4182-84a2-40848023e5a1",
-                               "HasAttachments":false,
-                               "Contact":{  
-                                  "ContactID":"9c2c64de-12c9-4167-b503-e2c0e1aa1f49",
-                                  "Name":"sam",
-                                  "Addresses":[  
-
-                                  ],
-                                  "Phones":[  
-
-                                  ],
-                                  "ContactGroups":[  
-
-                                  ],
-                                  "ContactPersons":[  
-
-                                  ],
-                                  "HasValidationErrors":false
-                               },
-                               "DateString":"2016-10-13T00:00:00",
-                               "Date":"\/Date(1476316800000+0000)\/",
-                               "Status":"AUTHORISED",
-                               "LineAmountTypes":"NoTax",
-                               "LineItems":[  
-
-                               ],
-                               "SubTotal":8.00,
-                               "TotalTax":0.00,
-                               "Total":8.00,
-                               "UpdatedDateUTC":"\/Date(1476392487037+0000)\/",
-                               "CurrencyCode":"USD"
+                            {
+                              "BankTransactionID": "0b89bf5c-d40b-4514-96be-36a739fb0188",
+                              "BankAccount": {
+                                "AccountID": "6f7594f2-f059-4d56-9e67-47ac9733bfe9",
+                                "Code": "088",
+                                "Name": "Business Wells Fargo"
+                              },
+                              "Type": "SPEND-OVERPAYMENT",
+                              "IsReconciled": false,
+                              "OverpaymentID": "bf9b5f33-c0d6-4182-84a2-40848023e5a1",
+                              "HasAttachments": false,
+                              "Contact": {
+                                "ContactID": "9c2c64de-12c9-4167-b503-e2c0e1aa1f49",
+                                "Name": "sam",
+                                "Addresses": [],
+                                "Phones": [],
+                                "ContactGroups": [],
+                                "ContactPersons": [],
+                                "HasValidationErrors": false
+                              },
+                              "DateString": "2016-10-13T00:00:00",
+                              "Date": "/Date(1476316800000+0000)/",
+                              "Status": "AUTHORISED",
+                              "LineAmountTypes": "NoTax",
+                              "LineItems": [],
+                              "SubTotal": 8,
+                              "TotalTax": 0,
+                              "Total": 8,
+                              "UpdatedDateUTC": "/Date(1476392487037+0000)/",
+                              "CurrencyCode": "USD"
                             }
                           ]
                         }'
@@ -1111,6 +1108,7 @@ paths:
         - Accounting
       operationId: createBankTransactions
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ bankTransactions: [{ type: BankTransaction.TypeEnum.SPEND, contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "000" } ], bankAccount: { code: "000" }}]}'
       x-ruby-requestBody: 'bank_transactions = { bank_transactions: [{ type: XeroRuby::Accounting::BankTransaction::SPEND, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unit_amount: 20.0, account_code: "000" } ], bank_account: { code: "000" }}]}'
       summary: Allows you to create one or more spend or receive money transaction
       parameters:
@@ -1376,7 +1374,27 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/BankTransactions'
-            example: '{ bankTransactions: [{ type: BankTransaction.TypeEnum.SPEND, contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "000" } ], bankAccount: { code: "000" }}]}'
+            example: '{
+                        "BankTransactions": [
+                          {
+                            "Type": "SPEND",
+                            "Contact": {
+                              "ContactID": "00000000-0000-0000-000-000000000000"
+                            },
+                            "Lineitems": [
+                              {
+                                "Description": "Foobar",
+                                "Quantity": 1,
+                                "UnitAmount": 20,
+                                "AccountCode": "400"
+                              }
+                            ],
+                            "BankAccount": {
+                              "Code": "088"
+                            }
+                          }
+                        ]
+                      }'
   '/BankTransactions/{BankTransactionID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -1530,6 +1548,7 @@ paths:
         - Accounting
       operationId: updateBankTransaction
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ bankTransactions: [{ type: BankTransaction.TypeEnum.SPEND, date: "2019-02-25", reference: "You just updated", status: BankTransaction.StatusEnum.AUTHORISED, bankTransactionID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, bankAccount: { accountID: "00000000-0000-0000-000-000000000000" }}]}'
       x-ruby-requestBody: '{ bank_transactions: [{ type: XeroRuby::Accounting::BankTransaction::SPEND, date: "2019-02-25", reference: "You just updated", status: XeroRuby::Accounting::BankTransaction::AUTHORISED, bank_transaction_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, bank_account: { account_id: "00000000-0000-0000-000-000000000000" }}]}'
       summary: Allows you to update a single spend or receive money transaction
       parameters:
@@ -1661,7 +1680,88 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/BankTransactions'
-            example: '{ bankTransactions: [{ type: BankTransaction.TypeEnum.SPEND, date: "2019-02-25", reference: "You just updated", status: BankTransaction.StatusEnum.AUTHORISED, bankTransactionID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, bankAccount: { accountID: "00000000-0000-0000-000-000000000000" }}]}'
+            example: '{
+                        "BankTransactions": [
+                          {
+                            "Type": "SPEND",
+                            "Contact": {
+                              "ContactID": "00000000-0000-0000-000-000000000000",
+                              "ContactStatus": "ACTIVE",
+                              "Name": "Buzz Lightyear",
+                              "FirstName": "Buzz",
+                              "LastName": "Lightyear",
+                              "EmailAddress": "buzz.Lightyear@email.com",
+                              "ContactPersons": [],
+                              "BankAccountDetails": "",
+                              "Addresses": [
+                                {
+                                  "AddressType": "STREET",
+                                  "City": "",
+                                  "Region": "",
+                                  "PostalCode": "",
+                                  "Country": ""
+                                },
+                                {
+                                  "AddressType": "POBOX",
+                                  "AddressLine1": "",
+                                  "AddressLine2": "",
+                                  "AddressLine3": "",
+                                  "AddressLine4": "",
+                                  "City": "Palo Alto",
+                                  "Region": "CA",
+                                  "PostalCode": "94020",
+                                  "Country": "United States"
+                                }
+                              ],
+                              "Phones": [
+                                {
+                                  "PhoneType": "DEFAULT",
+                                  "PhoneNumber": "847-1294",
+                                  "PhoneAreaCode": "(626)",
+                                  "PhoneCountryCode": ""
+                                },
+                                {
+                                  "PhoneType": "DDI",
+                                  "PhoneNumber": "",
+                                  "PhoneAreaCode": "",
+                                  "PhoneCountryCode": ""
+                                },
+                                {
+                                  "PhoneType": "FAX",
+                                  "PhoneNumber": "",
+                                  "PhoneAreaCode": "",
+                                  "PhoneCountryCode": ""
+                                },
+                                {
+                                  "PhoneType": "MOBILE",
+                                  "PhoneNumber": "",
+                                  "PhoneAreaCode": "",
+                                  "PhoneCountryCode": ""
+                                }
+                              ],
+                              "UpdatedDateUTC": "2017-08-21T13:49:04.227-07:00",
+                              "ContactGroups": []
+                            },
+                            "Lineitems": [],
+                            "BankAccount": {
+                              "Code": "088",
+                              "Name": "Business Wells Fargo",
+                              "AccountID": "00000000-0000-0000-000-000000000000"
+                            },
+                            "IsReconciled": false,
+                            "Date": "2019-02-25",
+                            "Reference": "You just updated",
+                            "CurrencyCode": "USD",
+                            "CurrencyRate": 1,
+                            "Status": "AUTHORISED",
+                            "LineAmountTypes": "Inclusive",
+                            "TotalTax": 1.74,
+                            "BankTransactionID": "00000000-0000-0000-000-000000000000",
+                            "UpdatedDateUTC": "2019-02-26T12:39:27.813-08:00"
+                          }
+                        ]
+                      }'
+
   '/BankTransactions/{BankTransactionID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -1829,20 +1929,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/Attachments'
               example: '{
-                            "Id": "572ad2fe-8c23-45aa-82f9-864485327685",
-                            "Status": "OK",
-                            "ProviderName": "Xero API Partner",
-                            "DateTimeUTC": "\/Date(1551286166630)\/",
-                            "Attachments": [
-                              {
-                                "AttachmentID": "4508a692-e52c-4ad8-a138-2f13e22bf57b",
-                                "FileName": "sample5.jpg",
-                                "Url": "https://api.xero.com/api.xro/2.0/BankTransactions/db54aab0-ad40-4ced-bcff-0940ba20db2c/Attachments/sample5.jpg",
-                                "MimeType": "image/jpg",
-                                "ContentLength": 2878711
-                              }
-                            ]
-                          }'
+                          "Id": "572ad2fe-8c23-45aa-82f9-864485327685",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "\/Date(1551286166630)\/",
+                          "Attachments": [
+                            {
+                              "AttachmentID": "4508a692-e52c-4ad8-a138-2f13e22bf57b",
+                              "FileName": "sample5.jpg",
+                              "Url": "https://api.xero.com/api.xro/2.0/BankTransactions/db54aab0-ad40-4ced-bcff-0940ba20db2c/Attachments/sample5.jpg",
+                              "MimeType": "image/jpg",
+                              "ContentLength": 2878711
+                            }
+                          ]
+                        }'
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -1886,20 +1986,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/Attachments'
               example: '{
-                            "Id": "572ad2fe-8c23-45aa-82f9-864485327685",
-                            "Status": "OK",
-                            "ProviderName": "Xero API Partner",
-                            "DateTimeUTC": "\/Date(1551286166630)\/",
-                            "Attachments": [
-                              {
-                                "AttachmentID": "4508a692-e52c-4ad8-a138-2f13e22bf57b",
-                                "FileName": "sample5.jpg",
-                                "Url": "https://api.xero.com/api.xro/2.0/BankTransactions/db54aab0-ad40-4ced-bcff-0940ba20db2c/Attachments/sample5.jpg",
-                                "MimeType": "image/jpg",
-                                "ContentLength": 2878711
-                              }
-                            ]
-                          }'
+                          "Id": "572ad2fe-8c23-45aa-82f9-864485327685",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "\/Date(1551286166630)\/",
+                          "Attachments": [
+                            {
+                              "AttachmentID": "4508a692-e52c-4ad8-a138-2f13e22bf57b",
+                              "FileName": "sample5.jpg",
+                              "Url": "https://api.xero.com/api.xro/2.0/BankTransactions/db54aab0-ad40-4ced-bcff-0940ba20db2c/Attachments/sample5.jpg",
+                              "MimeType": "image/jpg",
+                              "ContentLength": 2878711
+                            }
+                          ]
+                        }'
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -2043,6 +2143,7 @@ paths:
         - Accounting
       operationId: createBankTransfer
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ bankTransfers: [{ fromBankAccount: { code: "000", accountID: "00000000-0000-0000-000-000000000000" }, toBankAccount: { code: "001", accountID: "00000000-0000-0000-000-000000000000" }, amount: "50.00" }]}'
       x-ruby-requestBody: 'bank_transfers = { bank_transfers: [{ from_bank_account: { code: "000", account_id: "00000000-0000-0000-000-000000000000" }, to_bank_account: { code: "001", account_id: "00000000-0000-0000-000-000000000000" }, amount: "50.00" }]}'
       summary: Allows you to create a bank transfers
       responses:
@@ -2089,7 +2190,49 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/BankTransfers'
-            example: '{ bankTransfers: [{ fromBankAccount: { code: "000", accountID: "00000000-0000-0000-000-000000000000" }, toBankAccount: { code: "001", accountID: "00000000-0000-0000-000-000000000000" }, amount: "50.00" }]}'
+            example: '{
+                        "BankTransfers": [
+                          {
+                            "FromBankAccount": {
+                              "Code": "090",
+                              "Name": "My Savings",
+                              "AccountID": "00000000-0000-0000-000-000000000000",
+                              "Type": "BANK",
+                              "BankAccountNumber": "123455",
+                              "Status": "ACTIVE",
+                              "BankAccountType": "BANK",
+                              "CurrencyCode": "USD",
+                              "TaxType": "NONE",
+                              "EnablePaymentsToAccount": false,
+                              "ShowInExpenseClaims": false,
+                              "Class": "ASSET",
+                              "ReportingCode": "ASS",
+                              "ReportingCodeName": "Assets",
+                              "HasAttachments": false,
+                              "UpdatedDateUTC": "2016-10-17T13:45:33.993-07:00"
+                            },
+                            "ToBankAccount": {
+                              "Code": "088",
+                              "Name": "Business Wells Fargo",
+                              "AccountID": "00000000-0000-0000-000-000000000000",
+                              "Type": "BANK",
+                              "BankAccountNumber": "123455",
+                              "Status": "ACTIVE",
+                              "BankAccountType": "BANK",
+                              "CurrencyCode": "USD",
+                              "TaxType": "NONE",
+                              "EnablePaymentsToAccount": false,
+                              "ShowInExpenseClaims": false,
+                              "Class": "ASSET",
+                              "ReportingCode": "ASS",
+                              "ReportingCodeName": "Assets",
+                              "HasAttachments": false,
+                              "UpdatedDateUTC": "2016-06-03T08:31:14.517-07:00"
+                            },
+                            "Amount": "50.00"
+                          }
+                        ]
+                      }'
   '/BankTransfers/{BankTransferID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -2551,7 +2694,7 @@ paths:
                           "PaymentServices": [
                             {
                               "PaymentServiceID": "8cc53aa4-ae01-45b9-b06c-69c42eeae61f",
-                              "PaymentServiceName": "Sidney Maestre",
+                              "PaymentServiceName": "Buzz Lightyear",
                               "PaymentServiceType": "PayPal"
                             },
                             {
@@ -2570,7 +2713,8 @@ paths:
         - Accounting
       operationId: createBrandingThemePaymentServices
       x-hasAccountingValidationError: true
-      x-ruby-requestBody: 'payment_service = { payment_service_id: "dede7858-14e3-4a46-bf95-4d4cc491e645", payment_service_name: "ACME Payments", payment_service_url: "https://www.payupnow.com/", pay_now_text: "Pay Now" }'
+      x-node-requestBody: '{ paymentServiceID: "00000000-0000-0000-0000-000000000000", paymentServiceName: "ACME Payments", paymentServiceUrl: "https://www.payupnow.com/", payNowText: "Pay Now" }'
+      x-ruby-requestBody: 'payment_service = { payment_service_id: "00000000-0000-0000-0000-000000000000", payment_service_name: "ACME Payments", payment_service_url: "https://www.payupnow.com/", pay_now_text: "Pay Now" }'
       summary: Allow for the creation of new custom payment service for specified Branding Theme
       parameters:
         - required: true
@@ -2595,7 +2739,7 @@ paths:
                          "DateTimeUTC":"\/Date(1551139338915)\/",
                          "PaymentServices":[  
                             {  
-                               "PaymentServiceID":"dede7858-14e3-4a46-bf95-4d4cc491e645",
+                               "PaymentServiceID":"00000000-0000-0000-0000-000000000000",
                                "PaymentServiceName":"ACME Payments",
                                "PaymentServiceUrl":"https://www.payupnow.com/",
                                "PaymentServiceType":"Custom",
@@ -2612,7 +2756,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PaymentService'
-            example: '{  paymentServiceID: "dede7858-14e3-4a46-bf95-4d4cc491e645", paymentServiceName: "ACME Payments", paymentServiceUrl: "https://www.payupnow.com/", payNowText: "Pay Now" }'
+            example: '{  
+                         "PaymentServiceID":"00000000-0000-0000-0000-000000000000",
+                         "PaymentServiceName":"ACME Payments",
+                         "PaymentServiceUrl":"https://www.payupnow.com/",
+                         "PayNowText":"Pay Now"
+                      }'
   /Contacts:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -2817,6 +2966,7 @@ paths:
         - Accounting
       operationId: createContacts
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ contacts: [{ name: "Bruce Banner", emailAddress: "hulk@avengers.com", phones: [{ phoneType: Phone.PhoneTypeEnum.MOBILE, phoneNumber: "555-1212", phoneAreaCode: "415" }], paymentTerms: { bills: { day: 15, type: PaymentTermType.OFCURRENTMONTH }, sales: { day: 10, type: PaymentTermType.DAYSAFTERBILLMONTH }}}]}'
       x-ruby-requestBody: 'contacts = { contacts: [{ name: "Bruce Banner", email_address: "hulk@avengers.com", phones: [{ phone_type: XeroRuby::Accounting::Phone::MOBILE, phone_number: "555-1212", phone_area_code: "415" }], payment_terms: { bills: { day: 15, type: XeroRuby::Accounting::PaymentTermType::OFCURRENTMONTH }, sales: { day: 10, type: XeroRuby::Accounting::PaymentTermType::DAYSAFTERBILLMONTH }}}]}'
       summary: 'Allows you to create a multiple contacts (bulk) in a Xero organisation'
       parameters:
@@ -2917,8 +3067,8 @@ paths:
                             {
                               "ContactID": "00000000-0000-0000-0000-000000000000",
                               "AccountNumber": "12345-ABCD",
-                              "Name": "Sidney Maestre",
-                              "EmailAddress": "foo78858@bar.com",
+                              "Name": "Buzz Lightyear",
+                              "EmailAddress": "buzzlightyear@email.com",
                               "AccountsReceivableTaxType": "NONE",
                               "AccountsPayableTaxType": "INPUT",
                               "Addresses": [
@@ -2959,7 +3109,7 @@ paths:
                               "HasValidationErrors": true,
                               "ValidationErrors": [
                                 {
-                                  "Message": "The contact name Sidney Maestre is already assigned to another contact. The contact name must be unique across all active contacts."
+                                  "Message": "The contact name Buzz Lightyear is already assigned to another contact. The contact name must be unique across all active contacts."
                                 }
                               ]
                             }
@@ -2972,7 +3122,82 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Contacts'
-            example: '{ contacts: [{ name: "Bruce Banner", emailAddress: "hulk@avengers.com", phones: [{ phoneType: Phone.PhoneTypeEnum.MOBILE, phoneNumber: "555-1212", phoneAreaCode: "415" }], paymentTerms: { bills: { day: 15, type: PaymentTermType.OFCURRENTMONTH }, sales: { day: 10, type: PaymentTermType.DAYSAFTERBILLMONTH }}}]}'
+            example: '{
+                        "Id": "e997d6d7-6dad-4458-beb8-d9c1bf7f2edf",
+                        "Status": "OK",
+                        "ProviderName": "Xero API Partner",
+                        "DateTimeUTC": "/Date(1551399321121)/",
+                        "Contacts": [
+                          {
+                            "ContactID": "3ff6d40c-af9a-40a3-89ce-3c1556a25591",
+                            "ContactStatus": "ACTIVE",
+                            "Name": "Foo9987",
+                            "EmailAddress": "sid32476@blah.com",
+                            "BankAccountDetails": "",
+                            "Addresses": [
+                              {
+                                "AddressType": "STREET",
+                                "City": "",
+                                "Region": "",
+                                "PostalCode": "",
+                                "Country": ""
+                              },
+                              {
+                                "AddressType": "POBOX",
+                                "City": "",
+                                "Region": "",
+                                "PostalCode": "",
+                                "Country": ""
+                              }
+                            ],
+                            "Phones": [
+                              {
+                                "PhoneType": "DEFAULT",
+                                "PhoneNumber": "",
+                                "PhoneAreaCode": "",
+                                "PhoneCountryCode": ""
+                              },
+                              {
+                                "PhoneType": "DDI",
+                                "PhoneNumber": "",
+                                "PhoneAreaCode": "",
+                                "PhoneCountryCode": ""
+                              },
+                              {
+                                "PhoneType": "FAX",
+                                "PhoneNumber": "",
+                                "PhoneAreaCode": "",
+                                "PhoneCountryCode": ""
+                              },
+                              {
+                                "PhoneType": "MOBILE",
+                                "PhoneNumber": "555-1212",
+                                "PhoneAreaCode": "415",
+                                "PhoneCountryCode": ""
+                              }
+                            ],
+                            "UpdatedDateUTC": "/Date(1551399321043+0000)/",
+                            "ContactGroups": [],
+                            "IsSupplier": false,
+                            "IsCustomer": false,
+                            "SalesTrackingCategories": [],
+                            "PurchasesTrackingCategories": [],
+                            "PaymentTerms": {
+                              "Bills": {
+                                "Day": 15,
+                                "Type": "OFCURRENTMONTH"
+                              },
+                              "Sales": {
+                                "Day": 10,
+                                "Type": "DAYSAFTERBILLMONTH"
+                              }
+                            },
+                            "ContactPersons": [],
+                            "HasValidationErrors": false
+                          }
+                        ]
+                      }'
+
     post:
       security:
         - OAuth2: [accounting.contacts]
@@ -2998,10 +3223,10 @@ paths:
                           "DateTimeUTC": "\/Date(1551399321121)\/",
                           "Contacts": [
                             {
-                              "ContactID": "3ff6d40c-af9a-40a3-89ce-3c1556a25591",
+                              "ContactID": "00000000-0000-0000-0000-000000000000",
                               "ContactStatus": "ACTIVE",
-                              "Name": "Foo9987",
-                              "EmailAddress": "sid32476@blah.com",
+                              "Name": "Bruce Banner",
+                              "EmailAddress": "bruce@banner.com",
                               "BankAccountDetails": "",
                               "Addresses": [
                                 {
@@ -3080,8 +3305,8 @@ paths:
                             {
                               "ContactID": "00000000-0000-0000-0000-000000000000",
                               "AccountNumber": "12345-ABCD",
-                              "Name": "Sidney Maestre",
-                              "EmailAddress": "foo78858@bar.com",
+                              "Name": "Buzz Lightyear",
+                              "EmailAddress": "buzzlightyear@email.com",
                               "AccountsReceivableTaxType": "NONE",
                               "AccountsPayableTaxType": "INPUT",
                               "Addresses": [
@@ -3122,7 +3347,7 @@ paths:
                               "HasValidationErrors": true,
                               "ValidationErrors": [
                                 {
-                                  "Message": "The contact name Sidney Maestre is already assigned to another contact. The contact name must be unique across all active contacts."
+                                  "Message": "The contact name Buzz Lightyear is already assigned to another contact. The contact name must be unique across all active contacts."
                                 }
                               ]
                             }
@@ -6197,7 +6422,7 @@ paths:
         - Accounting
       operationId: createInvoices
       x-hasAccountingValidationError: true
-      x-ruby-requestBody: 'invoices = { invoices: [{ type: XeroRuby::Accounting::Invoice::ACCREC, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Acme Tires", quantity: 2.0, unit_amount: 20.0, account_code: "000", tax_type: TaxType.NONE, line_amount: 40.0 }], date: "2019-03-11", due_date: "2018-12-10", reference: "Website Design", status: XeroRuby::Accounting::Invoice::DRAFT }]}'
+      x-ruby-requestBody: 'invoices = { invoices: [{ type: XeroRuby::Accounting::Invoice::ACCREC, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Acme Tires", quantity: 2.0, unit_amount: 20.0, account_code: "000", tax_type: XeroRuby::Accounting::TaxType::NONE, line_amount: 40.0 }], date: "2019-03-11", due_date: "2018-12-10", reference: "Website Design", status: XeroRuby::Accounting::Invoice::DRAFT }]}'
       summary: Allows you to create one or more sales invoices or purchase bills
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -6350,7 +6575,7 @@ paths:
         - Accounting
       operationId: updateOrCreateInvoices
       x-hasAccountingValidationError: true
-      x-ruby-requestBody: 'invoices = { invoices: [{ type: XeroRuby::Accounting::Invoice::ACCREC, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Acme Tires", quantity: 2.0, unit_amount: 20.0, account_code: "000", tax_type: TaxType.NONE, line_amount: 40.0 }], date: "2019-03-11", due_date: "2018-12-10", reference: "Website Design", status: XeroRuby::Accounting::Invoice::DRAFT }]}'
+      x-ruby-requestBody: 'invoices = { invoices: [{ type: XeroRuby::Accounting::Invoice::ACCREC, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Acme Tires", quantity: 2.0, unit_amount: 20.0, account_code: "000", tax_type: XeroRuby::Accounting::TaxType::NONE, line_amount: 40.0 }], date: "2019-03-11", due_date: "2018-12-10", reference: "Website Design", status: XeroRuby::Accounting::Invoice::DRAFT }]}'
       summary: Allows you to update OR create one or more sales invoices or purchase bills
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -18180,9 +18405,9 @@ paths:
                           "Users": [
                             {
                               "UserID": "3c37ef1d-cd49-4589-9787-3c418ed8b6ac",
-                              "EmailAddress": "sid.maestre@xero.com",
-                              "FirstName": "Sidney",
-                              "LastName": "Maestre",
+                              "EmailAddress": "test@email.com",
+                              "FirstName": "Test",
+                              "LastName": "Xero",
                               "UpdatedDateUTC": "\/Date(1508523261613+0000)\/",
                               "IsSubscriber": false,
                               "OrganisationRole": "FINANCIALADVISER"
@@ -18233,9 +18458,9 @@ paths:
                           "Users": [
                             {
                               "UserID": "3c37ef1d-cd49-4589-9787-3c418ed8b6ac",
-                              "EmailAddress": "sid.maestre@xero.com",
-                              "FirstName": "Sidney",
-                              "LastName": "Maestre",
+                              "EmailAddress": "test@email.com",
+                              "FirstName": "Test",
+                              "LastName": "Xero",
                               "UpdatedDateUTC": "\/Date(1508523261613+0000)\/",
                               "IsSubscriber": false,
                               "OrganisationRole": "FINANCIALADVISER"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -20511,7 +20511,7 @@ components:
         - TMT
         - TND
         - TOP
-        - _TRY
+        - TRY_LIRA
         - TTD
         - TVD
         - TWD
@@ -20535,7 +20535,7 @@ components:
         - ZMW
         - ZMK
         - ZWD
-        - _EMPTY
+        - EMPTY_CURRENCY
       enum:
         - AED 
         - AFN

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3205,6 +3205,7 @@ paths:
         - Accounting
       operationId: updateOrCreateContacts
       x-hasAccountingValidationError: true
+      x-nod-requestBody: '{ contacts: [{ name: "Bruce Banner", emailAddress: "hulk@avengers.com", phones: [{ phoneType: Phone.PhoneTypeEnum.MOBILE, phoneNumber: "555-1212", phoneAreaCode: "415" }], paymentTerms: { bills: { day: 15, type: PaymentTermType.OFCURRENTMONTH }, sales: { day: 10, type: PaymentTermType.DAYSAFTERBILLMONTH }}}]}'
       x-ruby-requestBody: '{ contacts: [{ name: "Bruce Banner", email_address: "hulk@avengers.com", phones: [{ phone_type: XeroRuby::Accounting::Phone::MOBILE, phone_number: "555-1212", phone_area_code: "415" }], payment_terms: { bills: { day: 15, type: XeroRuby::Accounting::PaymentTermType::OFCURRENTMONTH }, sales: { day: 10, type: XeroRuby::Accounting::PaymentTermType::OFCURRENTMONTHDAYSAFTERBILLMONTH }}}]}' 
       summary: 'Allows you to update OR create one or more contacts in a Xero organisation'
       parameters:
@@ -3359,7 +3360,31 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Contacts'
-            example: '{ contacts: [{ name: "Bruce Banner", emailAddress: "hulk@avengers.com", phones: [{ phoneType: Phone.PhoneTypeEnum.MOBILE, phoneNumber: "555-1212", phoneAreaCode: "415" }], paymentTerms: { bills: { day: 15, type: PaymentTermType.OFCURRENTMONTH }, sales: { day: 10, type: PaymentTermType.DAYSAFTERBILLMONTH }}}]}'
+            example: '{
+                        "Contacts": [
+                          {
+                            "Name": "Bruce Banner",
+                            "EmailAddress": "hulk@avengers.com",
+                            "Phones": [
+                              {
+                                "PhoneType": "MOBILE",
+                                "PhoneNumber": "555-1212",
+                                "PhoneAreaCode": "415"
+                              }
+                            ],
+                            "PaymentTerms": {
+                              "Bills": {
+                                "Day": 15,
+                                "Type": "OFCURRENTMONTH"
+                              },
+                              "Sales": {
+                                "Day": 10,
+                                "Type": "DAYSAFTERBILLMONTH"
+                              }
+                            }
+                          }
+                        ]
+                      }'
   '/Contacts/{ContactNumber}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -3676,6 +3701,7 @@ paths:
         - Accounting
       operationId: updateContact
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ contacts: [{ contactID: "00000000-0000-0000-000-000000000000", name: "Thanos" }]}'
       x-ruby-requestBody: 'contacts = { contacts: [{ contact_id: "00000000-0000-0000-000-000000000000", name: "Thanos" }]}'
       parameters:
         - required: true
@@ -3777,7 +3803,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Contacts'
-            example: '{ contacts: [{ contactID: "00000000-0000-0000-000-000000000000", name: "Thanos" }]}'
+            example: '{ "Contacts": [{ "ContactID": "00000000-0000-0000-000-000000000000", "Name": "Thanos" }]}'
   '/Contacts/{ContactID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -4156,6 +4182,7 @@ paths:
         - Accounting
       operationId: createContactGroup
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ contactGroups: [{ name: "VIPs" }]}'
       x-ruby-requestBody: 'contact_groups = { contact_groups: [{ name: "VIPs" }]}'
       summary: Allows you to create a contact group
       responses:
@@ -4211,7 +4238,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ContactGroups'
-            example: '{ contactGroups: [{ name: "VIPs" }]}'
+            example: '{ "ContactGroups": [{ "Name": "VIPs" }]}'
   '/ContactGroups/{ContactGroupID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -4280,6 +4307,7 @@ paths:
         - Accounting
       operationId: updateContactGroup
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ contactGroups: [{ name: "Vendor" }]}'
       x-ruby-requestBody: 'contact_groups = { contact_groups: [{ name: "Vendor" }]}'
       summary: Allows you to update a Contact Group
       parameters:
@@ -4322,7 +4350,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ContactGroups'
-            example: '{ contactGroups: [{ name: "Vendor" }]}'
+            example: '{  
+                        "ContactGroups":[  
+                          {  
+                            "Name":"Suppliers"
+                          }
+                        ]
+                      }'
   '/ContactGroups/{ContactGroupID}/Contacts':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -4334,6 +4368,7 @@ paths:
         - Accounting
       operationId: createContactGroupContacts
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ contacts: [{ contactID: "a3675fc4-f8dd-4f03-ba5b-f1870566bcd7" }, { contactID: "4e1753b9-018a-4775-b6aa-1bc7871cfee3" }]}'
       x-ruby-requestBody: 'contacts = { contacts: [{ contact_id: "a3675fc4-f8dd-4f03-ba5b-f1870566bcd7" }, { contact_id: "4e1753b9-018a-4775-b6aa-1bc7871cfee3" }]}'
       summary: Allows you to add Contacts to a Contact Group
       parameters:
@@ -4387,7 +4422,16 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Contacts'
-            example: '{ contacts: [{ contactID: "a3675fc4-f8dd-4f03-ba5b-f1870566bcd7" }, { contactID: "4e1753b9-018a-4775-b6aa-1bc7871cfee3" }]}'
+            example: '{
+                        "Contacts": [
+                          {
+                            "ContactID": "a3675fc4-f8dd-4f03-ba5b-f1870566bcd7"
+                          },
+                          {
+                            "ContactID": "4e1753b9-018a-4775-b6aa-1bc7871cfee3"
+                          }
+                        ]
+                      }'
     delete:
       security:
         - OAuth2: [accounting.contacts]
@@ -4569,6 +4613,7 @@ paths:
         - Accounting
       operationId: createCreditNotes
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ creditNotes: [{ type: CreditNote.TypeEnum.ACCPAYCREDIT, contact: { contactID: "430fa14a-f945-44d3-9f97-5df5e28441b8" }, date: "2019-01-05", lineItems: [{ description: "Foobar", quantity: 2.0, unitAmount: 20.0, accountCode: "400" }]}]}'
       x-ruby-requestBody: 'credit_notes = { credit_notes: [{ type: XeroRuby::Accounting::CreditNote::ACCPAYCREDIT, contact: { contact_id: "430fa14a-f945-44d3-9f97-5df5e28441b8" }, date: "2019-01-05", line_items: [{ description: "Foobar", quantity: 2.0, unit_amount: 20.0, account_code: "400" }]}]}'
       summary: Allows you to create a credit note
       parameters:
@@ -4694,7 +4739,25 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreditNotes'
-            example: '{ creditNotes: [{ type: CreditNote.TypeEnum.ACCPAYCREDIT, contact: { contactID: "430fa14a-f945-44d3-9f97-5df5e28441b8" }, date: "2019-01-05", lineItems: [{ description: "Foobar", quantity: 2.0, unitAmount: 20.0, accountCode: "400" }]}]}'
+            example: '{  
+                        "CreditNotes":[  
+                          {  
+                            "Type":"ACCPAYCREDIT",
+                            "Contact":{  
+                              "ContactID":"430fa14a-f945-44d3-9f97-5df5e28441b8"
+                            },
+                            "Date":"2019-01-05",
+                            "LineItems":[  
+                              {  
+                                "Description":"Foobar",
+                                "Quantity":2.0,
+                                "UnitAmount":20.0,
+                                "AccountCode":"400"
+                              }
+                            ]
+                          }
+                        ]
+                      }'
     post:
       security:
         - OAuth2: [accounting.transactions]
@@ -4702,6 +4765,7 @@ paths:
         - Accounting
       operationId: updateOrCreateCreditNotes
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ creditNotes: [{ type: CreditNote.TypeEnum.ACCPAYCREDIT, contact: { contactID: "00000000-0000-0000-000-000000000000" }, date: "2019-01-05", lineItems: [{ description: "Foobar", quantity: 2.0, unitAmount: 20.0, accountCode: "400" }]}]}'
       x-ruby-requestBody: 'credit_notes = { credit_notes: [{ type: XeroRuby::Accounting::CreditNote::ACCPAYCREDIT, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, date: "2019-01-05", line_items: [{ description: "Foobar", quantity: 2.0, unit_amount: 20.0, account_code: "400" }]}]}'
       summary: Allows you to update OR create one or more credit notes
       parameters:
@@ -4827,7 +4891,27 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreditNotes'
-            example: '{ creditNotes: [{ type: CreditNote.TypeEnum.ACCPAYCREDIT, contact: { contactID: "00000000-0000-0000-000-000000000000" }, date: "2019-01-05", lineItems: [{ description: "Foobar", quantity: 2.0, unitAmount: 20.0, accountCode: "400" }]}]}'
+            example: '{  
+                       "CreditNotes":[  
+                          {  
+                            "Type":"ACCPAYCREDIT",
+                            "Contact":{  
+                              "ContactID":"430fa14a-f945-44d3-9f97-5df5e28441b8"
+                            },
+                            "Date":"2019-01-05",
+                            "Status":"AUTHORISED",
+                            "Reference": "HelloWorld",
+                            "LineItems":[  
+                              {  
+                                "Description":"Foobar",
+                                "Quantity":2.0,
+                                "UnitAmount":20.0,
+                                "AccountCode":"400"
+                              }
+                            ]
+                          }
+                       ]
+                    }'
   '/CreditNotes/{CreditNoteID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -4981,6 +5065,7 @@ paths:
         - Accounting
       operationId: updateCreditNote
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ creditNotes: [{ type: CreditNote.TypeEnum.ACCPAYCREDIT, contact: { contactID: "00000000-0000-0000-000-000000000000" }, date: "2019-01-05", status: CreditNote.StatusEnum.AUTHORISED, reference: "Mind stone", lineItems: [{ description: "Infinity Stones", quantity: 1.0, unitAmount: 100.0, accountCode: "400" } ]}]}'
       x-ruby-requestBody: 'credit_notes = { credit_notes: [{ type: XeroRuby::Accounting::CreditNote::ACCPAYCREDIT, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, date: "2019-01-05", status: XeroRuby::Accounting::CreditNote::AUTHORISED, reference: "Mind stone", line_items: [{ description: "Infinity Stones", quantity: 1.0, unit_amount: 100.0, account_code: "400" } ]}]}'
       summary: Allows you to update a specific credit note
       parameters:
@@ -5107,7 +5192,27 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreditNotes'
-            example: '{ creditNotes: [{ type: CreditNote.TypeEnum.ACCPAYCREDIT, contact: { contactID: "00000000-0000-0000-000-000000000000" }, date: "2019-01-05", status: CreditNote.StatusEnum.AUTHORISED, reference: "Mind stone", lineItems: [{ description: "Infinity Stones", quantity: 1.0, unitAmount: 100.0, accountCode: "400" } ]}]}'
+            example: '{
+                        "CreditNotes": [
+                          {
+                            "Type": "ACCPAYCREDIT",
+                            "Contact": {
+                              "ContactID": "430fa14a-f945-44d3-9f97-5df5e28441b8"
+                            },
+                            "Date": "2019-01-05",
+                            "Status": "AUTHORISED",
+                            "Reference": "HelloWorld",
+                            "LineItems": [
+                              {
+                                "Description": "Foobar",
+                                "Quantity": 2,
+                                "UnitAmount": 20,
+                                "AccountCode": "400"
+                              }
+                            ]
+                          }
+                        ]
+                      }'
   '/CreditNotes/{CreditNoteID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -5391,6 +5496,7 @@ paths:
         - Accounting
       operationId: createCreditNoteAllocation
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ allocations: [{ amount: 1.0, date: "2019-03-05", invoice: { invoiceID: "c45720a1-ade3-4a38-a064-d15489be6841", lineItems:[], type: Invoice.TypeEnum.ACCPAY, contact: {}}}]}'
       x-ruby-requestBody: 'allocations = { allocations: [{ amount: 1.0, date: "2019-03-05", invoice: { invoice_id: "c45720a1-ade3-4a38-a064-d15489be6841", line_items: [], type: XeroRuby::Accounting::Invoice::ACCPAY, contact: {} }}]}'
       summary: Allows you to create Allocation on CreditNote
       parameters:
@@ -5448,7 +5554,18 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Allocations'
-            example: '{ allocations: [{ amount: 1.0, date: "2019-03-05", invoice: { invoiceID: "c45720a1-ade3-4a38-a064-d15489be6841", lineItems:[], type: Invoice.TypeEnum.ACCPAY, contact: {}}}]}'
+            example: '{
+                        "Allocations": [
+                          {
+                            "Invoice": {
+                              "LineItems": [],
+                              "InvoiceID": "c45720a1-ade3-4a38-a064-d15489be6841"
+                            },
+                            "Amount": 1,
+                            "Date": "2019-03-05"
+                          }
+                        ]
+                      }'
   '/CreditNotes/{CreditNoteID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -5547,6 +5664,7 @@ paths:
         - Accounting
       operationId: createCurrency
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ code: CurrencyCode.USD, description: "United States Dollar" }'
       x-ruby-requestBody: 'currency = { code: XeroRuby::Accounting::CurrencyCode::USD, description: "United States Dollar" }'
       responses:
         '200':
@@ -5562,7 +5680,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Currency'
-              example: '{ code: CurrencyCode.USD, description: "United States Dollar" }'
+              example: '{
+                          "Code": "USD",
+                          "Description": "United States Dollar"
+                        }'
   /Employees:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -5644,6 +5765,7 @@ paths:
         - Accounting
       operationId: createEmployees
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ employees: [{ firstName: "Nick", lastName: "Fury", externalLink: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
       x-ruby-requestBody: 'employees = { employees: [{ first_name: "Nick", last_name: "Fury", externalink: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
       summary: Allows you to create new employees used in Xero payrun
       parameters:
@@ -5683,7 +5805,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Employees'
-              example: '{ employees: [{ firstName: "Nick", lastName: "Fury", externalLink: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
+              example: '{
+                          "Employees": [
+                            {
+                              "FirstName": "Nick",
+                              "LastName": "Fury",
+                              "ExternalLink": {
+                                "Url": "http://twitter.com/#!/search/Nick+Fury"
+                              }
+                            }
+                          ]
+                        }'
     post:
       security:
         - OAuth2: [accounting.settings]
@@ -5691,6 +5823,7 @@ paths:
         - Accounting
       operationId: updateOrCreateEmployees
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ employees: [{ firstName: "Nick", lastName: "Fury", externalLink: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
       x-ruby-requestBody: 'employees = { employees: [{ first_name: "Nick", last_name: "Fury", external_link: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
       summary: Allows you to create a single new employees used in Xero payrun
       parameters:
@@ -5730,7 +5863,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Employees'
-              example: '{ employees: [{ firstName: "Nick", lastName: "Fury", externalLink: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
+              example: '{
+                          "Employees": [
+                            {
+                              "FirstName": "Nick",
+                              "LastName": "Fury",
+                              "ExternalLink": {
+                                "Url": "http://twitter.com/#!/search/Nick+Fury"
+                              }
+                            }
+                          ]
+                        }'
   '/Employees/{EmployeeID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -5845,6 +5988,7 @@ paths:
         - Accounting
       operationId: createExpenseClaims
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ expenseClaims: [{ status: ExpenseClaim.StatusEnum.SUBMITTED, user: { userID: "d1164823-0ac1-41ad-987b-b4e30fe0b273" }, receipts: [{ receiptID: "dc1c7f6d-0a4c-402f-acac-551d62ce5816", lineItems: [], contact: {}, user: {}, date: "2018-01-01" }]}]}'
       x-ruby-requestBody: 'expense_claims = { expense_claims: [{ status: XeroRuby::Accounting::ExpenseClaim::SUBMITTED, user: { user_id: "d1164823-0ac1-41ad-987b-b4e30fe0b273" }, receipts: [{ receipt_id: "dc1c7f6d-0a4c-402f-acac-551d62ce5816", line_items: [], contact: {}, user: {}, date: "2018-01-01" }]}]}'
       summary: Allows you to retrieve expense claims 
       requestBody:
@@ -5854,7 +5998,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExpenseClaims'
-              example: '{ expenseClaims: [{ status: ExpenseClaim.StatusEnum.SUBMITTED, user: { userID: "d1164823-0ac1-41ad-987b-b4e30fe0b273" }, receipts: [{ receiptID: "dc1c7f6d-0a4c-402f-acac-551d62ce5816", lineItems: [], contact: {}, user: {}, date: "2018-01-01" }]}]}'
+              example: '{
+                          "ExpenseClaims": [
+                            {
+                              "Status": "SUBMITTED",
+                              "User": {
+                                "UserID": "d1164823-0ac1-41ad-987b-b4e30fe0b273"
+                              },
+                              "Receipts": [
+                                {
+                                  "Lineitems": [],
+                                  "ReceiptID": "dc1c7f6d-0a4c-402f-acac-551d62ce5816"
+                                }
+                              ]
+                            }
+                          ]
+                        }'
       responses:
         '200':
           description: Success - return response of type ExpenseClaims array with newly created ExpenseClaim

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -154,7 +154,6 @@ paths:
   '/Accounts/{AccountID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Account
     get:
       security:
         - OAuth2: [accounting.settings]
@@ -375,7 +374,6 @@ paths:
   '/Accounts/{AccountID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Account
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -418,7 +416,6 @@ paths:
   '/Accounts/{AccountID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Account
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -461,7 +458,6 @@ paths:
   '/Accounts/{AccountID}/Attachments/{FileName}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Account
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -621,7 +617,6 @@ paths:
   /BatchPayments:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BatchPayments
     description: Batch payments allow you to bundle multiple bills or invoices into one payment transaction. This means a single payment in Xero can be reconciled with a single transaction on the bank statement making for a much simpler bank reconciliation experience.
     get:
       security:
@@ -869,7 +864,6 @@ paths:
   '/BatchPayments/{BatchPaymentID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BatchPayment
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -1816,7 +1810,6 @@ paths:
   '/BankTransactions/{BankTransactionID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BankTransaction
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -1859,7 +1852,6 @@ paths:
   '/BankTransactions/{BankTransactionID}/Attachments/{FileName}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BankTransaction
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -2015,7 +2007,6 @@ paths:
   '/BankTransactions/{BankTransactionID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BankTransaction
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -2062,7 +2053,6 @@ paths:
   /BankTransfers:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BankTransfer
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -2238,7 +2228,6 @@ paths:
   '/BankTransfers/{BankTransferID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BankTransfer
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -2305,7 +2294,6 @@ paths:
   '/BankTransfers/{BankTransferID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BankTransfer
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -2348,7 +2336,6 @@ paths:
   '/BankTransfers/{BankTransferID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BankTransfer
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -2391,7 +2378,6 @@ paths:
   '/BankTransfers/{BankTransferID}/Attachments/{FileName}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BankTransfer
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -2545,7 +2531,6 @@ paths:
   '/BankTransfers/{BankTransferID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BankTransfer
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -2591,7 +2576,6 @@ paths:
   /BrandingThemes:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BrandingTheme
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -2623,7 +2607,6 @@ paths:
   '/BrandingThemes/{BrandingThemeID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BrandingTheme
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -2664,7 +2647,6 @@ paths:
   '/BrandingThemes/{BrandingThemeID}/PaymentServices':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: BrandingTheme
     get:
       security:
         - OAuth2: [paymentservices]
@@ -2767,7 +2749,6 @@ paths:
   /Contacts:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Contact
     get:
       security:
         - OAuth2: [accounting.contacts.read]
@@ -3390,7 +3371,6 @@ paths:
   '/Contacts/{ContactNumber}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Contact
     get:
       security:
         - OAuth2: [accounting.contacts.read]
@@ -3544,7 +3524,6 @@ paths:
   '/Contacts/{ContactID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Contact
     get:
       security:
         - OAuth2: [accounting.contacts.read]
@@ -3809,7 +3788,6 @@ paths:
   '/Contacts/{ContactID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Contact
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -3853,7 +3831,6 @@ paths:
   '/Contacts/{ContactID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Contact
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -3896,7 +3873,6 @@ paths:
   '/Contacts/{ContactID}/Attachments/{FileName}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Contact
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -4050,7 +4026,6 @@ paths:
   '/Contacts/{ContactID}/CISSettings':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Contact
     get:
       security:
         - OAuth2: [accounting.contacts.read]
@@ -4077,7 +4052,6 @@ paths:
   '/Contacts/{ContactID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Contact
     get:
       security:
         - OAuth2: [accounting.contacts.read]
@@ -4124,7 +4098,6 @@ paths:
   /ContactGroups:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ContactGroup
     get:
       security:
         - OAuth2: [accounting.contacts.read]
@@ -4244,7 +4217,6 @@ paths:
   '/ContactGroups/{ContactGroupID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ContactGroup
     get:
       security:
         - OAuth2: [accounting.contacts.read]
@@ -4362,7 +4334,6 @@ paths:
   '/ContactGroups/{ContactGroupID}/Contacts':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ContactGroup
     put:
       security:
         - OAuth2: [accounting.contacts]
@@ -4457,7 +4428,6 @@ paths:
   '/ContactGroups/{ContactGroupID}/Contacts/{ContactID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ContactGroup
     delete:
       security:
         - OAuth2: [accounting.contacts]
@@ -4491,7 +4461,6 @@ paths:
   /CreditNotes:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: CreditNote
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -4917,7 +4886,6 @@ paths:
   '/CreditNotes/{CreditNoteID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: CreditNote
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -5218,7 +5186,6 @@ paths:
   '/CreditNotes/{CreditNoteID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: CreditNote
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -5261,7 +5228,6 @@ paths:
   '/CreditNotes/{CreditNoteID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: CreditNote
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -5304,7 +5270,6 @@ paths:
   '/CreditNotes/{CreditNoteID}/Attachments/{FileName}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: CreditNote
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -5461,7 +5426,6 @@ paths:
   '/CreditNotes/{CreditNoteID}/pdf':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: CreditNote
     get:
       security:
         - OAuth2: [accounting.transactions]
@@ -5490,7 +5454,6 @@ paths:
   '/CreditNotes/{CreditNoteID}/Allocations':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: CreditNote
     put:
       security:
         - OAuth2: [accounting.transactions]
@@ -5571,7 +5534,6 @@ paths:
   '/CreditNotes/{CreditNoteID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: CreditNote
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -5618,7 +5580,6 @@ paths:
   /Currencies:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Currency
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -5689,7 +5650,6 @@ paths:
   /Employees:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Employee
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -5879,7 +5839,6 @@ paths:
   '/Employees/{EmployeeID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Employee
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -5925,7 +5884,6 @@ paths:
   /ExpenseClaims:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ExpenseClaim
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -6100,7 +6058,6 @@ paths:
   '/ExpenseClaims/{ExpenseClaimID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ExpenseClaim
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -6323,7 +6280,6 @@ paths:
   '/ExpenseClaims/{ExpenseClaimID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ExpenseClaim
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -6368,7 +6324,6 @@ paths:
   /Invoices:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Invoice
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -6948,7 +6903,6 @@ paths:
   '/Invoices/{InvoiceID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Invoice
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -7269,7 +7223,6 @@ paths:
   '/Invoices/{InvoiceID}/pdf':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Invoice
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -7298,7 +7251,6 @@ paths:
   '/Invoices/{InvoiceID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Invoice
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -7349,7 +7301,6 @@ paths:
   '/Invoices/{InvoiceID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Invoice
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -7392,7 +7343,6 @@ paths:
   '/Invoices/{InvoiceID}/Attachments/{FileName}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Invoice
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -7549,7 +7499,6 @@ paths:
   '/Invoices/{InvoiceID}/OnlineInvoice':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Invoice
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -7587,7 +7536,6 @@ paths:
   '/Invoices/{InvoiceID}/Email':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Invoice
     post:
       security:
         - OAuth2: [accounting.transactions]
@@ -7621,7 +7569,6 @@ paths:
   '/Invoices/{InvoiceID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Invoice
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -7668,7 +7615,6 @@ paths:
   '/InvoiceReminders/Settings':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Invoice
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -7697,7 +7643,6 @@ paths:
   /Items:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Item
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -7895,7 +7840,6 @@ paths:
   '/Items/{ItemID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Item
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -8042,7 +7986,6 @@ paths:
   '/Items/{ItemID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Item
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -8087,7 +8030,6 @@ paths:
   /Journals:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Journal
     get:
       security:
         - OAuth2: [accounting.journals.read]
@@ -8283,7 +8225,6 @@ paths:
   '/Journals/{JournalID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Journal
     get:
       security:
         - OAuth2: [accounting.journals.read]
@@ -8355,7 +8296,6 @@ paths:
   /LinkedTransactions:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: LinkedTransaction
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -8486,7 +8426,6 @@ paths:
   '/LinkedTransactions/{LinkedTransactionID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: LinkedTransaction
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -8643,7 +8582,6 @@ paths:
   /ManualJournals:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ManualJournal
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -8939,7 +8877,6 @@ paths:
   '/ManualJournals/{ManualJournalID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ManualJournal
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -9106,7 +9043,6 @@ paths:
   '/ManualJournals/{ManualJournalID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ManualJournal
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -9156,7 +9092,6 @@ paths:
   '/ManualJournals/{ManualJournalID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ManualJournal
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -9199,7 +9134,6 @@ paths:
   '/ManualJournals/{ManualJournalID}/Attachments/{FileName}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ManualJournal
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -9355,7 +9289,6 @@ paths:
   '/ManualJournals/{ManualJournalID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: ManualJournal
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -9402,7 +9335,6 @@ paths:
   /Organisation:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Organisation
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -9460,7 +9392,6 @@ paths:
   '/Organisation/Actions':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Organisation
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -9538,7 +9469,6 @@ paths:
   '/Organisation/{OrganisationID}/CISSettings':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Organisation
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -9565,7 +9495,6 @@ paths:
   /Overpayments:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Overpayment
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -9753,7 +9682,6 @@ paths:
   '/Overpayments/{OverpaymentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Overpayment
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -9903,7 +9831,6 @@ paths:
   '/Overpayments/{OverpaymentID}/Allocations':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Overpayment
     put:
       security:
         - OAuth2: [accounting.transactions]
@@ -9986,7 +9913,6 @@ paths:
   '/Overpayments/{OverpaymentID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Overpayment
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -10054,7 +9980,6 @@ paths:
   /Payments:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Payment
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -10432,7 +10357,6 @@ paths:
   '/Payments/{PaymentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Payment
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -10664,7 +10588,6 @@ paths:
   '/Payments/{PaymentID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Payment
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -10732,7 +10655,6 @@ paths:
   /PaymentServices:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: PaymentServices
     get:
       security:
         - OAuth2: [paymentservices]
@@ -10820,7 +10742,6 @@ paths:
   /Prepayments:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Prepayment
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -10897,7 +10818,6 @@ paths:
   '/Prepayments/{PrepaymentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Prepayment
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -11045,7 +10965,6 @@ paths:
   '/Prepayments/{PrepaymentID}/Allocations':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Prepayment
     put:
       security:
         - OAuth2: [accounting.transactions]
@@ -11126,7 +11045,6 @@ paths:
   '/Prepayments/{PrepaymentID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Prepayment
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -11194,7 +11112,6 @@ paths:
   /PurchaseOrders:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: PurchaseOrder
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -11707,7 +11624,6 @@ paths:
   '/PurchaseOrders/{PurchaseOrderID}/pdf':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: PurchaseOrder
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -11736,7 +11652,6 @@ paths:
   '/PurchaseOrders/{PurchaseOrderID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: PurchaseOrder
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -12029,7 +11944,6 @@ paths:
   '/PurchaseOrders/{PurchaseOrderNumber}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: PurchaseOrder
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -12180,7 +12094,6 @@ paths:
   '/PurchaseOrders/{PurchaseOrderID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: PurchaseOrder
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -12227,7 +12140,6 @@ paths:
   '/PurchaseOrders/{PurchaseOrderID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Account
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -12284,7 +12196,6 @@ paths:
   '/PurchaseOrders/{PurchaseOrderID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Account
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -12327,7 +12238,6 @@ paths:
   '/PurchaseOrders/{PurchaseOrderID}/Attachments/{FileName}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Account
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -12487,7 +12397,6 @@ paths:
   /Quotes:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Quote
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -12797,7 +12706,6 @@ paths:
   '/Quotes/{QuoteID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Quote
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -13017,7 +12925,6 @@ paths:
   '/Quotes/{QuoteID}/pdf':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Quote
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -13290,7 +13197,6 @@ paths:
   /Receipts:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Receipt
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -13528,7 +13434,6 @@ paths:
   '/Receipts/{ReceiptID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Receipt
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -13821,7 +13726,6 @@ paths:
   '/Receipts/{ReceiptID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Receipt
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -13864,7 +13768,6 @@ paths:
   '/Receipts/{ReceiptID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Receipt
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -13907,7 +13810,6 @@ paths:
   '/Receipts/{ReceiptID}/Attachments/{FileName}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Receipt
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -14063,7 +13965,6 @@ paths:
   '/Receipts/{ReceiptID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Receipt
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -14131,7 +14032,6 @@ paths:
   /RepeatingInvoices:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: RepeatingInvoice
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -14216,7 +14116,6 @@ paths:
   '/RepeatingInvoices/{RepeatingInvoiceID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: RepeatingInvoice
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -14319,7 +14218,6 @@ paths:
   '/RepeatingInvoices/{RepeatingInvoiceID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: RepeatingInvoice
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -14376,7 +14274,6 @@ paths:
   '/RepeatingInvoices/{RepeatingInvoiceID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: RepeatingInvoice
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -14419,7 +14316,6 @@ paths:
   '/RepeatingInvoices/{RepeatingInvoiceID}/Attachments/{FileName}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: RepeatingInvoice
     get:
       security:
         - OAuth2: [accounting.attachments.read]
@@ -14575,7 +14471,6 @@ paths:
   '/RepeatingInvoices/{RepeatingInvoiceID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: RepeatingInvoice
     get:
       security:
         - OAuth2: [accounting.transactions.read]
@@ -14622,7 +14517,6 @@ paths:
   '/Reports/TenNinetyNine':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.tenninetynine.read]
@@ -14734,7 +14628,6 @@ paths:
   '/Reports/AgedPayablesByContact':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.read]
@@ -15014,7 +14907,6 @@ paths:
   '/Reports/AgedReceivablesByContact':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.read]
@@ -15371,7 +15263,6 @@ paths:
   '/Reports/BalanceSheet':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.read]
@@ -16169,7 +16060,6 @@ paths:
   '/Reports/BankSummary':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.read]
@@ -16309,7 +16199,6 @@ paths:
   '/Reports':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.read]
@@ -16327,7 +16216,6 @@ paths:
   '/Reports/{ReportID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.read]
@@ -16353,7 +16241,6 @@ paths:
   '/Reports/BudgetSummary':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.read]
@@ -16609,7 +16496,6 @@ paths:
   '/Reports/ExecutiveSummary':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.read]
@@ -17102,7 +16988,6 @@ paths:
   '/Reports/ProfitAndLoss':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.read]
@@ -17187,7 +17072,6 @@ paths:
   '/Reports/TrialBalance':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: Report
     get:
       security:
         - OAuth2: [accounting.reports.read]
@@ -18587,7 +18471,6 @@ paths:
   /TrackingCategories:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: TrackingCategory
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -18683,7 +18566,6 @@ paths:
   '/TrackingCategories/{TrackingCategoryID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: TrackingCategory
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -18812,7 +18694,6 @@ paths:
   '/TrackingCategories/{TrackingCategoryID}/Options':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: TrackingCategory
     put:
       security:
         - OAuth2: [accounting.settings]
@@ -18867,7 +18748,6 @@ paths:
   '/TrackingCategories/{TrackingCategoryID}/Options/{TrackingOptionID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: TrackingCategory
     post:
       security:
         - OAuth2: [accounting.settings]
@@ -18979,7 +18859,6 @@ paths:
   /Users:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: User
     get:
       security:
         - OAuth2: [accounting.settings.read]
@@ -19037,7 +18916,6 @@ paths:
   '/Users/{UserID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-    x-related-model: User
     get:
       security:
         - OAuth2: [accounting.settings.read]

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3967,7 +3967,7 @@ paths:
               example: '{
                           "Id": "8543ae1a-297c-49b8-bf91-47decac452d5",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551485146555)\/",
                           "Attachments": [
                             {
@@ -4023,7 +4023,7 @@ paths:
               example: '{
                           "Id": "a5eddf71-86aa-42f5-99e2-0aaf9caf96b6",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551484292734)\/",
                           "Attachments": [
                             {
@@ -4155,7 +4155,7 @@ paths:
               example: '{
                           "Id": "b825df86-1a72-49c9-97dd-36afc7d04bd5",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551746015603)\/",
                           "ContactGroups": [
                             {
@@ -4195,7 +4195,7 @@ paths:
               example: '{
                           "Id": "5afe53f9-2271-45b8-9767-88d023b71d34",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551745740920)\/",
                           "ContactGroups": [
                             {
@@ -4269,7 +4269,7 @@ paths:
               example: '{
                           "Id": "079c14f6-2c2d-464e-a2c7-0edf7e465723",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551746772976)\/",
                           "ContactGroups": [
                             {
@@ -4329,7 +4329,7 @@ paths:
               example: '{
                           "Id": "b1ba6cdb-1637-4209-bb92-bd0c593f3243",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551746288544)\/",
                           "ContactGroups": [
                             {
@@ -4390,7 +4390,7 @@ paths:
               example: '{
                           "Id": "99db8024-6895-45c8-a1b5-54805aa8689c",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551747495785)\/",
                           "Contacts": [
                             {
@@ -4529,7 +4529,7 @@ paths:
               example: '{
                           "Id": "306379b0-3d75-4c77-953a-be08fa0efae8",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551812506620)\/",
                           "CreditNotes": [
                             {
@@ -4629,7 +4629,7 @@ paths:
               example: '{
                           "Id": "5e57a661-42da-4a19-96a0-00405a0e946d",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551812702713)\/",
                           "CreditNotes": [
                             {
@@ -4781,7 +4781,7 @@ paths:
               example: '{
                           "Id": "5e57a661-42da-4a19-96a0-00405a0e946d",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551812702713)\/",
                           "CreditNotes": [
                             {
@@ -4943,7 +4943,7 @@ paths:
               example: '{
                           "Id": "dd5c5da7-08ab-486a-ac34-aea295f1614b",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551812703811)\/",
                           "CreditNotes": [
                             {
@@ -5088,7 +5088,7 @@ paths:
               example: '{
                           "Id": "db2f7659-6044-418d-a4c6-d4b93eba4e1e",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551812704253)\/",
                           "CreditNotes": [
                             {
@@ -5244,7 +5244,7 @@ paths:
               example: '{
                           "Id": "2bb15054-3868-4f85-a9c6-0402ec8c1201",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551822670731)\/",
                           "Attachments": [
                             {
@@ -5376,7 +5376,7 @@ paths:
               example: '{
                           "Id": "27253066-8c4d-4e34-a251-7a749b72de40",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551828247939)\/",
                           "Attachments": [
                             {
@@ -5434,7 +5434,7 @@ paths:
               example: '{
                           "Id": "22a8d402-5dea-40ed-9d01-26896429f649",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551822953320)\/",
                           "Attachments": [
                             {
@@ -5519,7 +5519,7 @@ paths:
               example: '{
                           "Id": "73452751-6eaa-4bcb-86f5-4c013316f4cf",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551828543255)\/",
                           "Allocations": [
                             {
@@ -5648,7 +5648,7 @@ paths:
               example: '{
                           "Id": "e6803fc8-8035-4251-b3e4-39d6b2de0f4a",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552322853043)\/",
                           "Currencies": [
                             {
@@ -5720,7 +5720,7 @@ paths:
               example: ' {
                           "Id": "593cbccc-5cd2-4cd2-be5e-150f0843709e",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552325082775)\/",
                           "Employees": [
                             {
@@ -5780,7 +5780,7 @@ paths:
               example: '{
                           "Id": "0d6a08e7-6936-4828-a1bc-e4595e0ef778",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552324736508)\/",
                           "Employees": [
                             {
@@ -5838,7 +5838,7 @@ paths:
               example: '{
                           "Id": "0d6a08e7-6936-4828-a1bc-e4595e0ef778",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552324736508)\/",
                           "Employees": [
                             {
@@ -5904,7 +5904,7 @@ paths:
               example: '{
                           "Id": "417a529e-4f8d-4b1a-8816-7100245cf8b2",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552325084085)\/",
                           "Employees": [
                             {
@@ -5956,7 +5956,7 @@ paths:
               example: '{
                           "Id": "f6a8867e-af29-41ee-8f77-855f5ff214fe",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552325853538)\/",
                           "ExpenseClaims": [
                             {
@@ -6024,7 +6024,7 @@ paths:
               example: '{
                           "Id": "4a0879a6-3860-4b73-adc6-f6a0e0f68fc8",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552325850201)\/",
                           "ExpenseClaims": [
                             {
@@ -6125,7 +6125,7 @@ paths:
               example: '{
                           "Id": "b54bb45d-37da-4f53-9f1d-536302d6bad7",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552325854864)\/",
                           "ExpenseClaims": [
                             {
@@ -6202,7 +6202,8 @@ paths:
         - Accounting
       operationId: updateExpenseClaim
       x-hasAccountingValidationError: true
-      x-ruby-requestBody: 'expense_claims = { expense_claims: [{ status: XeroRuby::Accounting::ExpenseClaim::AUTHORISED, user: { user_id: "00000000-0000-0000-000-000000000000" }, receipts: [{ receipt_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, date:"2020-01-01", user: {} }]}]}'
+      x-node-requestBody: '{ expenseClaims: [{ status: ExpenseClaim.StatusEnum.AUTHORISED, user: { userID: "00000000-0000-0000-000-000000000000" }, receipts: [{ receiptID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, date: "2020-01-01", user: {} }]}]}'
+      x-ruby-requestBody: 'expense_claims = { expense_claims: [{ status: XeroRuby::Accounting::ExpenseClaim::AUTHORISED, user: { user_id: "00000000-0000-0000-000-000000000000" }, receipts: [{ receipt_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, date: "2020-01-01", user: {} }]}]}'
       summary: Allows you to update specified expense claims 
       parameters:
         - required: true
@@ -6223,7 +6224,7 @@ paths:
               example: '{
                           "Id": "8ee87f9c-058b-4f1b-b5b2-29569bf055d7",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552325851907)\/",
                           "ExpenseClaims": [
                             {
@@ -6301,7 +6302,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExpenseClaims'
-              example: '{ expenseClaims: [{ status: ExpenseClaim.StatusEnum.AUTHORISED, user: { userID: "00000000-0000-0000-000-000000000000" }, receipts: [{ receiptID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, date:"2020-01-01", user: {} }]}]}'
+              example: '{
+                          "ExpenseClaims": [
+                            {
+                              "Status": "SUBMITTED",
+                              "User": {
+                                "UserID": "d1164823-0ac1-41ad-987b-b4e30fe0b273"
+                              },
+                              "Receipts": [
+                                {
+                                  "Lineitems": [],
+                                  "ReceiptID": "dc1c7f6d-0a4c-402f-acac-551d62ce5816"
+                                }
+                              ]
+                            }
+                          ]
+                        }'
   '/ExpenseClaims/{ExpenseClaimID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -6442,7 +6458,7 @@ paths:
               example: '{
                           "Id": "900c500b-e83c-4ce2-902a-b8ba04751748",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552326816230)\/",
                           "Invoices": [
                             {
@@ -6581,6 +6597,7 @@ paths:
         - Accounting
       operationId: createInvoices
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ invoices: [{ type: Invoice.TypeEnum.ACCREC, contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Acme Tires", quantity: 2.0, unitAmount: 20.0, accountCode: "000", taxType: TaxType.NONE, lineAmount: 40.0 }], date: "2019-03-11", dueDate: "2018-12-10", reference: "Website Design", status: Invoice.StatusEnum.DRAFT }]}'
       x-ruby-requestBody: 'invoices = { invoices: [{ type: XeroRuby::Accounting::Invoice::ACCREC, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Acme Tires", quantity: 2.0, unit_amount: 20.0, account_code: "000", tax_type: XeroRuby::Accounting::TaxType::NONE, line_amount: 40.0 }], date: "2019-03-11", due_date: "2018-12-10", reference: "Website Design", status: XeroRuby::Accounting::Invoice::DRAFT }]}'
       summary: Allows you to create one or more sales invoices or purchase bills
       parameters:
@@ -6596,7 +6613,7 @@ paths:
               example: '{
                           "Id": "ccece84a-075c-4fcd-9073-149d4f7a91cf",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552327126164)\/",
                           "Invoices": [
                             {
@@ -6726,7 +6743,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Invoices'
-              example: '{ invoices: [{ type: Invoice.TypeEnum.ACCREC, contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Acme Tires", quantity: 2.0, unitAmount: 20.0, accountCode: "000", taxType: TaxType.NONE, lineAmount: 40.0 }], date: "2019-03-11", dueDate: "2018-12-10", reference: "Website Design", status: Invoice.StatusEnum.DRAFT }]}'
+              example: '{
+                          "Invoices": [
+                            {
+                              "Type": "ACCREC",
+                              "Contact": {
+                                "ContactID": "430fa14a-f945-44d3-9f97-5df5e28441b8"
+                              },
+                              "LineItems": [
+                                {
+                                  "Description": "Acme Tires",
+                                  "Quantity": 2,
+                                  "UnitAmount": 20,
+                                  "AccountCode": "200",
+                                  "TaxType": "NONE",
+                                  "LineAmount": 40
+                                }
+                              ],
+                              "Date": "2019-03-11",
+                              "DueDate": "2018-12-10",
+                              "Reference": "Website Design",
+                              "Status": "AUTHORISED"
+                            }
+                          ]
+                        }'
     post:
       security:
         - OAuth2: [accounting.transactions]
@@ -6734,6 +6774,7 @@ paths:
         - Accounting
       operationId: updateOrCreateInvoices
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ invoices: [{ type: Invoice.TypeEnum.ACCREC, contact: { contactID:"00000000-0000-0000-000-000000000000" }, lineItems:[ { description:"Acme Tires", quantity:2.0, unitAmount:20.0, accountCode:"200", taxType:"NONE", lineAmount:40.0 } ], date: "2019-03-11", dueDate:"2018-12-10", reference:"Website Design", status: Invoice.StatusEnum.AUTHORISED } ] }'
       x-ruby-requestBody: 'invoices = { invoices: [{ type: XeroRuby::Accounting::Invoice::ACCREC, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Acme Tires", quantity: 2.0, unit_amount: 20.0, account_code: "000", tax_type: XeroRuby::Accounting::TaxType::NONE, line_amount: 40.0 }], date: "2019-03-11", due_date: "2018-12-10", reference: "Website Design", status: XeroRuby::Accounting::Invoice::DRAFT }]}'
       summary: Allows you to update OR create one or more sales invoices or purchase bills
       parameters:
@@ -6749,7 +6790,7 @@ paths:
               example: '{
                           "Id": "ccece84a-075c-4fcd-9073-149d4f7a91cf",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552327126164)\/",
                           "Invoices": [
                             {
@@ -6878,7 +6919,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Invoices'
-              example: '{ invoices: [{ type: Invoice.TypeEnum.ACCREC, contact: { contactID:"00000000-0000-0000-000-000000000000" }, lineItems:[ { description:"Acme Tires", quantity:2.0, unitAmount:20.0, accountCode:"200", taxType:"NONE", lineAmount:40.0 } ], date:"2019-03-11", dueDate:"2018-12-10", reference:"Website Design", status: Invoice.StatusEnum.AUTHORISED } ] }'
+              example: '{
+                          "Invoices": [
+                            {
+                              "Type": "ACCREC",
+                              "Contact": {
+                                "ContactID": "430fa14a-f945-44d3-9f97-5df5e28441b8"
+                              },
+                              "LineItems": [
+                                {
+                                  "Description": "Acme Tires",
+                                  "Quantity": 2,
+                                  "UnitAmount": 20,
+                                  "AccountCode": "200",
+                                  "TaxType": "NONE",
+                                  "LineAmount": 40
+                                }
+                              ],
+                              "Date": "2019-03-11",
+                              "DueDate": "2018-12-10",
+                              "Reference": "Website Design",
+                              "Status": "AUTHORISED"
+                            }
+                          ]
+                        }'
   '/Invoices/{InvoiceID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -6910,7 +6974,7 @@ paths:
               example: '{
                           "Id": "516f400a-b764-4c88-831b-12d2b210fa24",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1551981658323)\/",
                           "Invoices": [
                             {
@@ -7066,6 +7130,7 @@ paths:
         - Accounting
       operationId: updateInvoice
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ invoices: [{ reference: "I am Iron Man", invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }]}'
       x-ruby-requestBody: 'invoices = { invoices: [{ reference: "I am Iron Man", invoice_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, type: XeroRuby::Accounting::Invoice::ACCPAY }]}'
       summary: Allows you to update a specified sales invoices or purchase bills
       parameters:
@@ -7088,7 +7153,7 @@ paths:
               example: '{
                           "Id": "bd83b60e-9d16-4a3b-9f59-0a2d0ccd35f2",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552329729002)\/",
                           "Invoices": [
                             {
@@ -7198,7 +7263,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Invoices'
-            example: '{ invoices: [{ reference: "I am Iron Man", invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }]}'
+            example: '{ "Invoices": [{ Reference: "May the force be with you", "InvoiceID": "00000000-0000-0000-000-000000000000", "LineItems": [], "Contact": {}, "Type": "ACCPAY" }]}'
   '/Invoices/{InvoiceID}/pdf':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -7259,7 +7324,7 @@ paths:
               example: ' {
                             "Id": "7e357a45-69f5-4e8f-8d7b-15da8ef50aab",
                             "Status": "OK",
-                            "ProviderName": "Java Partner Example",
+                            "ProviderName": "Provider Name Example",
                             "DateTimeUTC": "\/Date(1552330258523)\/",
                             "Attachments": [
                               {
@@ -7399,7 +7464,7 @@ paths:
               example: '{
                           "Id": "acd7d618-5fef-4d45-849c-a339ea31a973",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552330524005)\/",
                           "Attachments": [
                             {
@@ -7457,7 +7522,7 @@ paths:
               example: '{
                             "Id": "971fbd18-c850-453a-825f-63f2fee096ee",
                             "Status": "OK",
-                            "ProviderName": "Java Partner Example",
+                            "ProviderName": "Provider Name Example",
                             "DateTimeUTC": "\/Date(1552330001318)\/",
                             "Attachments": [
                               {
@@ -7509,7 +7574,7 @@ paths:
               example: '{
                           "Id": "d20705fb-fe1c-4366-835b-98de7474da3c",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552331100745)\/",
                           "OnlineInvoices": [
                             {
@@ -7619,7 +7684,7 @@ paths:
               example: '{
                           "Id": "c7cd0953-c012-4be8-b618-63ce4c2c3494",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552331430618)\/",
                           "InvoiceReminders": [
                             {
@@ -7663,7 +7728,7 @@ paths:
               example: '{
                           "Id": "8487e8d7-5fb3-4f02-b949-dec8f1e38182",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552331874897)\/",
                           "Items": [
                             {
@@ -7703,6 +7768,7 @@ paths:
         - Accounting
       operationId: createItems
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ items: [{ code: "abcXYZ123", name: "HelloWorld11", description: "Foobar", inventoryAssetAccountCode: "140", purchaseDetails: { cOGSAccountCode: "500" }}]}'
       x-ruby-requestBody: 'items = { items: [{ code: "abcXYZ123", name: "HelloWorld11", description: "Foobar", inventory_asset_account_code: "140", purchase_details: { cogs_account_code: "500" }}]}'
       summary: Allows you to create one or more items
       parameters:
@@ -7718,7 +7784,7 @@ paths:
               example: '{
                           "Id": "ae7ef7c8-9024-4d42-8d59-5f26ed3f508b",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552331871904)\/",
                           "Items": [
                             {
@@ -7749,7 +7815,19 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Items'
-            example: '{ items: [{ code: "abcXYZ123", name: "HelloWorld11", description: "Foobar", inventoryAssetAccountCode: "140", purchaseDetails: { cOGSAccountCode: "500" }}]}'
+            example: '{
+                        "Items": [
+                          {
+                            "Code": "code123",
+                            "Name": "Item Name XYZ",
+                            "Description": "Foobar",
+                            "InventoryAssetAccountCode": "140",
+                            "PurchaseDetails": {
+                              "COGSAccountCode": "500"
+                            }
+                          }
+                        ]
+                      }'
     post:
       security:
         - OAuth2: [accounting.settings]
@@ -7757,7 +7835,8 @@ paths:
         - Accounting
       operationId: updateOrCreateItems
       x-hasAccountingValidationError: true
-      x-ruby-requestBody: 'items = { items: [{ code: "abcXYZ", name: "HelloWorld", description: "Foobar" }]}'
+      x-node-requestBody: '{ items: [{ code: "ItemCode123", name: "ItemName XYZ", description: "Item Description ABC" }]}'
+      x-ruby-requestBody: 'items = { items: [{ code: "ItemCode123", name: "ItemName XYZ", description: "Item Description ABC" }]}'
       summary: Allows you to update or create one or more items
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -7772,7 +7851,7 @@ paths:
               example: '{
                           "Id": "ae7ef7c8-9024-4d42-8d59-5f26ed3f508b",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552331871904)\/",
                           "Items": [
                             {
@@ -7802,7 +7881,15 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Items'
-            example: '{ items: [{ code: "abcXYZ", name: "HelloWorld", description: "Foobar" }]}'
+            example: '{
+                        "Items": [
+                          {
+                            "Code": "ItemCode123",
+                            "Name": "ItemName XYZ",
+                            "Description": "Item Description ABC"
+                          }
+                        ]
+                      }'
   '/Items/{ItemID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -7834,7 +7921,7 @@ paths:
               example: '{
                           "Id": "0bbd8a92-9ba7-4711-8040-8d6a609ca7e8",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552333420160)\/",
                           "Items": [
                             {
@@ -7871,6 +7958,8 @@ paths:
         - Accounting
       operationId: updateItem
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ items: [{ code: "ItemCode123", description: "Description 123" }]}'
+      x-ruby-requestBody: 'items = { items: [{ code: "ItemCode123", description: "Description 123" }]}'
       summary: Allows you to update a specified item
       parameters:
         - required: true
@@ -7892,7 +7981,7 @@ paths:
               example: '{
                           "Id": "24feb629-6b14-499e-9aa1-fc2c596c0280",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552332558975)\/",
                           "Items": [
                             {
@@ -7918,7 +8007,14 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Items'
-            example: '{ items:[ { code:"abc123", description:"Hello Xero" } ] }'
+            example: '{
+                        "Items": [
+                          {
+                            "Code": "ItemCode123",
+                            "Description": "Description 123"
+                          }
+                        ]
+                      }'
     delete:
       security:
         - OAuth2: [accounting.settings]
@@ -8020,7 +8116,7 @@ paths:
               example: '{
                           "Id": "49a09a97-df50-4679-8043-02c86e0dcf5f",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552335214210)\/",
                           "Journals": [
                             {
@@ -8212,7 +8308,7 @@ paths:
               example: '{
                           "Id": "39ab8367-eb14-420d-83a9-e01ddddd21f8",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552335613002)\/",
                           "Journals": [
                             {
@@ -8312,7 +8408,7 @@ paths:
               example: '{
                           "Id": "516aabd0-e670-48d5-b0eb-10dce4494dd8",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552348338096)\/",
                           "LinkedTransactions": [
                             {
@@ -8336,6 +8432,7 @@ paths:
         - Accounting
       operationId: createLinkedTransaction
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ sourceTransactionID: "00000000-0000-0000-000-000000000000", sourceLineItemID: "00000000-0000-0000-000-000000000000" }'
       x-ruby-requestBody: 'linked_transaction = { source_transaction_id: "00000000-0000-0000-000-000000000000", source_line_item_id: "00000000-0000-0000-000-000000000000" }'
       summary: Allows you to create linked transactions (billable expenses)
       responses:
@@ -8348,7 +8445,7 @@ paths:
               example: '{
                           "Id": "f32b30e5-32d1-42a8-bcc9-5b22828f725c",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552351054646)\/",
                           "LinkedTransactions": [
                             {
@@ -8376,7 +8473,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LinkedTransaction'
-              example: '{ sourceTransactionID: "00000000-0000-0000-000-000000000000", sourceLineItemID: "00000000-0000-0000-000-000000000000" }'
+              example: '{
+                          "LinkedTransactions": [
+                            {
+                              "SourceTransactionID": "a848644a-f20f-4630-98c3-386bd7505631",
+                              "SourceLineItemID": "b0df260d-3cc8-4ced-9bd6-41924f624ed3"
+                            }
+                          ]
+                        }'
   '/LinkedTransactions/{LinkedTransactionID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -8407,7 +8511,7 @@ paths:
               example: '{
                           "Id": "171ca542-874d-44e2-8930-db9bccd7d88b",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552348339875)\/",
                           "LinkedTransactions": [
                             {
@@ -8431,6 +8535,7 @@ paths:
         - Accounting
       operationId: updateLinkedTransaction
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ linkedTransactions: [{ sourceLineItemID: "00000000-0000-0000-000-000000000000", contactID: "00000000-0000-0000-000-000000000000" }]}'
       x-ruby-requestBody: 'linked_transactions = { linked_transactions: [{ source_line_item_id: "00000000-0000-0000-000-000000000000", contact_id: "00000000-0000-0000-000-000000000000" }]}'
       summary: Allows you to update a specified linked transactions (billable expenses)
       parameters:
@@ -8452,7 +8557,7 @@ paths:
               example: '{
                           "Id": "bd364af7-08f0-432b-81db-c1e5ba05f3dd",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552351488159)\/",
                           "LinkedTransactions": [
                             {
@@ -8503,7 +8608,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LinkedTransactions'
-              example: '{ linkedTransactions: [{ sourceLineItemID: "00000000-0000-0000-000-000000000000", contactID: "00000000-0000-0000-000-000000000000" }]}'
+              example: '{
+                          "LinkedTransactions": [
+                            {
+                              "SourceTransactionID": "00000000-0000-0000-000-000000000000",
+                              "SourceLineItemID": "00000000-0000-0000-000-000000000000"
+                            }
+                          ]
+                        }'
     delete:
       security:
         - OAuth2: [accounting.transactions]
@@ -8568,7 +8680,7 @@ paths:
               example: '{
                           "Id": "8a508ec1-b578-48bf-97df-020c918fbf7d",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552357217359)\/",
                           "ManualJournals": [
                             {
@@ -8613,6 +8725,7 @@ paths:
         - Accounting
       operationId: createManualJournals
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ manualJournals: [{ narration: "Foo bar", date: "2019-03-14", journalLines: [{ lineAmount: 100.0, accountCode: "400", description: "Hello there" }, { lineAmount: -100.0, accountCode: "400", description: "Goodbye", tracking: [{ name: "Simpson", option: "Bart" }] }]}]}'
       x-ruby-requestBody: 'manual_journals = { manual_journals: [{ narration: "Foo bar", date: "2019-03-14", journal_lines: [{ line_amount: 100.0, account_code: "400", description: "Hello there" }, { line_amount: -100.0, account_code: "400", description: "Goodbye", tracking: [{ name: "Simpson", option: "Bart" }] }]}]}'
       summary: Allows you to create one or more manual journals
       parameters:
@@ -8627,7 +8740,7 @@ paths:
               example: '{
                           "Id": "45dfa608-0fcb-4f30-a377-c82cd348569c",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552595972952)\/",
                           "ManualJournals": [
                             {
@@ -8687,7 +8800,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{ manualJournals: [{ narration: "Foo bar", date: "2019-03-14", journalLines: [{ lineAmount: 100.0, accountCode: "400", description: "Hello there" }, { lineAmount: -100.0, accountCode: "400", description: "Goodbye", tracking: [{ name: "Simpson", option: "Bart" }] }]}]}'
+              example: '{
+                          "ManualJournals": [
+                            {
+                              "Narration": "Journal Desc",
+                              "JournalLines": [
+                                {
+                                  "LineAmount": 100,
+                                  "AccountCode": "400",
+                                  "Description": "Money Movement"
+                                },
+                                {
+                                  "LineAmount": -100,
+                                  "AccountCode": "400",
+                                  "Description": "Prepayment of things",
+                                  "Tracking": [
+                                    {
+                                      "Name": "North",
+                                      "Option": "Region"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Date": "2019-03-14"
+                            }
+                          ]
+                        }'
     post:
       security:
         - OAuth2: [accounting.transactions]
@@ -8695,6 +8833,7 @@ paths:
         - Accounting
       operationId: updateOrCreateManualJournals
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ manualJournals: [{ narration: "Foo bar", journalLines: [{ lineAmount: 100.0, accountCode: "400", description: "Hello there" },{ lineAmount: -100.0, accountCode: "400", description: "Goodbye", tracking: [{ name: "Simpsons", option: "Bart" }]}], date: "2019-03-14" }]}'
       x-ruby-requestBody: 'manual_journals = { manual_journals: [{ narration: "Foo bar", date: "2019-03-14", journal_lines: [{ line_amount: 100.0, account_code: "400", description: "Hello there" },{ line_amount: -100.0, account_code: "400", description: "Goodbye", tracking: [{ name: "Simpsons", option: "Bart" }]}] }]}'
       summary: Allows you to create a single manual journal
       parameters:
@@ -8709,7 +8848,7 @@ paths:
               example: '{
                           "Id": "45dfa608-0fcb-4f30-a377-c82cd348569c",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552595972952)\/",
                           "ManualJournals": [
                             {
@@ -8769,7 +8908,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{ manualJournals: [{ narration: "Foo bar", journalLines: [{ lineAmount: 100.0, accountCode: "400", description: "Hello there" },{ lineAmount: -100.0, accountCode: "400", description: "Goodbye", tracking: [{ name: "Simpsons", option: "Bart" }]}], date: "2019-03-14" }]}'
+              example: '{
+                          "ManualJournals": [
+                            {
+                              "Narration": "Journal Desc",
+                              "JournalLines": [
+                                {
+                                  "LineAmount": 100,
+                                  "AccountCode": "400",
+                                  "Description": "Money Movement"
+                                },
+                                {
+                                  "LineAmount": -100,
+                                  "AccountCode": "400",
+                                  "Description": "Prepayment of things",
+                                  "Tracking": [
+                                    {
+                                      "Name": "North",
+                                      "Option": "Region"
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Date": "2019-03-14"
+                            }
+                          ]
+                        }'
   '/ManualJournals/{ManualJournalID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -8800,7 +8964,7 @@ paths:
               example: '{
                           "Id": "7321fc21-1a13-4f40-ae47-df59cff5676d",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552399859139)\/",
                           "ManualJournals": [
                             {
@@ -8860,7 +9024,8 @@ paths:
         - Accounting
       operationId: updateManualJournal
       x-hasAccountingValidationError: true
-      x-ruby-requestBody: 'manual_journals = { manual_journals: [{ narration: "Hello Xero", manual_journal_id: "00000000-0000-0000-000-000000000000", journal_ines: [] }]}'
+      x-node-requestBody: '{ manualJournals: [{ narration: "Hello Xero", manualJournalId: "00000000-0000-0000-000-000000000000", journalLines: [] }]}'
+      x-ruby-requestBody: 'manual_journals = { manual_journals: [{ narration: "Hello Xero", manual_journal_id: "00000000-0000-0000-000-000000000000", journal_lines: [] }]}'
       summary: Allows you to update a specified manual journal
       parameters:
         - required: true
@@ -8881,7 +9046,7 @@ paths:
               example: '{
                           "Id": "b694559c-686c-4047-b657-661ba6c0dd1f",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552357736850)\/",
                           "ManualJournals": [
                             {
@@ -8927,7 +9092,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{ manualJournals: [{ narration: "Hello Xero", manualJournalID: "00000000-0000-0000-000-000000000000", journalLines: [] }]}'
+              example: '{
+                          "ManualJournals": [
+                            {
+                              "Narration": "Hello Xero",
+                              "ManualJournalID": "00000000-0000-0000-000-000000000000",
+                              "JournalLines": []
+                            }
+                          ]
+                        }'
   '/ManualJournals/{ManualJournalID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -8959,7 +9132,7 @@ paths:
               example: '{
                           "Id": "5fa4b3ef-7945-45a7-9bab-10e830673dfb",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552404121471)\/",
                           "Attachments": [
                             {
@@ -9098,7 +9271,7 @@ paths:
               example: '{
                           "Id": "e1cb9deb-a8f0-477f-b4d1-cf0c6c39e080",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552401039306)\/",
                           "Attachments": [
                             {
@@ -9155,7 +9328,7 @@ paths:
               example: '{
                           "Id": "a864994c-e7d7-4dee-b5ca-0a729fde2f39",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552400898428)\/",
                           "Attachments": [
                             {
@@ -9198,7 +9371,7 @@ paths:
               example: '{
                           "Id": "27b7a645-a3ee-43c8-b2c6-a2fa7b84c8c5",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552404447003)\/",
                           "Organisations": [
                             {
@@ -9383,7 +9556,7 @@ paths:
               example: '{
                           "Id": "c0ce675e-e5bc-4b2a-a20e-76a9eaedf89d",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552428951416)\/",
                           "Overpayments": [
                             {
@@ -9558,7 +9731,7 @@ paths:
               example: ' {
                             "Id": "46c9e8e2-9410-4e75-9297-f0ca8fa76c32",
                             "Status": "OK",
-                            "ProviderName": "Java Partner Example",
+                            "ProviderName": "Provider Name Example",
                             "DateTimeUTC": "\/Date(1553278835158)\/",
                             "Overpayments": [
                               {
@@ -9689,7 +9862,8 @@ paths:
         - Accounting
       operationId: createOverpaymentAllocations
       x-hasAccountingValidationError: true
-      x-ruby-requestBody: 'allocations = { allocations: [{ invoice: { invoice_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, type: XeroRuby::Accounting::Invoice::ACCPAY }, amount: 1.0, date: "2019-03-12" }]}'
+      x-node-requestBody: '{ allocations: [{ invoice: { invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }, amount: 10.0, date: "2019-03-12" }]}'
+      x-ruby-requestBody: 'allocations = { allocations: [{ invoice: { invoice_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, type: XeroRuby::Accounting::Invoice::ACCPAY }, amount: 10.0, date: "2019-03-12" }]}'
       summary: Allows you to create a single allocation for an overpayment
       parameters:
         - required: true
@@ -9711,7 +9885,7 @@ paths:
               example: '{
                           "Id": "3b7f7be2-384a-4703-bcfb-c56e9116c914",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552428952968)\/",
                           "Allocations": [
                             {
@@ -9746,7 +9920,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Allocations'
-              example: '{ allocations: [{ invoice: { invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }, amount: 1.0, date: "2019-03-12" }]}'
+              example: '{
+                          "Allocations": [
+                            {
+                              "Invoice": {
+                                "InvoiceID": "00000000-0000-0000-000-000000000000",
+                                "LineItems": [],
+                                "Contact": {},
+                                "Type": "ACCPAY"
+                              },
+                              "Amount": 10.00,
+                              "Date": "2019-03-12"
+                            }
+                          ]
+                        }'
   '/Overpayments/{OverpaymentID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -9857,7 +10044,7 @@ paths:
               example: '{
                           "Id": "9f310473-e1b5-4704-a25c-eec653deb596",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552431874205)\/",
                           "Payments": [
                             {
@@ -9964,6 +10151,7 @@ paths:
         - Accounting
       operationId: createPayments
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ payments: [{ invoice: { invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }, account: { code: "970" }, date: "2019-03-12", amount: 1.0 }]}'
       x-ruby-requestBody: 'payments = { payments: [{ invoice: { invoice_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, type: XeroRuby::Accounting::Invoice::ACCPAY }, account: { code: "970" }, date: "2019-03-12", amount: 1.0 }]}'
       summary: Allows you to create multiple payments for invoices or credit notes
       parameters:
@@ -9978,7 +10166,7 @@ paths:
               example: '{
                           "Id": "83b5715a-6a77-4c16-b5b8-2da08b5fde44",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552432238716)\/",
                           "Payments": [
                             {
@@ -10060,7 +10248,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Payments'
-              example: '{ payments: [{ invoice: { invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }, account: { code: "970" }, date: "2019-03-12", amount: 1.0 }]}'
+              example: '{
+                          "Payments": [
+                            {
+                              "Invoice": {
+                                "LineItems": [],
+                                "InvoiceID": "00000000-0000-0000-000-000000000000"
+                              },
+                              "Account": {
+                                "Code": "970"
+                              },
+                              "Date": "2019-03-12",
+                              "Amount": 1
+                            }
+                          ]
+                        }'
     post:
       security:
         - OAuth2: [accounting.transactions]
@@ -10068,6 +10270,7 @@ paths:
         - Accounting
       operationId: createPayment
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ invoice: { invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }, account: { code: "970" }, date: "2019-03-12", amount: 1.0 }'
       x-ruby-requestBody: 'invoice = { invoice: { invoice_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, type: XeroRuby::Accounting::Invoice::ACCPAY }, account: { code: "970" }, date: "2019-03-12", amount: 1.0 }'
       summary: Allows you to create a single payment for invoices or credit notes  
       responses:
@@ -10080,7 +10283,7 @@ paths:
               example: '{
                           "Id": "83b5715a-6a77-4c16-b5b8-2da08b5fde44",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552432238716)\/",
                           "Payments": [
                             {
@@ -10162,7 +10365,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Payment'
-              example: '{ invoice: { invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }, account: { code: "970" }, date: "2019-03-12", amount: 1.0 }'
+              example: '{
+                          "Payments": [
+                            {
+                              "Invoice": {
+                                "LineItems": [],
+                                "InvoiceID": "00000000-0000-0000-000-000000000000"
+                              },
+                              "Account": {
+                                "Code": "970"
+                              },
+                              "Date": "2019-03-12",
+                              "Amount": 1
+                            }
+                          ]
+                        }'
   '/Payments/{PaymentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -10193,7 +10410,7 @@ paths:
               example: '{
                           "Id": "4876f9ee-3a17-47d8-8c1b-84377c8f2998",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552431874852)\/",
                           "Payments": [
                             {
@@ -10291,6 +10508,8 @@ paths:
       tags:
         - Accounting
       operationId: deletePayment
+      x-node-requestBody: '{ status: "DELETED" }'
+      x-ruby-requestBody: 'payments = { status: "DELETED" }'
       x-hasAccountingValidationError: true
       summary: Allows you to update a specified payment for invoices and credit notes
       parameters:
@@ -10312,7 +10531,7 @@ paths:
               example: '{
                           "Id": "ee23328c-4a8b-4ee7-8fb6-9796ffab9cb0",
                           "Status": "OK",
-                          "ProviderName": "java-sdk-oauth2-dev-02",
+                          "ProviderName": "provider-name",
                           "DateTimeUTC": "\/Date(1583945852489)\/",
                           "Payments": [
                             {
@@ -10386,7 +10605,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaymentDelete'
-              example: '{ status: "DELETED" }'
+              example: '{  
+                          "Payments":[  
+                            {  
+                              "Status":"DELETED"
+                            }
+                          ]
+                        }'
   '/Payments/{PaymentID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -10476,7 +10701,7 @@ paths:
               example: '{
                           "Id": "ab82a7dd-5070-4e82-b841-0af52909fe04",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552488713171)\/",
                           "PaymentServices": [
                             {
@@ -10495,6 +10720,7 @@ paths:
         - Accounting
       operationId: createPaymentService
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ paymentServices: [{ paymentServiceName: "PayUpNow", paymentServiceUrl: "https://www.payupnow.com/", payNowText: "Time To Pay" }]}'
       x-ruby-requestBody: 'payment_services = { payment_services: [{ payment_service_name: "PayUpNow", payment_service_url: "https://www.payupnow.com/", pay_now_text: "Time To Pay" }]}'
       summary: Allows you to create payment services
       responses:
@@ -10507,7 +10733,7 @@ paths:
               example: '{
                           "Id": "7ed8b3c0-2155-49ee-a583-f2dce6607dfb",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552488712813)\/",
                           "PaymentServices": [
                             {
@@ -10533,7 +10759,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaymentServices'
-              example: '{ paymentServices: [{ paymentServiceName: "PayUpNow", paymentServiceUrl: "https://www.payupnow.com/", payNowText: "Time To Pay" }]}'
+              example: '{
+                          "PaymentServices": [
+                            {
+                              "PaymentServiceName": "PayUpNow",
+                              "PaymentServiceUrl": "https://www.payupnow.com/",
+                              "PayNowText": "Time To Pay"
+                            }
+                          ]
+                        }'
   /Prepayments:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -10577,7 +10811,7 @@ paths:
               example: '{
                           "Id": "d7a9ca0c-6159-4c26-ad2e-715440c50b7d",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552489227595)\/",
                           "Prepayments": [
                             {
@@ -10641,7 +10875,7 @@ paths:
               example: '{
                           "Id": "18e5f578-ef28-4096-a7aa-d06d65574b99",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1553540376847)\/",
                           "Prepayments": [
                             {
@@ -10770,6 +11004,7 @@ paths:
         - Accounting
       operationId: createPrepaymentAllocations
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ allocations: [{ invoice: { invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: null }, amount: 1.0, date: "2019-03-13" }]}'
       x-ruby-requestBody: 'allocations = { allocations: [{ invoice: { invoice_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, type: null }, amount: 1.0, date: "2019-03-13" }]}'
       summary: Allows you to create an Allocation for prepayments
       parameters:
@@ -10792,7 +11027,7 @@ paths:
               example: '{
                           "Id": "d4758808-d14d-45d5-851a-52787ae5739a",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552522424927)\/",
                           "Allocations": [
                             {
@@ -10827,7 +11062,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Allocations'
-              example: '{ allocations: [{ invoice: { invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: null }, amount: 1.0, date: "2019-03-13" }]}'
+              example: '{
+                          "Allocations": [
+                            {
+                              "Invoice": {
+                                "LineItems": [],
+                                "InvoiceID": "00000000-0000-0000-000-000000000000"
+                              },
+                              "Amount": 1,
+                              "Date": "2019-01-10"
+                            }
+                          ]
+                        }'
   '/Prepayments/{PrepaymentID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -10955,7 +11201,7 @@ paths:
               example: '{
                           "Id": "66910bfc-15cc-4692-bd4c-cc8f671e653c",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552523977238)\/",
                           "PurchaseOrders": [
                             {
@@ -11109,6 +11355,7 @@ paths:
         - Accounting
       operationId: createPurchaseOrders
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ purchaseOrders: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "710" }], date: "2019-03-13" }]}'
       x-ruby-requestBody: 'purchase_orders = { purchase_orders: [{ contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, account_code: "710" }], date: "2019-03-13" }]}'
       summary: Allows you to create one or more purchase orders
       parameters:
@@ -11123,7 +11370,7 @@ paths:
               example: ' {
                             "Id": "aa2f9d23-fd76-4bee-9600-30c0f0f34036",
                             "Status": "OK",
-                            "ProviderName": "Java Partner Example",
+                            "ProviderName": "Provider Name Example",
                             "DateTimeUTC": "\/Date(1552522946173)\/",
                             "PurchaseOrders": [
                               {
@@ -11237,7 +11484,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PurchaseOrders'
-              example: '{ purchaseOrders: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "710" }], date: "2019-03-13" }]}'
+              example: '{
+                          "PurchaseOrders": [
+                            {
+                              "Contact": {
+                                "ContactID": "00000000-0000-0000-000-000000000000"
+                              },
+                              "LineItems": [
+                                {
+                                  "Description": "Foobar",
+                                  "Quantity": 1,
+                                  "UnitAmount": 20,
+                                  "AccountCode": "710"
+                                }
+                              ],
+                              "Date": "2019-03-13"
+                            }
+                          ]
+                        }'
     post:
       security:
         - OAuth2: [accounting.transactions]
@@ -11245,6 +11509,7 @@ paths:
         - Accounting
       operationId: updateOrCreatePurchaseOrders
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ purchaseOrders: [ { contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "710" }], date: "2019-03-13" }]}'
       x-ruby-requestBody: 'purchase_orders = { purchase_orders: [{ contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "710" }], date: "2019-03-13" }]}'
       summary: Allows you to update or create one or more purchase orders
       parameters:
@@ -11259,7 +11524,7 @@ paths:
               example: ' {
                             "Id": "aa2f9d23-fd76-4bee-9600-30c0f0f34036",
                             "Status": "OK",
-                            "ProviderName": "Java Partner Example",
+                            "ProviderName": "Provider Name Example",
                             "DateTimeUTC": "\/Date(1552522946173)\/",
                             "PurchaseOrders": [
                               {
@@ -11372,7 +11637,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PurchaseOrders'
-              example: '{ purchaseOrders: [ { contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "710" }], date: "2019-03-13" }]}'
+              example: '{
+                          "PurchaseOrders": [
+                            {
+                              "Contact": {
+                                "ContactID": "00000000-0000-0000-000-000000000000"
+                              },
+                              "LineItems": [
+                                {
+                                  "Description": "Foobar",
+                                  "Quantity": 1,
+                                  "UnitAmount": 20,
+                                  "AccountCode": "710"
+                                }
+                              ],
+                              "Date": "2019-03-13"
+                            }
+                          ]
+                        }'
   '/PurchaseOrders/{PurchaseOrderID}/pdf':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -11432,7 +11714,7 @@ paths:
               example: '{
                           "Id": "53a8c7a5-92e8-475b-a037-acf7c55c3afd",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1553626110950)\/",
                           "PurchaseOrders": [
                             {
@@ -11561,6 +11843,7 @@ paths:
         - Accounting
       operationId: updatePurchaseOrder
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ purchaseOrders:[ { attentionTo: "Peter Parker", lineItems: [], contact: {} }]}'
       x-ruby-requestBody: 'purchase_orders = { purchase_orders: [ { attention_to: "Peter Parker", line_items: [], contact: {} }]}'
       summary: Allows you to update a specified purchase order
       parameters:
@@ -11582,7 +11865,7 @@ paths:
               example: '{
                           "Id": "0e9bb3f8-d68b-4bb2-a54d-7da240a4f51a",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552523976885)\/",
                           "PurchaseOrders": [
                             {
@@ -11685,7 +11968,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PurchaseOrders'
-              example: '{ purchaseOrders:[ { attentionTo: "Peter Parker", lineItems: [], contact: {} }]}'
+              example: '{
+                          "PurchaseOrders": [
+                            {
+                              "AttentionTo": "Peter Parker",
+                              "LineItems": [],
+                              "Contact": {}
+                            }
+                          ]
+                        }'
   '/PurchaseOrders/{PurchaseOrderNumber}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -11715,7 +12006,7 @@ paths:
               example: '{
                           "Id": "53a8c7a5-92e8-475b-a037-acf7c55c3afd",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1553626110950)\/",
                           "PurchaseOrders": [
                             {
@@ -12059,20 +12350,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/Attachments'
               example: '{
-                    "Id": "aeff9be0-54c2-45dd-8e3d-aa4f8af0fbd7",
-                    "Status": "OK",
-                    "ProviderName": "Xero API Partner",
-                    "DateTimeUTC": "/Date(1602100086197)/",
-                    "Attachments": [
-                        {
-                            "AttachmentID": "dce4eaa7-c8a9-4867-9434-95832b427d3b",
-                            "FileName": "xero-dev.png",
-                            "Url": "https://api.xero.com/api.xro/2.0/PurchaseOrders/93369c9b-c481-4e21-aaab-bb19e9a26efe/Attachments/2D_2.png",
-                            "MimeType": "image/png",
-                            "ContentLength": 98715
-                        }
-                    ]
-                }'
+                          "Id": "aeff9be0-54c2-45dd-8e3d-aa4f8af0fbd7",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "/Date(1602100086197)/",
+                          "Attachments": [
+                            {
+                              "AttachmentID": "dce4eaa7-c8a9-4867-9434-95832b427d3b",
+                              "FileName": "xero-dev.png",
+                              "Url": "https://api.xero.com/api.xro/2.0/PurchaseOrders/93369c9b-c481-4e21-aaab-bb19e9a26efe/Attachments/2D_2.png",
+                              "MimeType": "image/png",
+                              "ContentLength": 98715
+                            }
+                          ]
+                        }'
         '400':
           description: Validation Error - some data was incorrect returns response of type Error
           content:
@@ -12120,20 +12411,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/Attachments'
               example: '{
-                    "Id": "c728a4a4-179e-4bbd-a2d5-63e7f9ceba92",
-                    "Status": "OK",
-                    "ProviderName": "Xero API Partner",
-                    "DateTimeUTC": "/Date(1602099934723)/",
-                    "Attachments": [
-                        {
-                            "AttachmentID": "e58bd37b-e47f-451a-a42c-f946ef229c3e",
-                            "FileName": "xero-dev.png",
-                            "Url": "https://api.xero.com/api.xro/2.0/PurchaseOrders/93369c9b-c481-4e21-aaab-bb19e9a26efe/Attachments/2D.png",
-                            "MimeType": "image/png",
-                            "ContentLength": 82529
-                        }
-                    ]
-                }'
+                          "Id": "c728a4a4-179e-4bbd-a2d5-63e7f9ceba92",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "/Date(1602099934723)/",
+                          "Attachments": [
+                            {
+                              "AttachmentID": "e58bd37b-e47f-451a-a42c-f946ef229c3e",
+                              "FileName": "xero-dev.png",
+                              "Url": "https://api.xero.com/api.xro/2.0/PurchaseOrders/93369c9b-c481-4e21-aaab-bb19e9a26efe/Attachments/2D.png",
+                              "MimeType": "image/png",
+                              "ContentLength": 82529
+                            }
+                          ]
+                        }'
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -12280,7 +12571,8 @@ paths:
         - Accounting
       operationId: createQuotes
       x-hasAccountingValidationError: true
-      x-ruby-requestBody: 'quotes = { quotes: [{ contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unit_amount: 20.0, account_code: "12775" }], date:"2020-02-01" }]}'
+      x-node-requestBody: '{ quotes: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "12775" }], date: "2020-02-01" }]}'
+      x-ruby-requestBody: 'quotes = { quotes: [{ contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unit_amount: 20.0, account_code: "12775" }], date: "2020-02-01" }]}'
       summary: Allows you to create one or more quotes
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -12295,7 +12587,7 @@ paths:
                         "SummarizeErrors":false,
                         "Id":"29571f5a-bf73-4bb6-9de5-86be44e6bf2e",
                         "Status":"OK",
-                        "ProviderName":"java-sdk-oauth2-dev-02",
+                        "ProviderName":"provider-name",
                         "DateTimeUTC":"\/Date(1580607782916)\/",
                         "Quotes":[ 
                             { 
@@ -12345,7 +12637,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Quotes'
-              example: '{ quotes: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "12775" }], date:"2020-02-01" }]}'
+              example: '{
+                          "Quotes": [
+                            {
+                              "Contact": {
+                                "ContactID": "00000000-0000-0000-000-000000000000"
+                              },
+                              "LineItems": [
+                                {
+                                  "Description": "Foobar",
+                                  "Quantity": 1,
+                                  "UnitAmount": 20,
+                                  "AccountCode": "12775"
+                                }
+                              ],
+                              "Date": "2020-02-01"
+                            }
+                          ]
+                        }'
     post:
       security:
         - OAuth2: [accounting.transactions]
@@ -12353,6 +12662,7 @@ paths:
         - Accounting
       operationId: updateOrCreateQuotes
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ quotes: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "12775" }], date: "2020-02-01" }]}'
       x-ruby-requestBody: 'quotes = { quotes: [{ contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unit_amount: 20.0, account_code: "12775" }], date: "2020-02-01" }]}'
       summary: Allows you to update OR create one or more quotes
       parameters:
@@ -12368,7 +12678,7 @@ paths:
                         "SummarizeErrors":false,
                         "Id":"b425754f-0512-481d-827b-c8958db7667e",
                         "Status":"OK",
-                        "ProviderName":"java-sdk-oauth2-dev-02",
+                        "ProviderName":"provider-name",
                         "DateTimeUTC":"\/Date(1580607783833)\/",
                         "Quotes":[ 
                             { 
@@ -12417,7 +12727,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Quotes'
-              example: '{ quotes: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "12775" }], date: "2020-02-01" }]}'
+              example: '{
+                          "Quotes": [
+                            {
+                              "Contact": {
+                                "ContactID": "00000000-0000-0000-000-000000000000"
+                              },
+                              "LineItems": [
+                                {
+                                  "Description": "Foobar",
+                                  "Quantity": 1,
+                                  "UnitAmount": 20,
+                                  "AccountCode": "12775"
+                                }
+                              ],
+                              "Date": "2020-02-01"
+                            }
+                          ]
+                        }'
   '/Quotes/{QuoteID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -12449,7 +12776,7 @@ paths:
                         "SummarizeErrors":true,
                         "Id":"e3626c45-77f1-4ab0-ba9b-3593c7bcd25c",
                         "Status":"OK",
-                        "ProviderName":"java-sdk-oauth2-dev-02",
+                        "ProviderName":"provider-name",
                         "DateTimeUTC":"\/Date(1580607864786)\/",
                         "Quotes":[ 
                             { 
@@ -12511,6 +12838,7 @@ paths:
         - Accounting
       operationId: updateQuote
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ quotes: [{ reference: "I am an update", contact: { contactID: "00000000-0000-0000-000-000000000000" }, date: "2020-02-01" }]}'
       x-ruby-requestBody: 'quotes = { quotes: [{ reference: "I am an update", contact: { contact_id: "00000000-0000-0000-000-000000000000" }, date: "2020-02-01" }]}'
       summary: Allows you to update a specified quote
       parameters:
@@ -12533,7 +12861,7 @@ paths:
                         "SummarizeErrors":true,
                         "Id":"be4f43a7-ef02-497a-96c2-fc0bc047a82a",
                         "Status":"OK",
-                        "ProviderName":"java-sdk-oauth2-dev-02",
+                        "ProviderName":"provider-name",
                         "DateTimeUTC":"\/Date(1580605644385)\/",
                         "Quotes":[ 
                             { 
@@ -12580,7 +12908,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Quotes'
-              example: '{ quotes: [{ reference: "I am an update", contact: { contactID: "00000000-0000-0000-000-000000000000" }, date: "2020-02-01" }]}'
+              example: '{
+                          "Quotes": [
+                            {
+                              "Reference": "I am an update",
+                              "Contact": {
+                                "ContactID": "00000000-0000-0000-000-000000000000"
+                              },
+                              "Date": "2020-02-01"
+                            }
+                          ]
+                        }'
   '/Quotes/{QuoteID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -12937,7 +13275,7 @@ paths:
               example: '{
                           "Id": "078b2a2c-902f-4154-8739-357ece5982e5",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552524584695)\/",
                           "Receipts": [
                             {
@@ -12988,6 +13326,7 @@ paths:
         - Accounting
       operationId: createReceipt
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ receipts: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 2.0, unitAmount: 20.0, accountCode: "400", taxType: TaxType.NONE, lineAmount: 40.0 }], user: { userID: "00000000-0000-0000-000-000000000000" }, lineAmountTypes: LineAmountTypes.Inclusive, status: Receipt.StatusEnum.DRAFT, date: null} ] }'
       x-ruby-requestBody: 'receipts = { receipts: [ { contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 2.0, unit_amount: 20.0, account_code: "400", tax_type: XeroRuby::Accounting::TaxType::NONE, line_amount: 40.0 }], user: { user_id: "00000000-0000-0000-000-000000000000" }, line_amount_types: XeroRuby::Accounting::INCLUSIVE, status: XeroRuby::Accounting::Receipt::DRAFT, date: nil }]}'
       summary: Allows you to create draft expense claim receipts for any user
       parameters:
@@ -13002,7 +13341,7 @@ paths:
               example: '{
                           "Id": "35898898-5361-4b42-b6ca-9d2c584fc53d",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552524583429)\/",
                           "Receipts": [
                             {
@@ -13113,7 +13452,30 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Receipts'
-            example: '{ receipts: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 2.0, unitAmount: 20.0, accountCode: "400", taxType: TaxType.NONE, lineAmount: 40.0 }], user: { userID: "00000000-0000-0000-000-000000000000" }, lineAmountTypes: LineAmountTypes.Inclusive, status: Receipt.StatusEnum.DRAFT, date: null} ] }'
+            example: '{
+                        "Receipts": [
+                          {
+                            "Contact": {
+                              "ContactID": "00000000-0000-0000-000-000000000000"
+                            },
+                            "Lineitems": [
+                              {
+                                "Description": "Foobar",
+                                "Quantity": 2,
+                                "UnitAmount": 20,
+                                "AccountCode": "400",
+                                "TaxType": "NONE",
+                                "LineAmount": 40
+                              }
+                            ],
+                            "User": {
+                              "UserID": "00000000-0000-0000-000-000000000000"
+                            },
+                            "LineAmountTypes": "NoTax",
+                            "Status": "DRAFT"
+                          }
+                        ]
+                      }'
   '/Receipts/{ReceiptID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -13145,7 +13507,7 @@ paths:
               example: '{
                           "Id": "2c99af06-d278-4580-8c8c-463c806af5b6",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1553800357225)\/",
                           "Receipts": [
                             {
@@ -13267,6 +13629,7 @@ paths:
         - Accounting
       operationId: updateReceipt
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ receipts: [{ user: { userID: "00000000-0000-0000-000-000000000000" }, reference: "Foobar", date: "2020-01-01", contact: {}, lineItems: [] }]}'
       x-ruby-requestBody: 'receipts = { receipts: [{ user: { user_id: "00000000-0000-0000-000-000000000000" }, reference: "Foobar", date: "2020-01-01", contact: {}, line_items: [] }]}'
       summary: Allows you to retrieve a specified draft expense claim receipts
       parameters:
@@ -13289,7 +13652,7 @@ paths:
               example: '{
                           "Id": "05b76bf7-4734-4633-a399-7d569a6a25c6",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552675557052)\/",
                           "Receipts": [
                             {
@@ -13395,7 +13758,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Receipts'
-              example: '{ receipts: [{ user: { userID: "00000000-0000-0000-000-000000000000" }, reference: "Foobar", date: "2020-01-01", contact: {}, lineItems: [] }]}'
+              example: '{
+                          "Receipts": [
+                            {
+                              "Lineitems": [],
+                              "User": {
+                                "UserID": "00000000-0000-0000-000-000000000000"
+                              },
+                              "Reference": "Foobar"
+                            }
+                          ]
+                        }'
   '/Receipts/{ReceiptID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -13427,7 +13800,7 @@ paths:
               example: '{
                           "Id": "d379c04d-d3aa-4034-95b8-af69a449bd78",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552686430436)\/",
                           "Attachments": [
                             {
@@ -13559,7 +13932,7 @@ paths:
               example: '{
                           "Id": "aeca1ea8-8fd9-4757-96a6-397dc4957a69",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552686602761)\/",
                           "Attachments": [
                             {
@@ -13616,7 +13989,7 @@ paths:
               example: '{
                           "Id": "01c9a720-b1f1-4477-8de8-ff46d945fd1d",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1552686599884)\/",
                           "Attachments": [
                             {
@@ -13741,7 +14114,7 @@ paths:
               example: '{
                           "Id": "b336833d-a3a8-4a67-ab4c-6280b3ad87b0",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1553805183228)\/",
                           "RepeatingInvoices": [
                             {
@@ -13821,7 +14194,7 @@ paths:
               example: '{
                           "Id": "d9ac3755-7b81-4e3a-bef0-fa8a4f171442",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1553805184820)\/",
                           "RepeatingInvoices": [
                             {
@@ -13925,7 +14298,7 @@ paths:
               example: '{
                           "Id": "b88b807b-3087-474b-a4f9-d8f1b4f5a899",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1553805762049)\/",
                           "Attachments": [
                             {
@@ -14071,7 +14444,7 @@ paths:
               example: '{
                             "Id": "61b24d5c-4d6e-468f-9de1-abbc234b239a",
                             "Status": "OK",
-                            "ProviderName": "Java Partner Example",
+                            "ProviderName": "Provider Name Example",
                             "DateTimeUTC": "\/Date(1553805873362)\/",
                             "Attachments": [
                               {
@@ -14128,7 +14501,7 @@ paths:
               example: '{
                           "Id": "219de8c0-ee70-48af-a000-594eba14b417",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1553805866696)\/",
                           "Attachments": [
                             {
@@ -15014,7 +15387,7 @@ paths:
               example: '{
                         "Id": "2ddba304-6ed3-4da4-b185-3b6289699653",
                         "Status": "OK",
-                        "ProviderName": "Java Partner Example",
+                        "ProviderName": "Provider Name Example",
                         "DateTimeUTC": "\/Date(1555099412778)\/",
                         "Reports": [
                           {
@@ -15516,7 +15889,7 @@ paths:
                                         "Value": "Current Year Earnings",
                                         "Attributes": [
                                           {
-                                            "Value": "abababab-abab-abab-abab-abababababab",
+                                            "Value": "00000000-0000-0000-000-000000000000",
                                             "Id": "account"
                                           }
                                         ]
@@ -15525,7 +15898,7 @@ paths:
                                         "Value": "114.62",
                                         "Attributes": [
                                           {
-                                            "Value": "abababab-abab-abab-abab-abababababab",
+                                            "Value": "00000000-0000-0000-000-000000000000",
                                             "Id": "account"
                                           },
                                           {
@@ -15542,7 +15915,7 @@ paths:
                                         "Value": "156621.67",
                                         "Attributes": [
                                           {
-                                            "Value": "abababab-abab-abab-abab-abababababab",
+                                            "Value": "00000000-0000-0000-000-000000000000",
                                             "Id": "account"
                                           },
                                           {
@@ -15559,7 +15932,7 @@ paths:
                                         "Value": "500.00",
                                         "Attributes": [
                                           {
-                                            "Value": "abababab-abab-abab-abab-abababababab",
+                                            "Value": "00000000-0000-0000-000-000000000000",
                                             "Id": "account"
                                           },
                                           {
@@ -15969,7 +16342,7 @@ paths:
               example: '{
                           "Id": "9f1e2722-0d98-4669-890f-f8f4217c968b",
                           "Status": "OK",
-                          "ProviderName": "java-sdk-oauth2-dev-02",
+                          "ProviderName": "provider-name",
                           "DateTimeUTC": "\/Date(1573755037865)\/",
                           "Reports": [
                             {
@@ -15979,7 +16352,7 @@ paths:
                               "ReportTitles": [
                                 "Overall Budget",
                                 "Budget Summary",
-                                "Mind Body Online Test 11",
+                                "Online Test 11",
                                 "November 2019 to October 2022"
                               ],
                               "ReportDate": "14 November 2019",
@@ -16213,7 +16586,7 @@ paths:
               example: '{
                           "Id": "068d3505-ac37-43f3-8135-f912a5963d8a",
                           "Status": "OK",
-                          "ProviderName": "java-sdk-oauth2-dev-02",
+                          "ProviderName": "provider-name",
                           "DateTimeUTC": "/Date(1573755038314)/",
                           "Reports": [
                             {
@@ -16222,7 +16595,7 @@ paths:
                               "ReportType": "ExecutiveSummary",
                               "ReportTitles": [
                                 "Executive Summary",
-                                "Mind Body Online Test 11",
+                                "Online Test 11",
                                 "For the month of November 2019"
                               ],
                               "ReportDate": "14 November 2019",
@@ -17915,7 +18288,7 @@ paths:
               example: '{
                           "Id": "455d494d-9706-465b-b584-7086ca406b27",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555086839841)\/",
                           "TaxRates": [
                             {
@@ -18032,6 +18405,7 @@ paths:
         - Accounting
       operationId: createTaxRates
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ taxRates: [{ name: "CA State Tax", taxComponents: [{ name: "State Tax", rate: 2.25 }]}]}'
       x-ruby-requestBody: 'tax_rates = { tax_rates: [{ name: "CA State Tax", tax_components: [{ name: "State Tax", rate: 2.25 }]}]}'
       summary: Allows you to create one or more Tax Rates      
       responses:
@@ -18044,7 +18418,7 @@ paths:
               example: '{
                           "Id": "9d2c5e56-fab4-450b-a5ff-d47409508eab",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555086839080)\/",
                           "TaxRates": [
                             {
@@ -18079,7 +18453,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaxRates'
-              example: '{ taxRates: [{ name: "CA State Tax", taxComponents: [{ name: "State Tax", rate: 2.25 }]}]}'
+              example: '{
+                          "TaxRates": [
+                            {
+                              "Name": "CA State Tax",
+                              "TaxComponents": [
+                                {
+                                  "Name": "State Tax",
+                                  "Rate": 2.25
+                                }
+                              ]
+                            }
+                          ]
+                        }'
     post:
       security:
         - OAuth2: [accounting.settings]
@@ -18087,6 +18473,7 @@ paths:
         - Accounting
       operationId: updateTaxRate
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ taxRates: [{ name: "State Tax NY", taxComponents: [{ name: "State Tax", rate: 2.25 }], status: TaxRate.StatusEnum.DELETED, reportTaxType: TaxRate.ReportTaxTypeEnum.INPUT }]}'
       x-ruby-requestBody: 'tax_rates = { tax_rates: [{ name: "State Tax NY", tax_components: [{ name: "State Tax", rate: 2.25 }], status: XeroRuby::Accounting::TaxRate::Deleted, report_tax_type: XeroRuby::Accounting::TaxRate::INPUT }]}'
       summary: Allows you to update Tax Rates
       responses:
@@ -18099,7 +18486,7 @@ paths:
               example: '{
                           "Id": "12f4c453-2e25-41aa-a52f-6faaf6c05832",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555086839658)\/",
                           "TaxRates": [
                             {
@@ -18133,7 +18520,21 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TaxRates'
-            example: '{ taxRates: [{ name: "State Tax NY", taxComponents: [{ name: "State Tax", rate: 2.25 }], status: TaxRate.StatusEnum.Deleted, reportTaxType: TaxRate.ReportTaxTypeEnum.INPUT }]}'
+            example: '{
+                        "TaxRates": [
+                          {
+                            "Name": "State Tax NY",
+                            "TaxComponents": [
+                              {
+                                "Name": "State Tax",
+                                "Rate": 2.25
+                              }
+                            ],
+                            "Status": "DELETED",
+                            "ReportTaxType": "INPUT"
+                          }
+                        ]
+                      }'
   /TrackingCategories:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -18174,7 +18575,7 @@ paths:
               example: '{
                           "Id": "cec55068-8061-48e5-ac83-c77e7c54cf3d",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555085855047)\/",
                           "TrackingCategories": [
                             {
@@ -18209,7 +18610,7 @@ paths:
               example: '{
                           "Id": "1a9f8e03-9916-4a42-93a9-e8fa4902d49c",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555085855988)\/",
                           "TrackingCategories": [
                             {
@@ -18260,7 +18661,7 @@ paths:
               example: '{
                           "Id": "b75b8862-39c0-45a8-82b8-30ab4831996b",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555085855442)\/",
                           "TrackingCategories": [
                             {
@@ -18278,6 +18679,8 @@ paths:
         - Accounting
       operationId: updateTrackingCategory
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ name: "Avengers" }'
+      x-ruby-requestBody: 'tracking_categories = { name: "Avengers" }'
       summary: Allows you to update tracking categories
       parameters:
         - required: true
@@ -18298,7 +18701,7 @@ paths:
               example: '{
                           "Id": "55438774-f87d-4731-b586-799cf0f914ed",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555085856275)\/",
                           "TrackingCategories": [
                             {
@@ -18317,7 +18720,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TrackingCategory'
-            example: '{ name: "Avengers" }'
+            example: '{ "Name": "Avengers" }'
     delete:
       security:
         - OAuth2: [accounting.settings]
@@ -18344,7 +18747,7 @@ paths:
               example: '{
                           "Id": "ca7f8145-c8a5-4366-a2fb-784edc0cfbb7",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555086457922)\/",
                           "TrackingCategories": [
                             {
@@ -18388,7 +18791,7 @@ paths:
               example: '{
                           "Id": "923be702-d124-4f5c-a568-760906538d8e",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555085857061)\/",
                           "Options": [
                             {
@@ -18451,7 +18854,7 @@ paths:
               example: '{
                           "Id": "923be702-d124-4f5c-a568-760906538d8e",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555085857061)\/",
                           "Options": [
                             {
@@ -18508,7 +18911,7 @@ paths:
               example: '{
                           "Id": "d985866e-0831-418f-a07c-4d843ff66d25",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1555085857338)\/",
                           "Options": [
                             {
@@ -18559,7 +18962,7 @@ paths:
               example: '{
                           "Id": "17932a4e-4948-4d50-8672-4ef0e1dd90c5",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1553880796393)\/",
                           "Users": [
                             {
@@ -18612,7 +19015,7 @@ paths:
               example: '{
                           "Id": "51250ce8-1b35-4ba4-b404-dc94ff75bd87",
                           "Status": "OK",
-                          "ProviderName": "Java Partner Example",
+                          "ProviderName": "Provider Name Example",
                           "DateTimeUTC": "\/Date(1553880796732)\/",
                           "Users": [
                             {
@@ -18687,9 +19090,9 @@ components:
           schema:
             $ref: '#/components/schemas/HistoryRecords'
           example: '{  
-                      historyRecords:[  
+                      "HistoryRecords":[  
                         {  
-                            details :"Hello World"
+                          "Details": "Hello World"
                         }
                       ]
                     }'
@@ -20493,7 +20896,7 @@ components:
           type: string
           x-is-msdate: true
         ReceiptID:
-          description: The Xero identifier for the Receipt e.g.  e59a2c7f-1306-4078-a0f3-73537afcbba9
+          description: The Xero identifier for the Receipt e.g. e59a2c7f-1306-4078-a0f3-73537afcbba9
           type: string
           format: uuid
       type: object

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -19108,7 +19108,7 @@ components:
     summarizeErrors:
       in: query
       name: summarizeErrors
-      description: If false return 200 OK and mix of successfully created obejcts and any with validation errors
+      description: If false return 200 OK and mix of successfully created objects and any with validation errors
       example: true
       schema:
         type: boolean

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -73,8 +73,8 @@ paths:
         - Accounting
       operationId: createAccount
       x-hasAccountingValidationError: true
-      x-ruby-requestBody: 'account = { code: "123456", name: "Foobar", type: XeroRuby::Accounting::AccountType::EXPENSE, description: "Hello World" }'
       x-node-requestBody: '{ code: "123456", name: "Foobar", type: AccountType.EXPENSE, description: "Hello World" }'
+      x-ruby-requestBody: 'account = { code: "123456", name: "Foobar", type: XeroRuby::Accounting::AccountType::EXPENSE, description: "Hello World" }'
       summary: Allows you to create a new chart of accounts
       x-php:
           - '$account = new XeroAPI\XeroPHP\Models\Accounting\Account;'
@@ -753,6 +753,7 @@ paths:
         - Accounting
       operationId: createBatchPayment
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ batchPayments: [{ account: { accountId: "00000000-0000-0000-000-000000000000" }, reference: "ref", date: "2018-08-01", payments: [{  account: { code: "001" }, date: "2019-12-31", amount: 500, invoice: { invoiceId: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }}]}]}'
       x-ruby-requestBody: 'batch_payments = { batch_payments: [{ account: { account_id: "00000000-0000-0000-000-000000000000" }, reference: "ref", date: "2018-08-01", payments: [{  account: { code: "001" }, date: "2019-12-31", amount: 500, invoice: { invoice_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, type: XeroRuby::Accounting::Invoice::ACCPAY }}]}]}'
       summary: Create one or many BatchPayments for invoices
       parameters:
@@ -1246,6 +1247,7 @@ paths:
         - Accounting
       operationId: updateOrCreateBankTransactions
       x-hasAccountingValidationError: true
+      x-node-requestBody: '{ bankTransactions: [{ type: BankTransaction.TypeEnum.SPEND, contact: { contactId: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "000" }], bankAccount: { code: "000" }}]}'
       x-ruby-requestBody: 'bank_transactions = { bank_transactions: [{ type: XeroRuby::Accounting::BankTransaction::SPEND, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unit_amount: 20.0, account_code: "000" }], bank_account: { code: "000" }}]}'
       summary: Allows you to update or create one or more spend or receive money transaction
       parameters:
@@ -2733,17 +2735,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaymentServices'
               example: '{  
-                         "Id":"918feecb-067a-4ed9-841b-571c04eaada3",
-                         "Status":"OK",
-                         "ProviderName":"Xero API Partner",
-                         "DateTimeUTC":"\/Date(1551139338915)\/",
-                         "PaymentServices":[  
+                         "Id": "918feecb-067a-4ed9-841b-571c04eaada3",
+                         "Status": "OK",
+                         "ProviderName": "Xero API Partner",
+                         "DateTimeUTC": "\/Date(1551139338915)\/",
+                         "PaymentServices": [  
                             {  
-                               "PaymentServiceID":"00000000-0000-0000-0000-000000000000",
-                               "PaymentServiceName":"ACME Payments",
-                               "PaymentServiceUrl":"https://www.payupnow.com/",
-                               "PaymentServiceType":"Custom",
-                               "PayNowText":"Pay Now"
+                               "PaymentServiceID": "00000000-0000-0000-0000-000000000000",
+                               "PaymentServiceName": "ACME Payments",
+                               "PaymentServiceUrl": "https://www.payupnow.com/",
+                               "PaymentServiceType": "Custom",
+                               "PayNowText": "Pay Now"
                             }
                          ]
                       }'
@@ -2757,10 +2759,10 @@ paths:
             schema:
               $ref: '#/components/schemas/PaymentService'
             example: '{  
-                         "PaymentServiceID":"00000000-0000-0000-0000-000000000000",
-                         "PaymentServiceName":"ACME Payments",
-                         "PaymentServiceUrl":"https://www.payupnow.com/",
-                         "PayNowText":"Pay Now"
+                        "PaymentServiceID": "00000000-0000-0000-0000-000000000000",
+                        "PaymentServiceName": "ACME Payments",
+                        "PaymentServiceUrl": "https://www.payupnow.com/",
+                        "PayNowText": "Pay Now"
                       }'
   /Contacts:
     parameters:
@@ -3205,7 +3207,7 @@ paths:
         - Accounting
       operationId: updateOrCreateContacts
       x-hasAccountingValidationError: true
-      x-nod-requestBody: '{ contacts: [{ name: "Bruce Banner", emailAddress: "hulk@avengers.com", phones: [{ phoneType: Phone.PhoneTypeEnum.MOBILE, phoneNumber: "555-1212", phoneAreaCode: "415" }], paymentTerms: { bills: { day: 15, type: PaymentTermType.OFCURRENTMONTH }, sales: { day: 10, type: PaymentTermType.DAYSAFTERBILLMONTH }}}]}'
+      x-node-requestBody: '{ contacts: [{ name: "Bruce Banner", emailAddress: "hulk@avengers.com", phones: [{ phoneType: Phone.PhoneTypeEnum.MOBILE, phoneNumber: "555-1212", phoneAreaCode: "415" }], paymentTerms: { bills: { day: 15, type: PaymentTermType.OFCURRENTMONTH }, sales: { day: 10, type: PaymentTermType.DAYSAFTERBILLMONTH }}}]}'
       x-ruby-requestBody: '{ contacts: [{ name: "Bruce Banner", email_address: "hulk@avengers.com", phones: [{ phone_type: XeroRuby::Accounting::Phone::MOBILE, phone_number: "555-1212", phone_area_code: "415" }], payment_terms: { bills: { day: 15, type: XeroRuby::Accounting::PaymentTermType::OFCURRENTMONTH }, sales: { day: 10, type: XeroRuby::Accounting::PaymentTermType::OFCURRENTMONTHDAYSAFTERBILLMONTH }}}]}' 
       summary: 'Allows you to update OR create one or more contacts in a Xero organisation'
       parameters:


### PR DESCRIPTION
# Main
* reverts all the request body examples from javascript objects to raw json.
* puts the node examples into a vendor extension to match the temporary ruby style of `x-<language>-requestBody`

# Other changes
* removes `x-related-model` vendor extension (https://trello.com/c/aBASxoFz/68-vendor-extension-audit)
* rename two problem currencies to TRY_LIRA and EMPTY_CURRENCY

* Adds PR and Issue Templates