### PR TITLE
Add DueDate to CreditNotes

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -20270,6 +20270,10 @@ components:
             the timezone setting of the organisation
           type: string
           x-is-msdate: true
+        DueDate:
+          description: Date invoice is due – YYYY-MM-DD
+          type: string
+          x-is-msdate: true
         Status:
           description: See Credit Note Status Codes
           type: string


### PR DESCRIPTION
## Description
Discovered that this field was missing. Exists in the data and the documentation

## Release Notes
Add missing field (DueDate) on CreditNotes (same as Invoices)

## Types of Changes

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
