### PR TITLE
fixed ReportFields' FieldID type change from uuid to string

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23139,7 +23139,6 @@ components:
       properties:
         FieldID:
           type: string
-          format: uuid
         Description:
           type: string
         Value:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
FieldID in ReportFields is an uuid but the API returns a string. This results the report response (GetReportBASorGST) unable to be deserialised. 

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FieldID in ReportFields is changed from uuid to string

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/41350731/101121670-cc685e00-3644-11eb-9cdb-b10282dee644.png)


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
