### PR TITLE
Batch Payment code can be up to 255

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -19787,7 +19787,7 @@ components:
         Code:
           description: (NZ Only) Optional references for the batch payment transaction. It will also show with the batch payment transaction in the bank reconciliation Find & Match screen. Depending on your individual bank, the detail may also show on the bank statement you import into Xero. 
           type: string
-          maxLength: 12
+          maxLength: 255
         Details:
           description: (Non-NZ Only) These details are sent to the org’s bank as a reference for the batch payment transaction. They will also show with the batch payment transaction in the bank reconciliation Find & Match screen. Depending on your individual bank, the detail may also show on the bank statement imported into Xero. Maximum field length = 18
           type: string


### PR DESCRIPTION
Batch payments can be created w/ a code up to 255, but the OAS code length was set to max 12 chars

## Description
Ups the deserialization ability to 255 chars

## Release Notes
Bug found in sample app work, while debugging an issue raised by an app partner

## Screenshots (if appropriate):
<img width="852" alt="Screen Shot 2020-11-17 at 10 55 20 AM" src="https://user-images.githubusercontent.com/2935387/99428259-a1031680-28c3-11eb-9b55-58277c154f0f.png">
<img width="717" alt="Screen Shot 2020-11-17 at 10 53 27 AM" src="https://user-images.githubusercontent.com/2935387/99428265-a3657080-28c3-11eb-848c-1cdaa7c95c57.png">

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)