### PR TITLE
PayrollNZ SalaryAndWage DaysPerWeek, change from integer to double x-is-money

### DIFF
--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -6070,8 +6070,8 @@ components:
           x-is-money: true 
         daysPerWeek:
           description: The days per week for the salary.
-          type: integer
-          format: int32
+          type: number
+          format: double
         effectiveFrom:
           description: The effective date of the corresponding salary and wages
           type: string

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -6072,6 +6072,7 @@ components:
           description: The days per week for the salary.
           type: number
           format: double
+          x-is-money: true
         effectiveFrom:
           description: The effective date of the corresponding salary and wages
           type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The API may return a decimal value for this field, e.g. `7.000`
Changed the type so that this will be correctly deserialised.
Using `x-is-money` for consistency with other fields in this schema.

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Provides a fix for: https://github.com/XeroAPI/Xero-NetStandard/issues/264

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
