### PR TITLE
Adding the disposalDate field to the Asset object

### DIFF
--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -610,6 +610,11 @@ components:
           x-is-money: true
           description: "The purchase price of the asset"
           example: "1000.0000"
+        disposalDate:
+          type: string
+          format: date
+          description: "The date the asset was disposed"
+          example: "2020-07-01T00:00:00"          
         disposalPrice:
           type: number
           format: double


### PR DESCRIPTION

## Description
Adding the disposalDate field to the Asset object. This is not a new field in the API but was missing from the docs and spec.

## Release Notes
This field was missing from the spec

## Screenshots (if appropriate):

## Types of Changes
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
