### PR TITLE
Adding a definition for the setup endpoint

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -18181,6 +18181,84 @@ paths:
                             }
                           ]
                         }'
+  /Setup:
+    parameters:
+      - $ref: '#/components/parameters/requiredHeader'
+    post:
+      security:
+        - OAuth2: [accounting.settings]
+      tags:
+        - Accounting
+      operationId: postSetup
+      summary: Allows you to set the chart of accounts, the conversion date and conversion balances
+      responses:
+        '200':
+          description: Success - returns a summary of the chart of accounts updates
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportSummary'
+              example: '{
+                          "Id": "80dcb65b-4d14-4350-84e6-1438a809244a",
+                          "Status": "OK",
+                          "ProviderName": "Java Public Example",
+                          "DateTimeUTC": "/Date(1604457589645)/",
+                          "ImportSummary": {
+                              "Accounts": {
+                                  "Total": 17,
+                                  "New": 0,
+                                  "Updated": 8,
+                                  "Deleted": 0,
+                                  "Locked": 0,
+                                  "System": 9,
+                                  "Errored": 0,
+                                  "Present": true,
+                                  "NewOrUpdated": 8
+                              },
+                              "Organisation": {
+                                  "Present": false
+                              }
+                          }
+                      }'
+      requestBody:
+        required: true
+        description: Object including an accounts array, a conversion balances array and a conversion date object in body of request
+        content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Setup'
+              example: '{
+                          "ConversionDate": {},
+                          "ConversionBalances": [],
+                          "Accounts": [
+                            {
+                                "Code": "200",
+                                "Name": "Sales",
+                                "Type": "SALES",
+                                "ReportingCode": "REV.TRA.GOO"
+                            },
+                            {
+                                "Code": "400",
+                                "Name": "Advertising",
+                                "Type": "OVERHEADS",
+                                "ReportingCode": "EXP"
+                            },
+                            {
+                                "Code": "610",
+                                "Name": "Accounts Receivable",
+                                "Type": "CURRENT",
+                                "SystemAccount": "DEBTORS",
+                                "ReportingCode": "ASS.CUR.REC.TRA"
+                            },
+                            {
+                                "Code": "800",
+                                "Name": "Accounts Payable",
+                                "Type": "CURRLIAB",
+                                "SystemAccount": "CREDITORS",
+                                "ReportingCode": "LIA.CUR.PAY"
+                            }
+                          ]
+                        }'
   /TaxRates:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -23307,6 +23385,107 @@ components:
       - DRCHARGE20
       - DRCHARGESUPPLY5
       - DRCHARGE5
+    Setup:
+      externalDocs:
+        url: 'https://developer.xero.com/documentation/api-guides/conversions'
+      properties:
+        Accounts:
+          description: See Accounts
+          type: array
+          items:
+            $ref: '#/components/schemas/Accounts'
+        ConversionDate:
+          description: The date when the organisation starts using Xero
+          type: object
+          properties:
+            Month: 
+              description: The month the organisation starts using Xero. Value is an integer between 1 and 12
+              type: number
+              format: integer
+              example: 1
+            Year:
+              description: The year the organisation starts using Xero. Value is an integer greater than 2006
+              type: number
+              format: integer
+              example: 2020
+        ConversionBalances:
+          description: Balance supplied for each account that has a value as at the conversion date.
+          type: array
+          items:
+            type: object
+            properties:
+              AccountCode:
+                description: The account code for a account
+                type: string
+              Balance:
+                description: The opening balances of the account. Debits are positive, credits are negative values
+                type: number
+                format: double
+              BalanceDetails:
+                description: An array to specify multiple currency balances of an account
+                type: array
+                items:
+                  type: object
+                  properties:
+                    Balance:
+                      description: The opening balances of the account. Debits are positive, credits are negative values
+                      type: number
+                      format: double
+                    CurrencyCode:
+                      description: The currency of the balance (Not required for base currency)
+                      type: string
+                    CurrencyRate: 
+                      description: (Optional) Exchange rate to base currency when money is spent or received. If not specified, XE rate for the day is applied
+                      type: number
+                      format: double
+                      x-is-money: true
+    ImportSummary:
+      externalDocs:
+        url: 'https://developer.xero.com/documentation/api-guides/conversions'
+      properties:
+        Accounts:
+          description: A summary of the accounts changes
+          type: object
+          properties:
+            Total:
+              description: The total number of accounts in the org
+              type: number
+              format: integer
+            New:
+              description: The number of new accounts created
+              type: number
+              format: integer
+            Updated:
+              description: The number of accounts updated
+              type: number
+              format: integer
+            Deleted:
+              description: The number of accounts deleted
+              type: number
+              format: integer
+            Locked:
+              description: The number of locked accounts
+              type: number
+              format: integer
+            System:
+              description: The number of system accounts
+              type: number
+              format: integer
+            Errored:
+              description: The number of accounts that had an error
+              type: number
+              format: integer
+            Present:
+              type: boolean
+            NewOrUpdated:
+              description: The number of new or updated accounts
+              type: number
+              format: integer
+        Organisation:
+          type: object
+          properties:
+            Present:
+              type: boolean
     TaxRate:
       externalDocs:
         url: 'http://developer.xero.com/documentation/api/tax-rates/'


### PR DESCRIPTION
## Description
Adding a definition for the POST /Setup endpoint including schemas for the request and response.

## Release Notes
It allows the Setup endpoint to be added to SDKs and other tools generated from the OpenAPI spec. This is very important for conversion partners migrating to OAuth 2

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
