### PR TITLE
Added missing invalid-end-date to bankfeeds Error enum and added missing CISDeduction and CISRate to Accounting

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -20173,6 +20173,8 @@ components:
         Rate:
           description: CIS Deduction rate for the contact if he is a subcontractor. If the contact is not CISEnabled, then the rate is not returned
           type: number
+          format: double
+          x-is-money: true 
     CISOrgSetting:
       externalDocs:
         url: 'https://developer.xero.com/documentation/api/organisation'
@@ -20186,6 +20188,8 @@ components:
         Rate:
           description: CIS Deduction rate for the organisation
           type: number
+          format: double
+          x-is-money: true 
     ContactPerson:
       externalDocs:
         url: 'http://developer.xero.com/documentation/api/contacts/'
@@ -20317,6 +20321,8 @@ components:
         CISRate:
           description: CIS Deduction rate for the organisation
           type: number
+          format: double
+          x-is-money: true 
         UpdatedDateUTC:
           description: UTC timestamp of last update to the credit note
           type: string
@@ -21046,6 +21052,8 @@ components:
         CISRate:
           description: CIS Deduction rate for the organisation
           type: number
+          format: double
+          x-is-money: true 
         SubTotal:
           description: Total of invoice excluding taxes
           readOnly: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -20172,7 +20172,7 @@ components:
           type: boolean
         Rate:
           description: CIS Deduction rate for the contact if he is a subcontractor. If the contact is not CISEnabled, then the rate is not returned
-          type: integer
+          type: number
     CISOrgSetting:
       externalDocs:
         url: 'https://developer.xero.com/documentation/api/organisation'
@@ -20185,7 +20185,7 @@ components:
           type: boolean
         Rate:
           description: CIS Deduction rate for the organisation
-          type: integer
+          type: number
     ContactPerson:
       externalDocs:
         url: 'http://developer.xero.com/documentation/api/contacts/'
@@ -20316,7 +20316,7 @@ components:
           x-is-money: true
         CISRate:
           description: CIS Deduction rate for the organisation
-          type: integer
+          type: number
         UpdatedDateUTC:
           description: UTC timestamp of last update to the credit note
           type: string
@@ -21045,7 +21045,7 @@ components:
           x-is-money: true
         CISRate:
           description: CIS Deduction rate for the organisation
-          type: integer
+          type: number
         SubTotal:
           description: Total of invoice excluding taxes
           readOnly: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -20174,6 +20174,7 @@ components:
           description: CIS Deduction rate for the contact if he is a subcontractor. If the contact is not CISEnabled, then the rate is not returned
           type: number
           format: double
+          readOnly: true
           x-is-money: true 
     CISOrgSetting:
       externalDocs:
@@ -20189,6 +20190,7 @@ components:
           description: CIS Deduction rate for the organisation
           type: number
           format: double
+          readOnly: true
           x-is-money: true 
     ContactPerson:
       externalDocs:
@@ -20322,6 +20324,7 @@ components:
           description: CIS Deduction rate for the organisation
           type: number
           format: double
+          readOnly: true
           x-is-money: true 
         UpdatedDateUTC:
           description: UTC timestamp of last update to the credit note
@@ -21053,6 +21056,7 @@ components:
           description: CIS Deduction rate for the organisation
           type: number
           format: double
+          readOnly: true
           x-is-money: true 
         SubTotal:
           description: Total of invoice excluding taxes

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -20314,6 +20314,9 @@ components:
           type: number
           format: double
           x-is-money: true
+        CISRate:
+          description: CIS Deduction rate for the organisation
+          type: integer
         UpdatedDateUTC:
           description: UTC timestamp of last update to the credit note
           type: string
@@ -21040,6 +21043,9 @@ components:
           type: number
           format: double
           x-is-money: true
+        CISRate:
+          description: CIS Deduction rate for the organisation
+          type: integer
         SubTotal:
           description: Total of invoice excluding taxes
           readOnly: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -20308,6 +20308,12 @@ components:
           type: number
           format: double
           x-is-money: true
+        CISDeduction:
+          description: CIS deduction for UK contractors
+          readOnly: true
+          type: number
+          format: double
+          x-is-money: true
         UpdatedDateUTC:
           description: UTC timestamp of last update to the credit note
           type: string

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -835,6 +835,7 @@ components:
           - "invalid-start-date"
           - "internal-error"
           - "feed-already-connected-in-current-organisation"
+          - "invalid-end-date"
           example: "invalid-application"
     CreditDebitIndicator:
       type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added missing <i>invalid-end-date</i> to bankfeeds Error enum and added missing <i>CISDeduction</i> and <i>CISRate</i> to Accounting.

## Description
<!--- Describe your changes in detail -->
CISDeduction added to CreditNote, CISRate added to both CreditNote and Invoice in Accounting. 
CISRate has been changed to decimal and set as readOnly.

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This adds missing values to schemas.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
