### PR TITLE
included "invalid-end-date" in Error type ENUM list

### DIFF
--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -835,6 +835,7 @@ components:
           - "invalid-start-date"
           - "internal-error"
           - "feed-already-connected-in-current-organisation"
+          - "invalid-end-date"
           example: "invalid-application"
     CreditDebitIndicator:
       type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bankfeed Error object is missing "invalid-end-date" type

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This adds the missing enum option in.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/41350731/101304293-11ce9a80-3894-11eb-9b6f-94e1888af317.png)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
