### PR TITLE
Add TwiceMonthly value to NZ Payroll Payruns CalendarTypeEnum

### DIFF
--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -6177,6 +6177,7 @@ components:
           enum:
           - Weekly
           - Fortnightly
+          - TwiceMonthly
           - FourWeekly
           - Monthly
           - Annual

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -6177,11 +6177,11 @@ components:
           enum:
           - Weekly
           - Fortnightly
-          - TwiceMonthly
           - FourWeekly
           - Monthly
           - Annual
           - Quarterly
+          - TwiceMonthly
         postedDateTime:
           description: Posted date time of the pay run
           type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
Appended a new value `TwiceMonthly` to the `calendarType` enum in the specification.

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
The values of the CalendarTypeEnum were incorrect. The Api was returning the value 'TwiceMonthly'. The enum did not have this value.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/XeroAPI/Xero-NetStandard/issues/256

## Screenshots (if appropriate):
<img width="303" alt="Screenshot 2020-11-20 121144" src="https://user-images.githubusercontent.com/74579854/99743775-7cf53e80-2b2a-11eb-951b-451c0c49eb1f.png">
Deserializes the correct enum value for the `CalendarType` property.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
