### PR TITLE
Fix payrollnz taxsettings periodunit int to decimal

### DIFF
--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -6177,6 +6177,7 @@ components:
           enum:
           - Weekly
           - Fortnightly
+          - TwiceMonthly
           - FourWeekly
           - Monthly
           - Annual

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -6642,8 +6642,9 @@ components:
       properties:
         periodUnits:
           description: The number of units for the period type
-          type: integer
-          format: int32
+          type: number
+          format: double
+          x-is-money: true
         periodType:
           description: The type of period ("weeks" or "months")
           type: string

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -6177,11 +6177,11 @@ components:
           enum:
           - Weekly
           - Fortnightly
-          - TwiceMonthly
           - FourWeekly
           - Monthly
           - Annual
           - Quarterly
+          - TwiceMonthly
         postedDateTime:
           description: Posted date time of the pay run
           type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated SDK to version 3.9.0

## Release Notes
### Payroll NZ API
- Now refers to CalendarType class for enum options.
- Periodunit type changed from int to decimal

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
