### PR TITLE
Add x-example and language specific param examples to generate htmlDoc2

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -17357,6 +17357,7 @@ paths:
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.now()"
           php: "new DateTime('2019-12-10')"
+          python: "dateutil.parser.parse('2020-10-10T00:00:00Z')"
         - user:
           is_object: true
           key: user
@@ -17386,6 +17387,7 @@ paths:
           default: Foobar
           object: receipt
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -14222,6 +14222,7 @@ paths:
           key: contact
           keyPascal: Contact
         - contactID:
+          is_last: true
           is_uuid: true
           key: contactId
           keyPascal: ContactID
@@ -14268,11 +14269,14 @@ paths:
           is_list_add: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
+          python: line_item
           object: lineItem
         - purchaseOrder:
           is_object: true
           key: purchaseOrder
           keyPascal: PurchaseOrder
+          keySnake: purchase_order
         - set_contact:
           is_variable: true
           nonString: true
@@ -14290,6 +14294,7 @@ paths:
           python: line_items
           object: purchaseOrder
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date
@@ -14302,6 +14307,7 @@ paths:
           key: purchaseOrders
           keyPascal: PurchaseOrders
         - add_purchaseOrder:
+          is_last: true
           is_array_add: true
           key: purchaseOrders
           keyPascal: PurchaseOrders

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22493,45 +22493,54 @@ paths:
       x-node-requestBody: '{ taxRates: [{ name: "State Tax NY", taxComponents: [{ name: "State Tax", rate: 2.25 }], status: TaxRate.StatusEnum.DELETED, reportTaxType: TaxRate.ReportTaxTypeEnum.INPUT }]}'
       x-ruby-requestBody: 'tax_rates = { tax_rates: [{ name: "State Tax NY", tax_components: [{ name: "State Tax", rate: 2.25 }], status: XeroRuby::Accounting::TaxRate::Deleted, report_tax_type: XeroRuby::Accounting::TaxRate::INPUT }]}'
       x-example:
-        - taxRates:
-          is_array: true
-          key: taxRates
-          keyPascal: TaxRates
-        - taxRate:
-          is_object: true
-          key: taxRate
-          keyPascal: TaxRate
-        - name:
-          key: name
-          keyPascal: Name
-          default: CA State Tax
-          object: taxRate
         - taxComponent:
           is_object: true
           key: taxComponent
           keyPascal: TaxComponent
+          keySnake: tax_component
         - name:
           key: name
           keyPascal: Name
           default: State Tax
           object: taxComponent
         - rate:
+          is_last: true
           nonString: true
           key: rate
           keyPascal: Rate
           default: 2.25
           object: taxComponent
+        - taxRate:
+          is_object: true
+          key: taxRate
+          keyPascal: TaxRate
+          keySnake: tax_rate
+        - name:
+          key: name
+          keyPascal: Name
+          default: CA State Tax
+          object: taxRate
         - add_taxComponent:
+          is_last: true
           is_array_add: true
           key: taxRate
           keyPascal: TaxComponents
+          keySnake: tax_components
           java: TaxComponents
+          python: tax_component
           object: taxComponent
+        - taxRates:
+          is_object: true
+          key: taxRates
+          keyPascal: TaxRates
         - add_taxRate:
+          is_last: true
           is_array_add: true
           key: taxRates
           keyPascal: TaxRates
+          keySnake: tax_rates
           java: TaxRates
+          python: tax_rate
           object: taxRate
       responses:
         '200':
@@ -22756,6 +22765,7 @@ paths:
           key: trackingCategory
           keyPascal: TrackingCategory
         - name:
+          is_last: true
           key: name
           keyPascal: Name
           default: Foobar
@@ -22920,6 +22930,7 @@ paths:
           key: trackingOption
           keyPascal: TrackingOption
         - name:
+          is_last: true
           key: name
           keyPascal: Name
           default: Foobar

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1593,47 +1593,23 @@ paths:
       x-node-requestBody: '{ bankTransactions: [{ type: BankTransaction.TypeEnum.SPEND, contact: { contactId: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "000" }], bankAccount: { code: "000" }}]}'
       x-ruby-requestBody: 'bank_transactions = { bank_transactions: [{ type: XeroRuby::Accounting::BankTransaction::SPEND, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unit_amount: 20.0, account_code: "000" }], bank_account: { code: "000" }}]}'
       x-example:
-        - bankTransactions:
-          is_array: true
-          key: bankTransactions
-          keyPascal: BankTransactions
-        - bankTransaction:
-          is_object: true
-          key: bankTransaction
-          keyPascal: BankTransaction
-        - type:
-          nonString: true
-          key: type
-          keyPascal: Type
-          default: SPEND
-          php: XeroAPI\XeroPHP\Models\Accounting\BankTransaction::TYPE_SPEND
-          node: BankTransaction.TypeEnum.SPEND
-          ruby: XeroRuby::Accounting::BankTransaction::SPEND
-          python: AccountType.EXPENSE
-          java: com.xero.models.accounting.BankTransaction.TypeEnum.SPEND
-          csharp: Account.ClassEnum.EXPENSE
-          object: bankTransaction
         - contact:
           is_object: true
           key: contact
           keyPascal: Contact
         - contactID:
           is_uuid: true
+          is_last: true
           key: contactId
           keyPascal: ContactID
+          keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - set_contact:
-          is_variable: true
-          nonString: true
-          key: contact
-          keyPascal: Contact
-          default: contact
-          object: bankTransaction
         - lineItem:
           is_object: true
           key: lineItem
           keyPascal: LineItem
+          keySnake: line_item
         - description:
           key: description
           keyPascal: Description
@@ -1649,41 +1625,83 @@ paths:
           nonString: true
           key: unitAmount
           keyPascal: UnitAmount
+          keySnake: unit_amount
           default: 20.0
           object: lineItem
         - accountCode:
+          is_last: true
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: "000"
-          object: lineItem
-        - add_lineitems:
-          is_array_add: true
-          key: bankTransaction
-          keyPascal: LineItems
-          java: LineItems
           object: lineItem
         - bankAccount:
           is_object: true
           key: bankAccount
           keyPascal: Account
+          keySnake: bank_account
         - accountID:
+          is_last: true
           is_uuid: true
           key: accountID
           keyPascal: AccountID
+          keySnake: account_id
           default: 00000000-0000-0000-000-000000000000
           object: bankAccount
+        - bankTransaction:
+          is_object: true
+          key: bankTransaction
+          keyPascal: BankTransaction
+          keySnake: bank_transaction
+        - type:
+          nonString: true
+          key: type
+          keyPascal: Type
+          default: RECEIVE
+          php: XeroAPI\XeroPHP\Models\Accounting\BankTransaction::TYPE_RECEIVE
+          node: BankTransaction.TypeEnum.RECEIVE
+          ruby: XeroRuby::Accounting::BankTransaction::RECEIVE
+          python_string: RECEIVE
+          java: com.xero.models.accounting.BankTransaction.TypeEnum.RECEIVE
+          csharp: BankTransaction.TypeEnum.RECEIVE
+          object: bankTransaction
+        - set_contact:
+          is_variable: true
+          nonString: true
+          key: contact
+          keyPascal: Contact
+          default: contact
+          object: bankTransaction
+        - add_lineitems:
+          is_array_add: true
+          key: bankTransaction
+          keyPascal: LineItems
+          keySnake: line_items
+          java: LineItems
+          python: line_item
+          object: lineItem
         - set_bankaccount:
+          is_last: true
           is_variable: true
           nonString: true
           key: bankAccount
           keyPascal: BankAccount
+          keySnake: bank_account
+          python: bank_account
           default: bankAccount
           object: bankTransaction
+        - bankTransactions:
+          is_object: true
+          key: bankTransactions
+          keyPascal: BankTransactions
         - add_bankTransaction:
+          is_last: true
           is_array_add: true
           key: bankTransactions
           keyPascal: BankTransactions
+          keySnake: bank_transactions
           java: BankTransactions
+          python: bank_transaction
           object: bankTransaction
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -12778,6 +12778,7 @@ paths:
           key: payments
           keyPascal: Payments
         - add_payment:
+          is_last: true
           is_array_add: true
           key: payments
           keyPascal: Payments
@@ -12974,6 +12975,7 @@ paths:
           key: payments
           keyPascal: Payments
         - add_payment:
+          is_last: true
           is_array_add: true
           key: payments
           keyPascal: Payments
@@ -13457,30 +13459,36 @@ paths:
       x-node-requestBody: '{ paymentServices: [{ paymentServiceName: "PayUpNow", paymentServiceUrl: "https://www.payupnow.com/", payNowText: "Time To Pay" }]}'
       x-ruby-requestBody: 'payment_services = { payment_services: [{ payment_service_name: "PayUpNow", payment_service_url: "https://www.payupnow.com/", pay_now_text: "Time To Pay" }]}'
       x-example:
-        - paymentServices:
-          is_array: true
-          key: paymentServices
-          keyPascal: PaymentServices
         - object:
           is_object: true
           key: paymentService
           keyPascal: PaymentService
+          keySnake: payment_service
         - paymentServiceName:
           key: paymentServiceName
           keyPascal: PaymentServiceName
+          keySnake: payment_service_name
           default: ACME Payments
           object: paymentService
         - paymentServiceUrl:
           key: paymentServiceUrl
           keyPascal: PaymentServiceUrl
+          keySnake: payment_service_url
           default: "https://www.payupnow.com/"
           object: paymentService
         - payNowText:
+          is_last: true
           key: payNowText
           keyPascal: PayNowText
+          keySnake: pay_now_text
           default: Pay Now
           object: paymentService
+        - paymentServices:
+          is_object: true
+          key: paymentServices
+          keyPascal: PaymentServices
         - add_paymentService:
+          is_last: true
           is_array_add: true
           key: paymentServices
           keyPascal: PaymentServices

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3423,7 +3423,7 @@ paths:
         - in: query
           name: where
           description: Filter by an any element
-          example: ContactStatus=='ACTIVE'
+          example: ContactStatus==&quot;ACTIVE&quot;
           x-example-java: ContactStatus==&quot;&apos; + Contact.ContactStatusEnum.ACTIVE + &apos;&quot;
           x-example-php: ContactStatus==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Contact::CONTACT_STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: ContactStatus==#{XeroRuby::Accounting::Contact::ACTIVE}

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -10929,7 +10929,7 @@ paths:
           keyPascal: JournalLines
           keySnake: journal_lines
           default: manualJournalLines
-          python: manual_journal
+          python: manual_journal_line
           object: manualJournal
         - manualJournals:
           is_object: true
@@ -10944,7 +10944,7 @@ paths:
           keySnake: manual_journals
           java: ManualJournals
           php: manualJournals
-          python: manual_journals
+          python: manual_journal
           object: manualJournal
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -16675,39 +16675,40 @@ paths:
       x-node-requestBody: '{ receipts: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 2.0, unitAmount: 20.0, accountCode: "400", taxType: TaxType.NONE, lineAmount: 40.0 }], user: { userID: "00000000-0000-0000-000-000000000000" }, lineAmountTypes: LineAmountTypes.Inclusive, status: Receipt.StatusEnum.DRAFT, date: null} ] }'
       x-ruby-requestBody: 'receipts = { receipts: [ { contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 2.0, unit_amount: 20.0, account_code: "400", tax_type: XeroRuby::Accounting::TaxType::NONE, line_amount: 40.0 }], user: { user_id: "00000000-0000-0000-000-000000000000" }, line_amount_types: XeroRuby::Accounting::INCLUSIVE, status: XeroRuby::Accounting::Receipt::DRAFT, date: nil }]}'
       x-example:
-        - receipts:
-          is_array: true
-          key: receipts
-          keyPascal: Receipts
-        - receipt:
-          is_object: true
-          key: receipt
-          keyPascal: Receipt
         - contact:
           is_object: true
           key: contact
           keyPascal: Contact
         - contactID:
+          is_last: true
           is_uuid: true
           key: contactId
           keyPascal: ContactID
+          keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - set_contact:
-          is_variable: true
-          nonString: true
-          key: contact
-          keyPascal: Contact
-          default: contact
-          object: receipt
+        - user:
+          is_object: true
+          key: user
+          keyPascal: User
+        - userID:
+          is_last: true
+          is_uuid: true
+          key: userID
+          keyPascal: UserID
+          keySnake: user_id
+          default: 00000000-0000-0000-000-000000000000
+          object: user
         - lineItems:
           is_list: true
           key: lineItems
           keyPascal: LineItem
+          keySnake: line_items
         - lineItem:
           is_object: true
           key: lineItem
           keyPascal: LineItem
+          keySnake: line_item
         - description:
           key: description
           keyPascal: Description
@@ -16723,41 +16724,48 @@ paths:
           nonString: true
           key: unitAmount
           keyPascal: UnitAmount
+          keySnake: unit_amount
           default: 20.0
           object: lineItem
         - accountCode:
+          is_last: true
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: "000"
           object: lineItem
         - add_lineitems:
+          is_last: true
           is_list_add: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           object: lineItem
-        - set_lineitem:
+          python: line_item
+        - receipt:
+          is_object: true
+          key: receipt
+          keyPascal: Receipt
+        - set_contact:
           is_variable: true
           nonString: true
-          key: lineItems
-          keyPascal: LineItems
-          default: lineItems
+          key: contact
+          keyPascal: Contact
+          default: contact
           object: receipt
-        - user:
-          is_object: true
-          key: user
-          keyPascal: User
-        - userID:
-          is_uuid: true
-          key: userID
-          keyPascal: UserID
-          default: 00000000-0000-0000-000-000000000000
-          object: user
         - set_user:
           is_variable: true
           nonString: true
           key: user
           keyPascal: User
           default: user
+          object: receipt
+        - set_lineitem:
+          is_variable: true
+          nonString: true
+          key: lineItems
+          keyPascal: LineItems
+          default: lineItems
           object: receipt
         - lineAmountTypes:
           nonString: true
@@ -16767,11 +16775,12 @@ paths:
           php: XeroAPI\XeroPHP\Models\Accounting\LineAmountTypes::INCLUSIVE
           node: LineAmountTypes.Inclusive
           ruby: XeroRuby::Accounting::INCLUSIVE
-          python: LineAmountTypes.xxx
+          python_string: INCLUSIVE
           java: com.xero.models.accounting.LineAmountTypes.INCLUSIVE
           csharp: LineAmountTypes.xxx
           object: receipt
         - status:
+          is_last: true
           nonString: true
           key: status
           keyPascal: Status
@@ -16779,11 +16788,16 @@ paths:
           php: XeroAPI\XeroPHP\Models\Accounting\Receipt::STATUS_DRAFT
           node: Receipt.StatusEnum.DRAFT
           ruby: XeroRuby::Accounting::Receipt::DRAFT
-          python: Receipt.xxx
+          python_string: DRAFT
           java: com.xero.models.accounting.Receipt.StatusEnum.DRAFT
           csharp: Receipt.xxx
           object: receipt
+        - receipts:
+          is_object: true
+          key: receipts
+          keyPascal: Receipts
         - add_receipt:
+          is_last: true
           is_array_add: true
           key: receipts
           keyPascal: Receipts

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -10828,38 +10828,21 @@ paths:
       x-node-requestBody: '{ manualJournals: [{ narration: "Foo bar", date: "2019-03-14", journalLines: [{ lineAmount: 100.0, accountCode: "400", description: "Hello there" }, { lineAmount: -100.0, accountCode: "400", description: "Goodbye", tracking: [{ name: "Simpson", option: "Bart" }] }]}]}'
       x-ruby-requestBody: 'manual_journals = { manual_journals: [{ narration: "Foo bar", date: "2019-03-14", journal_lines: [{ line_amount: 100.0, account_code: "400", description: "Hello there" }, { line_amount: -100.0, account_code: "400", description: "Goodbye", tracking: [{ name: "Simpson", option: "Bart" }] }]}]}'
       x-example:
-        - manualJournals:
-          is_array: true
-          key: manualJournals
-          keyPascal: ManualJournals
-        - manualJournal:
-          is_object: true
-          key: manualJournal
-          keyPascal: ManualJournal
-        - narration:
-          key: narration
-          keyPascal: Narration
-          default: Foobar
-          object: manualJournal
         - dateValue:
           is_date: true
           key: dateValue
           keyPascal: Date
+          keySnake: date_value
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.of(2020, Month.OCTOBER, 10)"
           php: "new DateTime('2019-10-10')"
-        - date:
-          is_variable: true
-          nonString: true
-          key: date
-          keyPascal: Date
-          default: dateValue
-          object: manualJournal
+          python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
         - manualJournalLines:
           is_list: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
+          keySnake: manual_journal_lines
         - credit:
           is_object: true
           key: credit
@@ -10868,11 +10851,13 @@ paths:
           nonString: true
           key: lineAmount
           keyPascal: LineAmount
+          keySnake: line_amount
           default: 100.0
           object: credit
         - accountCode:
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: 400
           object: credit
         - description:
@@ -10881,6 +10866,7 @@ paths:
           default: "Hello there"
           object: credit
         - add_credit:
+          is_last: true
           is_list_add: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
@@ -10893,11 +10879,13 @@ paths:
           nonString: true
           key: lineAmount
           keyPascal: LineAmount
+          keySnake: line_amount
           default: -100.0
           object: debit
         - accountCode:
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: 120
           object: debit
         - description:
@@ -10906,23 +10894,53 @@ paths:
           default: "Hello there"
           object: debit
         - add_debit:
+          is_last: true
           is_list_add: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
           object: debit
+        - manualJournal:
+          is_object: true
+          key: manualJournal
+          keyPascal: ManualJournal
+          keySnake: manual_journal
+        - narration:
+          key: narration
+          keyPascal: Narration
+          default: Foobar
+          object: manualJournal
+        - date:
+          is_variable: true
+          nonString: true
+          key: date
+          keyPascal: Date
+          default: dateValue
+          python: date_value
+          object: manualJournal
         - set_manualJournalLines:
+          is_last: true
           is_variable: true
           nonString: true
           key: manualJournalLines
           keyPascal: JournalLines
+          keySnake: journal_lines
           default: manualJournalLines
+          python: manual_journal
           object: manualJournal
+        - manualJournals:
+          is_object: true
+          key: manualJournals
+          keyPascal: ManualJournals
+          keySnake: manual_journals
         - add_manualJournal:
+          is_last: true
           is_array_add: true
           key: manualJournals
           keyPascal: ManualJournals
+          keySnake: manual_journals
           java: ManualJournals
           php: manualJournals
+          python: manual_journals
           object: manualJournal
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -16780,7 +16780,7 @@ paths:
           php: XeroAPI\XeroPHP\Models\Accounting\LineAmountTypes::INCLUSIVE
           node: LineAmountTypes.Inclusive
           ruby: XeroRuby::Accounting::INCLUSIVE
-          python_string: LineAmountTypes.INCLUSIVE
+          python: LineAmountTypes.INCLUSIVE
           java: com.xero.models.accounting.LineAmountTypes.INCLUSIVE
           csharp: LineAmountTypes.xxx
           object: receipt
@@ -22143,6 +22143,7 @@ paths:
           is_object: true
           key: taxRate
           keyPascal: TaxRate
+          keySnake: tax_rate
         - name:
           key: name
           keyPascal: Name

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -7286,10 +7286,6 @@ paths:
       x-node-requestBody: '{ employees: [{ firstName: "Nick", lastName: "Fury", externalLink: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
       x-ruby-requestBody: 'employees = { employees: [{ first_name: "Nick", last_name: "Fury", external_link: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
       x-example:
-        - employees:
-          is_array: true
-          key: employees
-          keyPascal: Employees
         - employee:
           is_object: true
           key: employee
@@ -7297,14 +7293,22 @@ paths:
         - firstName:
           key: firstName
           keyPascal: FirstName
+          keySnake: first_name
           default: Nick
           object: employee
         - lastName:
+          is_last: true
           key: lastName
           keyPascal: LastName
+          keySnake: last_name
           default: Fury
           object: employee
+        - employees:
+          is_object: true
+          key: employees
+          keyPascal: Employees
         - add_employee:
+          is_last: true
           is_array_add: true
           key: employees
           keyPascal: Employees
@@ -8639,81 +8643,43 @@ paths:
       x-node-requestBody: '{ invoices: [{ type: Invoice.TypeEnum.ACCREC, contact: { contactID:"00000000-0000-0000-000-000000000000" }, lineItems:[ { description:"Acme Tires", quantity:2.0, unitAmount:20.0, accountCode:"200", taxType:"NONE", lineAmount:40.0 } ], date: "2019-03-11", dueDate:"2018-12-10", reference:"Website Design", status: Invoice.StatusEnum.AUTHORISED } ] }'
       x-ruby-requestBody: 'invoices = { invoices: [{ type: XeroRuby::Accounting::Invoice::ACCREC, contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Acme Tires", quantity: 2.0, unit_amount: 20.0, account_code: "000", tax_type: XeroRuby::Accounting::TaxType::NONE, line_amount: 40.0 }], date: "2019-03-11", due_date: "2018-12-10", reference: "Website Design", status: XeroRuby::Accounting::Invoice::DRAFT }]}'
       x-example:
-        - invoices:
-          is_array: true
-          key: invoices
-          keyPascal: Invoices
-        - invoice:
-          is_object: true
-          key: invoice
-          keyPascal: Invoice
-        - type:
-          nonString: true
-          key: type
-          keyPascal: Type
-          default: ACCREC
-          php: XeroAPI\XeroPHP\Models\Accounting\Invoice::TYPE_ACCREC
-          node: Invoice.TypeEnum.ACCREC
-          ruby: XeroRuby::Accounting::Invoice::ACCREC
-          python: Invoice.xxx
-          java: com.xero.models.accounting.Invoice.TypeEnum.ACCREC
-          csharp: Invoice.xxx
-          object: invoice
+        - dateValue:
+          is_date: true
+          key: dateValue
+          keyPascal: Date
+          keySnake: date_value
+          java_datatype: LocalDate
+          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
+          java: "LocalDate.of(2020, Month.OCTOBER, 10)"
+          php: "new DateTime('2020-10-10')"
+          python: "dateutil.parser.parse('2020-10-10T00:00:00Z')"
+        - dueDateValue:
+          is_date: true
+          key: dueDateValue
+          keyPascal: Date
+          keySnake: due_date_value
+          java_datatype: LocalDate
+          default: "LocalDate.of(2020, Month.OCTOBER, 28)"
+          java: "LocalDate.of(2020, Month.OCTOBER, 28)"
+          php: "new DateTime('2020-10-28')"
+          python: "dateutil.parser.parse('2020-10-28T00:00:00Z')"
         - contact:
           is_object: true
           key: contact
           keyPascal: Contact
         - contactID:
+          is_last: true
           is_uuid: true
           key: contactId
           keyPascal: ContactID
+          keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - set_contact:
-          is_variable: true
-          nonString: true
-          key: contact
-          keyPascal: Contact
-          default: contact
-          object: invoice
-        - dateValue:
-          is_date: true
-          key: dateValue
-          keyPascal: Date
-          java_datatype: LocalDate
-          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          java: "LocalDate.now()"
-          php: "new DateTime('2020-12-10')"
-        - date:
-          is_variable: true
-          nonString: true
-          key: date
-          keyPascal: Date
-          default: dateValue
-          object: invoice
-        - dueDateValue:
-          is_date: true
-          key: dueDateValue
-          keyPascal: Date
-          java_datatype: LocalDate
-          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          java: "LocalDate.now()"
-          php: "new DateTime('2020-12-10')"
-        - dueDate:
-          is_variable: true
-          nonString: true
-          key: date
-          keyPascal: Date
-          default: dueDateValue
-          object: invoice
-        - lineItems:
-          is_list: true
-          key: lineItems
-          keyPascal: LineItem
         - lineItem:
           is_object: true
           key: lineItem
           keyPascal: LineItem
+          keySnake: line_item
         - description:
           key: description
           keyPascal: Description
@@ -8729,24 +8695,77 @@ paths:
           nonString: true
           key: unitAmount
           keyPascal: UnitAmount
+          keySnake: unit_amount
           default: 20.0
           object: lineItem
         - accountCode:
+          is_last: true
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: "000"
           object: lineItem
+        - lineItems:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItem
+          keySnake: line_items
         - add_lineitems:
+          is_last: true
           is_list_add: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
+          python: line_item
           object: lineItem
+        - invoice:
+          is_object: true
+          key: invoice
+          keyPascal: Invoice
+        - type:
+          nonString: true
+          key: type
+          keyPascal: Type
+          default: ACCREC
+          php: XeroAPI\XeroPHP\Models\Accounting\Invoice::TYPE_ACCREC
+          node: Invoice.TypeEnum.ACCREC
+          ruby: XeroRuby::Accounting::Invoice::ACCREC
+          python_string: ACCREC
+          java: com.xero.models.accounting.Invoice.TypeEnum.ACCREC
+          csharp: Invoice.xxx
+          object: invoice
+        - set_contact:
+          is_variable: true
+          nonString: true
+          key: contact
+          keyPascal: Contact
+          default: contact
+          object: invoice
+        - date:
+          is_variable: true
+          nonString: true
+          key: date
+          keyPascal: Date
+          default: dateValue
+          python: date_value
+          object: invoice
+        - dueDate:
+          is_variable: true
+          nonString: true
+          key: dueDate
+          keyPascal: Date
+          keySnake: due_date
+          default: dueDateValue
+          python: due_date_value
+          object: invoice
         - set_lineitem:
           is_variable: true
           nonString: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           default: lineItems
+          python: line_items
           object: invoice
         - reference:
           key: reference
@@ -8754,6 +8773,7 @@ paths:
           default: Website Design
           object: invoice
         - status:
+          is_last: true
           nonString: true
           key: status
           keyPascal: Status
@@ -8761,11 +8781,16 @@ paths:
           php: XeroAPI\XeroPHP\Models\Accounting\Invoice::STATUS_DRAFT
           node: Invoice.StatusEnum.DRAFT
           ruby: XeroRuby::Accounting::Invoice::DRAFT
-          python: Invoice.xxx
+          python_string: DRAFT 
           java: com.xero.models.accounting.Invoice.StatusEnum.DRAFT
           csharp: Invoice.xxx
           object: invoice
+        - invoices:
+          is_object: true
+          key: invoices
+          keyPascal: Invoices
         - add_invoice:
+          is_last: true
           is_array_add: true
           key: invoices
           keyPascal: Invoices
@@ -9930,10 +9955,6 @@ paths:
       x-node-requestBody: '{ items: [{ code: "ItemCode123", name: "ItemName XYZ", description: "Item Description ABC" }]}'
       x-ruby-requestBody: 'items = { items: [{ code: "ItemCode123", name: "ItemName XYZ", description: "Item Description ABC" }]}'
       x-example:
-        - items:
-          is_array: true
-          key: items
-          keyPascal: Items
         - item:
           is_object: true
           key: item
@@ -9953,7 +9974,12 @@ paths:
           keyPascal: Description
           default: Foobar
           object: item
+        - items:
+          is_object: true
+          key: items
+          keyPascal: Items
         - add_item:
+          is_last: true
           is_array_add: true
           key: items
           keyPascal: Items

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -16699,11 +16699,6 @@ paths:
           keySnake: user_id
           default: 00000000-0000-0000-000-000000000000
           object: user
-        - lineItems:
-          is_list: true
-          key: lineItems
-          keyPascal: LineItem
-          keySnake: line_items
         - lineItem:
           is_object: true
           key: lineItem
@@ -16734,6 +16729,11 @@ paths:
           keySnake: account_code
           default: "000"
           object: lineItem
+        - lineItems:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItem
+          keySnake: line_items
         - add_lineitems:
           is_last: true
           is_list_add: true
@@ -16765,12 +16765,15 @@ paths:
           nonString: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           default: lineItems
+          python: line_items
           object: receipt
         - lineAmountTypes:
           nonString: true
           key: lineAmountTypes
           keyPascal: LineAmountTypes
+          keySnake: line_amount_types
           default: INCLUSIVE
           php: XeroAPI\XeroPHP\Models\Accounting\LineAmountTypes::INCLUSIVE
           node: LineAmountTypes.Inclusive

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -5563,6 +5563,7 @@ paths:
           keyPascal: LineItems
           keySnake: line_items
         - add_lineitems:
+          is_last: true
           is_list_add: true
           key: lineItems
           keyPascal: LineItems
@@ -7423,6 +7424,7 @@ paths:
           key: receipts
           keyPascal: Receipt
         - add_receipts:
+          is_last: true
           is_list_add: true
           key: receipts
           keyPascal: Receipts
@@ -10935,7 +10937,6 @@ paths:
           is_object: true
           key: manualJournals
           keyPascal: ManualJournals
-          keySnake: manual_journals
         - add_manualJournal:
           is_last: true
           is_array_add: true
@@ -12706,24 +12707,42 @@ paths:
       x-node-requestBody: '{ payments: [{ invoice: { invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }, account: { code: "970" }, date: "2019-03-12", amount: 1.0 }]}'
       x-ruby-requestBody: 'payments = { payments: [{ invoice: { invoice_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, type: XeroRuby::Accounting::Invoice::ACCPAY }, account: { code: "970" }, date: "2019-03-12", amount: 1.0 }]}'
       x-example:
-        - payments:
-          is_array: true
-          key: payments
-          keyPascal: Payments
-        - payment:
-          is_object: true
-          key: payment
-          keyPascal: Payment
+        - dateValue:
+          is_date: true
+          key: dateValue
+          keyPascal: Date
+          keySnake: date_value
+          java_datatype: LocalDate
+          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
+          java: "LocalDate.now()"
+          php: "new DateTime('2020-10-10')"
+          python: "dateutil.parser.parse('2020-10-10T00:00:00Z')"
         - invoice:
           is_object: true
           key: invoice
           keyPascal: Invoice
         - invoiceID:
+          is_last: true
           is_uuid: true
           key: invoiceID
           keyPascal: InvoiceID
           default: 00000000-0000-0000-000-000000000000
           object: invoice
+        - account:
+          is_object: true
+          key: account
+          keyPascal: Account
+        - accountID:
+          is_last: true
+          key: accountID
+          keyPascal: AccountID
+          keySnake: account_id
+          default: 00000000-0000-0000-000-000000000000
+          object: account
+        - payment:
+          is_object: true
+          key: payment
+          keyPascal: Payment
         - set_invoice:
           is_variable: true
           nonString: true
@@ -12731,15 +12750,6 @@ paths:
           keyPascal: Invoice
           default: invoice
           object: payment
-        - account:
-          is_object: true
-          key: account
-          keyPascal: Account
-        - accountID:
-          key: accountID
-          keyPascal: AccountID
-          default: 00000000-0000-0000-000-000000000000
-          object: account
         - set_account:
           is_variable: true
           nonString: true
@@ -12753,21 +12763,19 @@ paths:
           keyPascal: Amount
           default: 1.0
           object: payment
-        - dateValue:
-          is_date: true
-          key: dateValue
-          keyPascal: Date
-          java_datatype: LocalDate
-          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          java: "LocalDate.now()"
-          php: "new DateTime('2019-12-10')"
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date
           keyPascal: Date
           default: dateValue
+          python: date_value
           object: payment
+        - payments:
+          is_object: true
+          key: payments
+          keyPascal: Payments
         - add_payment:
           is_array_add: true
           key: payments

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22409,6 +22409,7 @@ paths:
           key: trackingCategory
           keyPascal: TrackingCategory
         - name:
+          is_last: true
           key: name
           keyPascal: Name
           default: Foobar
@@ -22599,6 +22600,7 @@ paths:
           key: trackingOption
           keyPascal: TrackingOption
         - name:
+          is_last: true
           key: name
           keyPascal: Name
           default: Foobar

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22152,7 +22152,7 @@ paths:
         - add_taxComponent:
           is_last: true
           is_array_add: true
-          key: taxComponents
+          key: taxRate
           keyPascal: TaxComponents
           keySnake: tax_components
           java: TaxComponents

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -916,6 +916,7 @@ paths:
           key: payments
           keyPascal: Payment
         - add_payments:
+          is_last: true
           is_list_add: true
           key: payments
           keyPascal: Payments
@@ -3647,6 +3648,7 @@ paths:
           key: phones
           keyPascal: Phone
         - add_phone:
+          is_last: true
           is_list_add: true
           key: phones
           keyPascal: Phones

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -12726,6 +12726,7 @@ paths:
           is_uuid: true
           key: invoiceID
           keyPascal: InvoiceID
+          keySnake: invoice_id
           default: 00000000-0000-0000-000-000000000000
           object: invoice
         - account:

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -14311,6 +14311,7 @@ paths:
           is_array_add: true
           key: purchaseOrders
           keyPascal: PurchaseOrders
+          keySnake: purchase_orders
           java: PurchaseOrders
           python: purchase_order
           object: purchaseOrder
@@ -15737,7 +15738,7 @@ paths:
           keyPascal: LineItems
           keySnake: line_items
           default: lineItems
-          python: line_item
+          python: line_items
           object: quote
         - date:
           is_last: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -17349,24 +17349,30 @@ paths:
       x-node-requestBody: '{ receipts: [{ user: { userID: "00000000-0000-0000-000-000000000000" }, reference: "Foobar", date: "2020-01-01", contact: {}, lineItems: [] }]}'
       x-ruby-requestBody: 'receipts = { receipts: [{ user: { user_id: "00000000-0000-0000-000-000000000000" }, reference: "Foobar", date: "2020-01-01", contact: {}, line_items: [] }]}'
       x-example:
-        - receipts:
-          is_array: true
-          key: receipts
-          keyPascal: Receipts
-        - receipt:
-          is_object: true
-          key: receipt
-          keyPascal: Receipt
+        - dateValue:
+          is_date: true
+          key: dateValue
+          keyPascal: Date
+          java_datatype: LocalDate
+          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
+          java: "LocalDate.now()"
+          php: "new DateTime('2019-12-10')"
         - user:
           is_object: true
           key: user
           keyPascal: User
         - userID:
+          is_last: true
           is_uuid: true
           key: userID
           keyPascal: UserID
+          keySnake: user_id
           default: 00000000-0000-0000-000-000000000000
           object: user
+        - receipt:
+          is_object: true
+          key: receipt
+          keyPascal: Receipt
         - set_user:
           is_variable: true
           nonString: true
@@ -17379,14 +17385,6 @@ paths:
           keyPascal: Reference
           default: Foobar
           object: receipt
-        - dateValue:
-          is_date: true
-          key: dateValue
-          keyPascal: Date
-          java_datatype: LocalDate
-          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          java: "LocalDate.now()"
-          php: "new DateTime('2019-12-10')"
         - date:
           is_variable: true
           nonString: true
@@ -17394,7 +17392,12 @@ paths:
           keyPascal: Date
           default: dateValue
           object: receipt
+        - receipts:
+          is_object: true
+          key: receipts
+          keyPascal: Receipts
         - add_receipt:
+          is_last: true
           is_array_add: true
           key: receipts
           keyPascal: Receipts

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -21849,17 +21849,6 @@ paths:
           key: accounts
           keyPascal: Accounts
           object: account
-        - Setup:
-          is_object: true
-          key: setup
-          keyPascal: Setup
-        - set_accounts:
-          is_variable: true
-          nonString: true
-          key: accounts
-          keyPascal: Accounts
-          default: accounts
-          object: setup
         - conversionDate:
           is_object: true
           key: conversionDate
@@ -21878,6 +21867,22 @@ paths:
           keyPascal: Year
           default: 2020
           object: conversionDate
+        - conversionBalances:
+          is_list: true
+          key: conversionBalances
+          keyPascal: ConversionBalances
+          keySnake: conversion_balances
+        - Setup:
+          is_object: true
+          key: setup
+          keyPascal: Setup
+        - set_accounts:
+          is_variable: true
+          nonString: true
+          key: accounts
+          keyPascal: Accounts
+          default: accounts
+          object: setup
         - set_conversionDate:
           is_variable: true
           nonString: true
@@ -21886,11 +21891,6 @@ paths:
           keySnake: conversion_date
           default: conversionDate
           object: setup
-        - conversionBalances:
-          is_list: true
-          key: conversionBalances
-          keyPascal: ConversionBalances
-          keySnake: conversion_balances
         - set_conversionBalances:
           is_last: true
           is_variable: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -27,7 +27,7 @@ paths:
         - in: query
           name: where
           description: Filter by an any element
-          example: Status=="' + Account.StatusEnum.ACTIVE + '" AND Type=="' + Account.BankAccountTypeEnum.BANK + '"
+          example: Status==&quot;ACTIVE&quot; AND Type==&quot;BANK&quot;
           x-example-java: Status==&quot;&apos; + Account.StatusEnum.ACTIVE+ &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Account::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Account::ACTIVE}

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -9970,6 +9970,7 @@ paths:
           default: HelloWorld
           object: item
         - description:
+          is_last: true
           key: description
           keyPascal: Description
           default: Foobar
@@ -15100,24 +15101,29 @@ paths:
       x-node-requestBody: '{ purchaseOrders:[ { attentionTo: "Peter Parker", lineItems: [], contact: {} }]}'
       x-ruby-requestBody: 'purchase_orders = { purchase_orders: [ { attention_to: "Peter Parker", line_items: [], contact: {} }]}'
       x-example:
-        - purchaseOrders:
-          is_array: true
-          key: purchaseOrders
-          keyPascal: PurchaseOrders
         - purchaseOrder:
           is_object: true
           key: purchaseOrder
           keyPascal: PurchaseOrder
+          keySnake: purchase_order
         - attentionTo:
+          is_last: true
           key: attentionTo
           keyPascal: AttentionTo
           default: Peter Parker
           object: purchaseOrder
+        - purchaseOrders:
+          is_object: true
+          key: purchaseOrders
+          keyPascal: PurchaseOrders
         - add_purchaseOrder:
+          is_last: true
           is_array_add: true
           key: purchaseOrders
           keyPascal: PurchaseOrders
+          keySnake: purchase_orders
           java: PurchaseOrders
+          python: purchase_order
           object: purchaseOrder
       parameters:
         - required: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -10491,16 +10491,20 @@ paths:
           is_object: true
           key: linkedTransaction
           keyPascal: LinkedTransaction
+          keySnake: linked_transaction
         - sourceTransactionID:
           is_uuid: true
           key: sourceTransactionID
           keyPascal: SourceTransactionID
+          keySnake: source_transaction_id
           default: 00000000-0000-0000-000-000000000000
           object: linkedTransaction
         - sourceLineItemID:
+          is_last: true
           is_uuid: true
           key: sourceLineItemID
           keyPascal: SourceLineItemID
+          keySnake: source_line_item_id
           default: 00000000-0000-0000-000-000000000000
           object: linkedTransaction
       responses:

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3504,9 +3504,9 @@ paths:
           description: Filter by a comma separated list of ContactIDs. Allows you to retrieve a specific set of contacts in a single call.
           style: form
           explode: false
-          example: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
-          x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"),UUID.fromString("00000000-0000-0000-000-000000000000"))
-          x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
+          example: '&quot;00000000-0000-0000-000-000000000000&quot;'
+          x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"))
+          x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;'
           schema:
             type: array
             items:
@@ -8128,9 +8128,9 @@ paths:
           description: Filter by a comma-separated list of InvoicesIDs. 
           style: form
           explode: false
-          example: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
-          x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"),UUID.fromString("00000000-0000-0000-000-000000000000"))
-          x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
+          example: '&quot;00000000-0000-0000-000-000000000000&quot;'
+          x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"))
+          x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;'
           schema:
             type: array
             items:

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -15675,11 +15675,6 @@ paths:
           keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - lineItems:
-          is_list: true
-          key: lineItems
-          keyPascal: LineItem
-          keySnake: line_items
         - lineItem:
           is_object: true
           key: lineItem
@@ -15710,6 +15705,11 @@ paths:
           keySnake: account_code
           default: "000"
           object: lineItem
+        - lineItems:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItem
+          keySnake: line_items
         - add_lineitems:
           is_last: true
           is_list_add: true
@@ -15739,6 +15739,7 @@ paths:
           python: line_item
           object: quote
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -9494,6 +9494,7 @@ paths:
       x-hasAccountingValidationError: true
       x-example:
         - requestEmpty:
+          is_last: true
           is_object: true
           key: requestEmpty
           keyPascal: RequestEmpty

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22153,10 +22153,9 @@ paths:
           is_last: true
           key: taxRate
           keyPascal: TaxRate
-          keySnake: tax_rate
           java: TaxComponents
-          object: taxComponent
           python: tax_component
+          object: taxComponent
         - taxRates:
           is_array: true
           key: taxRates
@@ -22167,7 +22166,6 @@ paths:
           is_array_add: true
           key: taxRates
           keyPascal: TaxRates
-          keySnake: tax_rates
           java: TaxRates
           python: tax_rate
           object: taxRate

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -10726,10 +10726,13 @@ paths:
           key: linkedTransactions
           keyPascal: LinkedTransactions
         - add_linkedTransaction:
+          is_last: true
           is_array_add: true
           key: linkedTransactions
           keyPascal: LinkedTransactions
+          keySnake: linked_transactions
           java: LinkedTransactions
+          python: linked_transaction
           object: linkedTransaction
       parameters:
         - required: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -8263,6 +8263,7 @@ paths:
           keyPascal: LineItem
           keySnake: line_items
         - add_lineitems:
+          is_last: true
           is_list_add: true
           key: lineItems
           keyPascal: LineItems

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -266,7 +266,6 @@ paths:
           csharp: Account.ClassEnum.EXPENSE
           object: account
         - description:
-          is_last: true
           key: description
           keyPascal: Description
           default: "Hello World"
@@ -4527,6 +4526,7 @@ paths:
           default: Thanos
           object: contact
         - contactID:
+          is_last: true
           is_uuid: true
           key: contactID
           keyPascal: ContactID
@@ -5191,24 +5191,29 @@ paths:
       x-node-requestBody: '{ contactGroups: [{ name: "Vendor" }]}'
       x-ruby-requestBody: 'contact_groups = { contact_groups: [{ name: "Vendor" }]}'
       x-example:
-        - contactGroups:
-          is_array: true
-          key: contactGroups
-          keyPascal: ContactGroups
         - contact:
           is_object: true
           key: contactGroup
           keyPascal: ContactGroup
+          keySnake: contact_group
         - name:
+          is_last: true
           key: name
           keyPascal: Name
           default: Vendor
           object: contactGroup
+        - contactGroups:
+          is_object: true
+          key: contactGroups
+          keyPascal: ContactGroups
         - add_ContactGroup:
+          is_last: true
           is_array_add: true
           key: contactGroups
           keyPascal: ContactGroups
+          keySnake: contact_groups
           java: ContactGroups
+          python: contact_group
           object: contactGroup
       parameters:
         - required: true
@@ -5651,7 +5656,7 @@ paths:
           is_object: true
           key: creditNotes
           keyPascal: CreditNotes
-        - add_bankTransaction:
+        - add_creditNote:
           is_last: true
           is_array_add: true
           key: creditNotes
@@ -6226,76 +6231,23 @@ paths:
           java: "LocalDate.now()"
           php: "new DateTime('2019-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
-        - creditNotes:
-          is_array: true
-          key: creditNotes
-          keyPascal: CreditNotes
-        - creditNote:
-          is_object: true
-          key: creditNote
-          keyPascal: CreditNote
-        - type:
-          nonString: true
-          key: type
-          keyPascal: Type
-          default: ACCPAYCREDIT
-          php: XeroAPI\XeroPHP\Models\Accounting\CreditNote::TYPE_ACCPAYCREDIT
-          node: CreditNote.TypeEnum.ACCPAYCREDIT
-          ruby: XeroRuby::Accounting::CreditNote::ACCPAYCREDIT
-          python: CreditNote.xxx
-          java: com.xero.models.accounting.CreditNote.TypeEnum.ACCPAYCREDIT
-          csharp: CreditNote.xxx
-          object: creditNote
-        - status:
-          nonString: true
-          key: status
-          keyPascal: Status
-          default: ACCPAYCREDIT
-          php: XeroAPI\XeroPHP\Models\Accounting\CreditNote::STATUS_AUTHORISED
-          node: CreditNote.StatusEnum.AUTHORISED
-          ruby: XeroRuby::Accounting::CreditNote::AUTHORISED
-          python: CreditNote.xxx
-          java: com.xero.models.accounting.CreditNote.StatusEnum.AUTHORISED
-          csharp: CreditNote.xxx
-          object: creditNote
-        - reference:
-          key: reference
-          keyPascal: Reference
-          default: My ref.
-          object: creditNote
         - contact:
           is_object: true
           key: contact
           keyPascal: Contact
         - contactID:
+          is_last: true
           is_uuid: true
           key: contactId
           keyPascal: ContactID
+          keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - set_contact:
-          is_variable: true
-          nonString: true
-          key: contact
-          keyPascal: Contact
-          default: contact
-          object: creditNote
-        - date:
-          is_variable: true
-          nonString: true
-          key: date
-          keyPascal: Date
-          default: currDate
-          python: curr_date
-          object: creditNote
-        - lineItems:
-          is_list: true
-          key: lineItems
-          keyPascal: LineItem
         - lineItem:
           is_object: true
           key: lineItem
           keyPascal: LineItem
+          keySnake: line_item
         - description:
           key: description
           keyPascal: Description
@@ -6311,30 +6263,100 @@ paths:
           nonString: true
           key: unitAmount
           keyPascal: UnitAmount
+          keySnake: unit_amount
           default: 20.0
           object: lineItem
         - accountCode:
+          is_last: true
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: "000"
           object: lineItem
+        - lineItems:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItems
+          keySnake: line_items
         - add_lineitems:
+          is_last: true
           is_list_add: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
+          python: line_item
           object: lineItem
+        - creditNote:
+          is_object: true
+          key: creditNote
+          keyPascal: CreditNote
+          keySnake: credit_note
+        - type:
+          nonString: true
+          key: type
+          keyPascal: Type
+          default: ACCPAYCREDIT
+          php: XeroAPI\XeroPHP\Models\Accounting\CreditNote::TYPE_ACCPAYCREDIT
+          node: CreditNote.TypeEnum.ACCPAYCREDIT
+          ruby: XeroRuby::Accounting::CreditNote::ACCPAYCREDIT
+          python_string: ACCPAYCREDIT
+          java: com.xero.models.accounting.CreditNote.TypeEnum.ACCPAYCREDIT
+          csharp: CreditNote.xxx
+          object: creditNote
+        - status:
+          nonString: true
+          key: status
+          keyPascal: Status
+          default: AUTHORISED
+          php: XeroAPI\XeroPHP\Models\Accounting\CreditNote::STATUS_AUTHORISED
+          node: CreditNote.StatusEnum.AUTHORISED
+          ruby: XeroRuby::Accounting::CreditNote::AUTHORISED
+          python_string: AUTHORISED
+          java: com.xero.models.accounting.CreditNote.StatusEnum.AUTHORISED
+          csharp: CreditNote.xxx
+          object: creditNote
+        - reference:
+          key: reference
+          keyPascal: Reference
+          default: My ref.
+          object: creditNote
+        - set_contact:
+          is_variable: true
+          nonString: true
+          key: contact
+          keyPascal: Contact
+          default: contact
+          object: creditNote
+        - date:
+          is_variable: true
+          nonString: true
+          key: date
+          keyPascal: Date
+          default: currDate
+          python: curr_date
+          object: creditNote
         - set_lineitem:
+          is_last: true
           is_variable: true
           nonString: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           default: lineItems
+          python: line_items
           object: creditNote
-        - add_bankTransaction:
+        - creditNotes:
+          is_object: true
+          key: creditNotes
+          keyPascal: CreditNotes
+        - add_creditNote:
+          is_last: true
           is_array_add: true
           key: creditNotes
           keyPascal: CreditNotes
+          keySnake: credit_notes
           java: CreditNotes
+          python: credit_note
           object: creditNote
       parameters:
         - required: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -13788,24 +13788,22 @@ paths:
           java: "LocalDate.now()"
           php: "new DateTime('2019-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
-        - allocations:
-          is_array: true
-          key: allocations
-          keyPascal: Allocations
-        - allocation:
-          is_object: true
-          key: allocation
-          keyPascal: Allocation
         - invoice:
           is_object: true
           key: invoice
           keyPascal: Invoice
         - invoiceID:
+          is_last: true
           is_uuid: true
           key: invoiceID
           keyPascal: InvoiceID
+          keySnake: invoice_id
           default: 00000000-0000-0000-000-000000000000
           object: invoice
+        - allocation:
+          is_object: true
+          key: allocation
+          keyPascal: Allocation
         - set_invoice:
           is_variable: true
           nonString: true
@@ -13820,6 +13818,7 @@ paths:
           default: 1.0
           object: allocation
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date
@@ -13827,7 +13826,12 @@ paths:
           default: currDate
           python: curr_date
           object: allocation
+        - allocations:
+          is_object: true
+          key: allocations
+          keyPascal: Allocations
         - add_allocation:
+          is_last: true
           is_array_add: true
           key: allocations
           keyPascal: Allocations
@@ -14203,14 +14207,16 @@ paths:
       x-node-requestBody: '{ purchaseOrders: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "710" }], date: "2019-03-13" }]}'
       x-ruby-requestBody: 'purchase_orders = { purchase_orders: [{ contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, account_code: "710" }], date: "2019-03-13" }]}'
       x-example:
-        - purchaseOrders:
-          is_array: true
-          key: purchaseOrders
-          keyPascal: PurchaseOrders
-        - purchaseOrder:
-          is_object: true
-          key: purchaseOrder
-          keyPascal: PurchaseOrder
+        - dateValue:
+          is_date: true
+          key: dateValue
+          keyPascal: Date
+          keySnake: date_value
+          java_datatype: LocalDate
+          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
+          java: "LocalDate.now()"
+          php: "new DateTime('2019-12-10')"
+          python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
         - contact:
           is_object: true
           key: contact
@@ -14219,23 +14225,14 @@ paths:
           is_uuid: true
           key: contactId
           keyPascal: ContactID
+          keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - set_contact:
-          is_variable: true
-          nonString: true
-          key: contact
-          keyPascal: Contact
-          default: contact
-          object: purchaseOrder
-        - lineItems:
-          is_list: true
-          key: lineItems
-          keyPascal: LineItem
         - lineItem:
           is_object: true
           key: lineItem
           keyPascal: LineItem
+          keySnake: line_item
         - description:
           key: description
           keyPascal: Description
@@ -14251,40 +14248,59 @@ paths:
           nonString: true
           key: unitAmount
           keyPascal: UnitAmount
+          keySnake: unit_amount
           default: 20.0
           object: lineItem
         - accountCode:
+          is_last: true
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: "000"
           object: lineItem
+        - lineItems:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItem
+          keySnake: line_items
         - add_lineitems:
+          is_last: true
           is_list_add: true
           key: lineItems
           keyPascal: LineItems
           object: lineItem
+        - purchaseOrder:
+          is_object: true
+          key: purchaseOrder
+          keyPascal: PurchaseOrder
+        - set_contact:
+          is_variable: true
+          nonString: true
+          key: contact
+          keyPascal: Contact
+          default: contact
+          object: purchaseOrder
         - set_lineitem:
           is_variable: true
           nonString: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           default: lineItems
+          python: line_items
           object: purchaseOrder
-        - dateValue:
-          is_date: true
-          key: dateValue
-          keyPascal: Date
-          java_datatype: LocalDate
-          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          java: "LocalDate.now()"
-          php: "new DateTime('2019-12-10')"
         - date:
           is_variable: true
           nonString: true
           key: date
           keyPascal: Date
           default: dateValue
+          python: date_value
           object: purchaseOrder
+        - purchaseOrders:
+          is_object: true
+          key: purchaseOrders
+          keyPascal: PurchaseOrders
         - add_purchaseOrder:
           is_array_add: true
           key: purchaseOrders

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -21957,6 +21957,7 @@ paths:
           keyPascal: ConversionDate
           keySnake: conversion_date
           default: conversionDate
+          python: conversion_date
           object: setup
         - set_conversionBalances:
           is_last: true
@@ -21966,6 +21967,7 @@ paths:
           keyPascal: ConversionBalances
           keySnake: conversion_balances
           default: conversionBalances
+          python: conversion_balances
           object: setup
       responses:
         '200':

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1126,24 +1126,30 @@ paths:
       summary: Allows you to create a history record for a Batch Payment
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3978,10 +3978,40 @@ paths:
       x-node-requestBody: '{ contacts: [{ name: "Bruce Banner", emailAddress: "hulk@avengers.com", phones: [{ phoneType: Phone.PhoneTypeEnum.MOBILE, phoneNumber: "555-1212", phoneAreaCode: "415" }], paymentTerms: { bills: { day: 15, type: PaymentTermType.OFCURRENTMONTH }, sales: { day: 10, type: PaymentTermType.DAYSAFTERBILLMONTH }}}]}'
       x-ruby-requestBody: '{ contacts: [{ name: "Bruce Banner", email_address: "hulk@avengers.com", phones: [{ phone_type: XeroRuby::Accounting::Phone::MOBILE, phone_number: "555-1212", phone_area_code: "415" }], payment_terms: { bills: { day: 15, type: XeroRuby::Accounting::PaymentTermType::OFCURRENTMONTH }, sales: { day: 10, type: XeroRuby::Accounting::PaymentTermType::OFCURRENTMONTHDAYSAFTERBILLMONTH }}}]}'
       x-example:
-        - contacts:
-          is_array: true
-          key: contacts
-          keyPascal: Contacts
+        - phone:
+          is_object: true
+          key: phone
+          keyPascal: Phone
+        - phoneNumber:
+          key: phoneNumber
+          keyPascal: PhoneNumber
+          keySnake: phone_number
+          default: 555-1212
+          object: phone
+        - phoneType:
+          is_last: true
+          nonString: true
+          key: phoneType
+          keyPascal: PhoneType
+          keySnake: phone_type
+          default: MOBILE
+          php: XeroAPI\XeroPHP\Models\Accounting\Phone::PHONE_TYPE_MOBILE
+          node: PhoneType.MOBILE
+          ruby: XeroRuby::Accounting::PhoneType::MOBILE
+          python_string: MOBILE
+          java: com.xero.models.accounting.Phone.PhoneTypeEnum.MOBILE
+          csharp: Phone.TypeEnum.MOBILE
+          object: phone
+        - phones:
+          is_list: true
+          key: phones
+          keyPascal: Phone
+        - add_phone:
+          is_last: true
+          is_list_add: true
+          key: phones
+          keyPascal: Phones
+          object: phone
         - contact:
           is_object: true
           key: contact
@@ -3994,46 +4024,23 @@ paths:
         - emailAddress:
           key: emailAddress
           keyPascal: EmailAddress
+          keySnake: email_address
           default: hulk@avengers.com
           object: contact
-        - phones:
-          is_list: true
-          key: phones
-          keyPascal: Phone
-        - phone:
-          is_object: true
-          key: phone
-          keyPascal: Phone
-        - phoneNumber:
-          key: phoneNumber
-          keyPascal: PhoneNumber
-          default: 555-1212
-          object: phone
-        - phoneType:
-          nonString: true
-          key: phoneType
-          keyPascal: PhoneType
-          default: MOBILE
-          php: XeroAPI\XeroPHP\Models\Accounting\Phone::PHONE_TYPE_MOBILE
-          node: PhoneType.MOBILE
-          ruby: XeroRuby::Accounting::PhoneType::MOBILE
-          python: PhoneType.MOBILE
-          java: com.xero.models.accounting.Phone.PhoneTypeEnum.MOBILE
-          csharp: Phone.TypeEnum.MOBILE
-          object: phone
-        - add_phone:
-          is_list_add: true
-          key: phones
-          keyPascal: Phones
-          object: phone
         - set_phones:
+          is_last: true
           is_variable: true
           nonString: true
           key: phones
           keyPascal: Phones
           default: phones
           object: contact
+        - contacts:
+          is_object: true
+          key: contacts
+          keyPascal: Contacts
         - add_contact:
+          is_last: true
           is_array_add: true
           key: contacts
           keyPascal: Contacts
@@ -5846,59 +5853,23 @@ paths:
           java: "LocalDate.now()"
           php: "new DateTime('2019-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
-        - creditNotes:
-          is_array: true
-          key: creditNotes
-          keyPascal: CreditNotes
-        - creditNote:
-          is_object: true
-          key: creditNote
-          keyPascal: CreditNote
-        - type:
-          nonString: true
-          key: type
-          keyPascal: Type
-          default: ACCPAYCREDIT
-          php: XeroAPI\XeroPHP\Models\Accounting\CreditNote::TYPE_ACCPAYCREDIT
-          node: CreditNote.TypeEnum.ACCPAYCREDIT
-          ruby: XeroRuby::Accounting::CreditNote::ACCPAYCREDIT
-          python: CreditNote.xxx
-          java: com.xero.models.accounting.CreditNote.TypeEnum.ACCPAYCREDIT
-          csharp: CreditNote.xxx
-          object: creditNote
         - contact:
           is_object: true
           key: contact
           keyPascal: Contact
         - contactID:
+          is_last: true
           is_uuid: true
           key: contactId
           keyPascal: ContactID
+          keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - set_contact:
-          is_variable: true
-          nonString: true
-          key: contact
-          keyPascal: Contact
-          default: contact
-          object: creditNote
-        - date:
-          is_variable: true
-          nonString: true
-          key: date
-          keyPascal: Date
-          default: currDate
-          python: curr_date
-          object: creditNote
-        - lineItems:
-          is_list: true
-          key: lineItems
-          keyPascal: LineItem
         - lineItem:
           is_object: true
           key: lineItem
           keyPascal: LineItem
+          keySnake: line_item
         - description:
           key: description
           keyPascal: Description
@@ -5914,30 +5885,83 @@ paths:
           nonString: true
           key: unitAmount
           keyPascal: UnitAmount
+          keySnake: unit_amount
           default: 20.0
           object: lineItem
         - accountCode:
+          is_last: true
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: "000"
           object: lineItem
+        - lineItems:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItems
+          keySnake: line_items
         - add_lineitems:
+          is_last: true
           is_list_add: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
+          python: line_item
           object: lineItem
+        - creditNote:
+          is_object: true
+          key: creditNote
+          keyPascal: CreditNote
+          keySnake: credit_note
+        - type:
+          nonString: true
+          key: type
+          keyPascal: Type
+          default: ACCPAYCREDIT
+          php: XeroAPI\XeroPHP\Models\Accounting\CreditNote::TYPE_ACCPAYCREDIT
+          node: CreditNote.TypeEnum.ACCPAYCREDIT
+          ruby: XeroRuby::Accounting::CreditNote::ACCPAYCREDIT
+          python_string: ACCPAYCREDIT
+          java: com.xero.models.accounting.CreditNote.TypeEnum.ACCPAYCREDIT
+          csharp: CreditNote.xxx
+          object: creditNote
+        - set_contact:
+          is_variable: true
+          nonString: true
+          key: contact
+          keyPascal: Contact
+          default: contact
+          object: creditNote
+        - date:
+          is_variable: true
+          nonString: true
+          key: date
+          keyPascal: Date
+          default: currDate
+          python: curr_date
+          object: creditNote
         - set_lineitem:
+          is_last: true
           is_variable: true
           nonString: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           default: lineItems
+          python: line_items
           object: creditNote
-        - add_bankTransaction:
+        - creditNotes:
+          is_object: true
+          key: creditNotes
+          keyPascal: CreditNotes
+        - add_creditNote:
+          is_last: true
           is_array_add: true
           key: creditNotes
           keyPascal: CreditNotes
+          keySnake: credit_notes
           java: CreditNotes
+          python: credit_note
           object: creditNote
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -12369,6 +12369,7 @@ paths:
           default: 1.0
           object: allocation
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -15653,39 +15653,38 @@ paths:
       x-node-requestBody: '{ quotes: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "12775" }], date: "2020-02-01" }]}'
       x-ruby-requestBody: 'quotes = { quotes: [{ contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unit_amount: 20.0, account_code: "12775" }], date: "2020-02-01" }]}'
       x-example:
-        - quotes:
-          is_array: true
-          key: quotes
-          keyPascal: Quotes
-        - quote:
-          is_object: true
-          key: quote
-          keyPascal: Quote
+        - dateValue:
+          is_date: true
+          key: dateValue
+          keyPascal: Date
+          keySnake: date_value
+          java_datatype: LocalDate
+          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
+          java: "LocalDate.now()"
+          php: "new DateTime('2019-12-10')"
+          python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
         - contact:
           is_object: true
           key: contact
           keyPascal: Contact
         - contactID:
+          is_last: true
           is_uuid: true
           key: contactId
           keyPascal: ContactID
+          keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - set_contact:
-          is_variable: true
-          nonString: true
-          key: contact
-          keyPascal: Contact
-          default: contact
-          object: quote
         - lineItems:
           is_list: true
           key: lineItems
           keyPascal: LineItem
+          keySnake: line_items
         - lineItem:
           is_object: true
           key: lineItem
           keyPascal: LineItem
+          keySnake: line_item
         - description:
           key: description
           keyPascal: Description
@@ -15701,41 +15700,58 @@ paths:
           nonString: true
           key: unitAmount
           keyPascal: UnitAmount
+          keySnake: unit_amount
           default: 20.0
           object: lineItem
         - accountCode:
+          is_last: true
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: "000"
           object: lineItem
         - add_lineitems:
+          is_last: true
           is_list_add: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           object: lineItem
+          python: line_item
+        - quote:
+          is_object: true
+          key: quote
+          keyPascal: Quote
+        - set_contact:
+          is_variable: true
+          nonString: true
+          key: contact
+          keyPascal: Contact
+          default: contact
+          object: quote
         - set_lineitem:
           is_variable: true
           nonString: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           default: lineItems
+          python: line_item
           object: quote
-        - dateValue:
-          is_date: true
-          key: dateValue
-          keyPascal: Date
-          java_datatype: LocalDate
-          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          java: "LocalDate.now()"
-          php: "new DateTime('2019-12-10')"
         - date:
           is_variable: true
           nonString: true
           key: date
           keyPascal: Date
           default: dateValue
+          python: date_value
           object: quote
+        - quotes:
+          is_object: true
+          key: quotes
+          keyPascal: Quotes
         - add_quote:
+          is_last: true
           is_array_add: true
           key: quotes
           keyPascal: Quotes

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -10040,10 +10040,6 @@ paths:
       x-node-requestBody: '{ items: [{ code: "ItemCode123", description: "Description 123" }]}'
       x-ruby-requestBody: 'items = { items: [{ code: "ItemCode123", description: "Description 123" }]}'
       x-example:
-        - items:
-          is_array: true
-          key: items
-          keyPascal: Items
         - item:
           is_object: true
           key: item
@@ -10058,7 +10054,12 @@ paths:
           keyPascal: Description
           default: Goodbye
           object: item
+        - items:
+          is_object: true
+          key: items
+          keyPascal: Items
         - add_item:
+          is_last: true
           is_array_add: true
           key: items
           keyPascal: Items

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -12346,10 +12346,18 @@ paths:
           java: "LocalDate.now()"
           php: "new DateTime('2019-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
-        - allocations:
-          is_array: true
-          key: allocations
-          keyPascal: Allocations
+        - invoice:
+          is_object: true
+          key: invoice
+          keyPascal: Invoice
+        - invoiceID:
+          is_last: true
+          is_uuid: true
+          key: invoiceID
+          keyPascal: InvoiceID
+          keySnake: invoice_id
+          default: 00000000-0000-0000-000-000000000000
+          object: invoice
         - allocation:
           is_object: true
           key: allocation
@@ -12368,24 +12376,20 @@ paths:
           default: currDate
           python: curr_date
           object: allocation
-        - invoice:
-          is_object: true
-          key: invoice
-          keyPascal: Invoice
-        - invoiceID:
-          is_uuid: true
-          key: invoiceID
-          keyPascal: InvoiceID
-          default: 00000000-0000-0000-000-000000000000
-          object: invoice
         - set_invoice:
+          is_last: true
           is_variable: true
           nonString: true
           key: invoice
           keyPascal: Invoice
           default: invoice
           object: allocation
+        - allocations:
+          is_object: true
+          key: allocations
+          keyPascal: Allocations
         - add_allocation:
+          is_last: true
           is_array_add: true
           key: allocations
           keyPascal: Allocations

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -279,7 +279,7 @@ paths:
           default: NONE
           object: account
         - accounts:
-          is_array: true
+          is_object: true
           key: accounts
           keyPascal: Accounts
         - accounts:
@@ -1990,40 +1990,23 @@ paths:
       x-node-requestBody: '{ bankTransactions: [{ type: BankTransaction.TypeEnum.SPEND, date: "2019-02-25", reference: "You just updated", status: BankTransaction.StatusEnum.AUTHORISED, bankTransactionID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, bankAccount: { accountID: "00000000-0000-0000-000-000000000000" }}]}'
       x-ruby-requestBody: '{ bank_transactions: [{ type: XeroRuby::Accounting::BankTransaction::SPEND, date: "2019-02-25", reference: "You just updated", status: XeroRuby::Accounting::BankTransaction::AUTHORISED, bank_transaction_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, bank_account: { account_id: "00000000-0000-0000-000-000000000000" }}]}'      
       x-example:
-        - bankTransactions:
-          is_array: true
-          key: bankTransactions
-          keyPascal: BankTransactions
-        - bankTransaction:
-          is_object: true
-          key: bankTransaction
-          keyPascal: BankTransaction
-        - reference:
-          key: reference
-          keyPascal: Reference
-          default: You just updated
-          object: bankTransaction
         - contact:
           is_object: true
           key: contact
           keyPascal: Contact
         - contactID:
           is_uuid: true
+          is_last: true
           key: contactId
           keyPascal: ContactID
+          keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - set_contact:
-          is_variable: true
-          nonString: true
-          key: contact
-          keyPascal: Contact
-          default: contact
-          object: bankTransaction
         - lineItem:
           is_object: true
           key: lineItem
           keyPascal: LineItem
+          keySnake: line_item
         - description:
           key: description
           keyPascal: Description
@@ -2039,41 +2022,88 @@ paths:
           nonString: true
           key: unitAmount
           keyPascal: UnitAmount
+          keySnake: unit_amount
           default: 20.0
           object: lineItem
         - accountCode:
+          is_last: true
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: "000"
-          object: lineItem
-        - add_lineitems:
-          is_array_add: true
-          key: bankTransaction
-          keyPascal: LineItems
-          java: LineItems
           object: lineItem
         - bankAccount:
           is_object: true
           key: bankAccount
           keyPascal: Account
+          keySnake: bank_account
         - accountID:
+          is_last: true
           is_uuid: true
           key: accountID
           keyPascal: AccountID
+          keySnake: account_id
           default: 00000000-0000-0000-000-000000000000
           object: bankAccount
+        - bankTransaction:
+          is_object: true
+          key: bankTransaction
+          keyPascal: BankTransaction
+          keySnake: bank_transaction
+        - reference:
+          key: reference
+          keyPascal: Reference
+          default: You just updated
+          object: bankTransaction
+        - type:
+          nonString: true
+          key: type
+          keyPascal: Type
+          default: RECEIVE
+          php: XeroAPI\XeroPHP\Models\Accounting\BankTransaction::TYPE_RECEIVE
+          node: BankTransaction.TypeEnum.RECEIVE
+          ruby: XeroRuby::Accounting::BankTransaction::RECEIVE
+          python_string: RECEIVE
+          java: com.xero.models.accounting.BankTransaction.TypeEnum.RECEIVE
+          csharp: BankTransaction.TypeEnum.RECEIVE
+          object: bankTransaction
+        - set_contact:
+          is_variable: true
+          nonString: true
+          key: contact
+          keyPascal: Contact
+          default: contact
+          object: bankTransaction
+        - add_lineitems:
+          is_array_add: true
+          key: bankTransaction
+          keyPascal: LineItems
+          keySnake: line_items
+          java: LineItems
+          python: line_item
+          object: lineItem
         - set_bankaccount:
+          is_last: true
           is_variable: true
           nonString: true
           key: bankAccount
           keyPascal: BankAccount
+          keySnake: bank_account
+          python: bank_account
           default: bankAccount
           object: bankTransaction
+        - bankTransactions:
+          is_object: true
+          key: bankTransactions
+          keyPascal: BankTransactions
         - add_bankTransaction:
+          is_last: true
           is_array_add: true
           key: bankTransactions
           keyPascal: BankTransactions
+          keySnake: bank_transactions
           java: BankTransactions
+          python: bank_transaction
           object: bankTransaction
       parameters:
         - required: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -4517,26 +4517,27 @@ paths:
       x-node-requestBody: '{ contacts: [{ contactID: "00000000-0000-0000-000-000000000000", name: "Thanos" }]}'
       x-ruby-requestBody: 'contacts = { contacts: [{ contact_id: "00000000-0000-0000-000-000000000000", name: "Thanos" }]}'
       x-example:
-        - contacts:
-          is_array: true
-          key: contacts
-          keyPascal: Contacts
         - contact:
           is_object: true
           key: contact
           keyPascal: Contact
+        - name:
+          key: name
+          keyPascal: Name
+          default: Thanos
+          object: contact
         - contactID:
           is_uuid: true
           key: contactID
           keyPascal: ContactID
           default: 00000000-0000-0000-0000-000000000000
           object: contact
-        - name:
-          key: name
-          keyPascal: Name
-          default: Thanos
-          object: contact
+        - contacts:
+          is_object: true
+          key: contacts
+          keyPascal: Contacts
         - add_contact:
+          is_last: true
           is_array_add: true
           key: contacts
           keyPascal: Contacts

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -7755,47 +7755,18 @@ paths:
           java: "LocalDate.now()"
           php: "new DateTime('2019-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
-        - expenseClaims:
-          is_array: true
-          key: expenseClaims
-          keyPascal: ExpenseClaims
-        - expenseClaim:
-          is_object: true
-          key: expenseClaim
-          keyPascal: ExpenseClaim
-        - status:
-          nonString: true
-          key: status
-          keyPascal: Status
-          default: AUTHORISED
-          php: XeroAPI\XeroPHP\Models\Accounting\ExpenseClaim::STATUS_AUTHORISED
-          node: ExpenseClaim.StatusEnum.AUTHORISED
-          ruby: XeroRuby::Accounting::ExpenseClaim::AUTHORISED
-          python: ExpenseClaim.xxx
-          java: com.xero.models.accounting.ExpenseClaim.StatusEnum.AUTHORISED
-          csharp: ExpenseClaim.xxx
-          object: expenseClaim
         - user:
           is_object: true
           key: user
           keyPascal: User
         - userID:
+          is_last: true
           is_uuid: true
           key: userID
           keyPascal: UserID
+          keySnake: user_id
           default: 00000000-0000-0000-000-000000000000
           object: user
-        - set_user:
-          is_variable: true
-          nonString: true
-          key: user
-          keyPascal: User
-          default: user
-          object: expenseClaim
-        - receipts:
-          is_list: true
-          key: receipts
-          keyPascal: Receipt
         - receipt:
           is_object: true
           key: receipt
@@ -7804,9 +7775,11 @@ paths:
           is_uuid: true
           key: receiptID
           keyPascal: ReceiptID
+          keySnake: receipt_id
           default: 00000000-0000-0000-000-000000000000
           object: receipt
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date
@@ -7814,23 +7787,60 @@ paths:
           default: currDate
           python: curr_date
           object: receipt
+        - receipts:
+          is_list: true
+          key: receipts
+          keyPascal: Receipt
         - add_receipts:
+          is_last: true
           is_list_add: true
           key: receipts
           keyPascal: Receipts
           object: receipt
+        - expenseClaim:
+          is_object: true
+          key: expenseClaim
+          keyPascal: ExpenseClaim
+          keySnake: expense_claim
+        - status:
+          nonString: true
+          key: status
+          keyPascal: Status
+          default: SUBMITTED
+          php: XeroAPI\XeroPHP\Models\Accounting\ExpenseClaim::STATUS_SUBMITTED
+          node: ExpenseClaim.StatusEnum.SUBMITTED
+          ruby: XeroRuby::Accounting::ExpenseClaim::SUBMITTED
+          python_string: SUBMITTED
+          java: com.xero.models.accounting.ExpenseClaim.StatusEnum.SUBMITTED
+          csharp: ExpenseClaim.xxx
+          object: expenseClaim
+        - set_user:
+          is_variable: true
+          nonString: true
+          key: user
+          keyPascal: User
+          default: user
+          object: expenseClaim
         - set_receipt:
+          is_last: true
           is_variable: true
           nonString: true
           key: receipts
           keyPascal: Receipts
           default: receipts
           object: expenseClaim
-        - add_expenseClaim:
-          is_array_add: true
+        - expenseClaims:
+          is_object: true
           key: expenseClaims
           keyPascal: ExpenseClaims
+        - add_expenseClaim:
+          is_array_add: true
+          is_last: true
+          key: expenseClaims
+          keyPascal: ExpenseClaims
+          keySnake: expense_claims
           java: ExpenseClaims
+          python: expense_claim
           object: expenseClaim
       parameters:
         - required: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -11417,38 +11417,21 @@ paths:
       x-node-requestBody: '{ manualJournals: [{ narration: "Hello Xero", manualJournalId: "00000000-0000-0000-000-000000000000", journalLines: [] }]}'
       x-ruby-requestBody: 'manual_journals = { manual_journals: [{ narration: "Hello Xero", manual_journal_id: "00000000-0000-0000-000-000000000000", journal_lines: [] }]}'
       x-example:
-        - manualJournals:
-          is_array: true
-          key: manualJournals
-          keyPascal: ManualJournals
-        - manualJournal:
-          is_object: true
-          key: manualJournal
-          keyPascal: ManualJournal
-        - narration:
-          key: narration
-          keyPascal: Narration
-          default: Foobar
-          object: manualJournal
         - dateValue:
           is_date: true
           key: dateValue
           keyPascal: Date
+          keySnake: date_value
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.of(2020, Month.OCTOBER, 10)"
           php: "new DateTime('2019-10-10')"
-        - date:
-          is_variable: true
-          nonString: true
-          key: date
-          keyPascal: Date
-          default: dateValue
-          object: manualJournal
+          python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
         - manualJournalLines:
           is_list: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
+          keySnake: manual_journal_lines
         - credit:
           is_object: true
           key: credit
@@ -11457,22 +11440,27 @@ paths:
           nonString: true
           key: lineAmount
           keyPascal: LineAmount
+          keySnake: line_amount
           default: 100.0
           object: credit
         - accountCode:
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: 400
           object: credit
         - description:
+          is_last: true
           key: description
           keyPascal: Description
           default: "Hello there"
           object: credit
         - add_credit:
+          is_last: true
           is_list_add: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
+          keySnake: manual_journal_lines
           object: credit
         - debit:
           is_object: true
@@ -11482,36 +11470,69 @@ paths:
           nonString: true
           key: lineAmount
           keyPascal: LineAmount
+          keySnake: line_amount
           default: -100.0
           object: debit
         - accountCode:
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: 120
           object: debit
         - description:
+          is_last: true
           key: description
           keyPascal: Description
           default: "Hello there"
           object: debit
         - add_debit:
+          is_last: true
           is_list_add: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
+          keySnake: manual_journal_lines
           object: debit
+        - manualJournal:
+          is_object: true
+          key: manualJournal
+          keyPascal: ManualJournal
+          keySnake: manual_journal
+        - narration:
+          key: narration
+          keyPascal: Narration
+          default: Foobar
+          object: manualJournal
+        - date:
+          is_variable: true
+          nonString: true
+          key: date
+          keyPascal: Date
+          default: dateValue
+          python: date_value
+          object: manualJournal
         - set_manualJournalLines:
+          is_last: true
           is_variable: true
           nonString: true
           key: manualJournalLines
           keyPascal: JournalLines
+          keySnake: journal_lines
           default: manualJournalLines
+          python: manual_journal_lines
           object: manualJournal
+        - manualJournals:
+          is_object: true
+          key: manualJournals
+          keyPascal: ManualJournals
         - add_manualJournal:
+          is_last: true
           is_array_add: true
           key: manualJournals
           keyPascal: ManualJournals
+          keySnake: manual_journals
           java: ManualJournals
           php: manualJournals
+          python: manual_journal
           object: manualJournal
       parameters:
         - required: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -2631,6 +2631,7 @@ paths:
           is_object: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
           is_last: true
           is_array_add: true
@@ -2639,7 +2640,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
-          object: historyRecord   
+          object: historyRecord 
       parameters:
         - required: true
           in: path
@@ -3231,24 +3232,30 @@ paths:
       summary: Allows you to create history record for a bank transfers
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -4970,24 +4977,30 @@ paths:
       summary: Allows you to retrieve a history records of an Contact
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -6881,7 +6894,7 @@ paths:
           default: invoice
           object: allocation
         - allocations:
-          is_array: true
+          is_object: true
           key: allocations
           keyPascal: Allocations
         - add_allocation:
@@ -6989,24 +7002,30 @@ paths:
       summary: Allows you to retrieve a history records of an CreditNote
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -8038,24 +8057,30 @@ paths:
       summary: Allows you to create a history records of an ExpenseClaim
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -9693,24 +9718,30 @@ paths:
       summary: Allows you to retrieve a history records of an invoice
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -10248,24 +10279,30 @@ paths:
       summary: Allows you to create a history record for items
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -11985,24 +12022,30 @@ paths:
       summary: Allows you to create history record for a manual journal
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -12692,24 +12735,30 @@ paths:
       summary: Allows you to create history records of an Overpayment
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -13556,24 +13605,30 @@ paths:
       summary: Allows you to create a history record for a payment
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -14131,24 +14186,30 @@ paths:
       summary: Allows you to create a history record for an Prepayment
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -15443,24 +15504,30 @@ paths:
       summary: Allows you to create HistoryRecord for purchase orders
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -16521,24 +16588,30 @@ paths:
       summary: Allows you to retrieve a history records of an quote
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -17818,24 +17891,30 @@ paths:
       summary: Allows you to retrieve a history records of an Receipt
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true
@@ -18346,24 +18425,30 @@ paths:
       summary: Allows you to create history for a repeating invoice
       x-hasAccountingValidationError: true
       x-example:
-        - historyRecords:
-          is_array: true
-          key: historyRecords
-          keyPascal: HistoryRecords
         - historyRecord:
           is_object: true
           key: historyRecord
           keyPascal: HistoryRecord
+          keySnake: history_record
         - Details:
+          is_last: true
           key: details
           keyPascal: Details
           default: Hello World
           object: historyRecord
+        - historyRecords:
+          is_object: true
+          key: historyRecords
+          keyPascal: HistoryRecords
+          keySnake: history_records
         - add_historyRecord:
+          is_last: true
           is_array_add: true
           key: historyRecords
           keyPascal: HistoryRecords
+          keySnake: history_records
           java: HistoryRecords
+          python: history_record
           object: historyRecord 
       parameters:
         - required: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -9085,20 +9085,22 @@ paths:
       x-node-requestBody: '{ invoices: [{ reference: "I am Iron Man", invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }]}'
       x-ruby-requestBody: 'invoices = { invoices: [{ reference: "I am Iron Man", invoice_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, type: XeroRuby::Accounting::Invoice::ACCPAY }]}'
       x-example:
-        - invoices:
-          is_array: true
-          key: invoices
-          keyPascal: Invoices
         - invoice:
           is_object: true
           key: invoice
           keyPascal: Invoice
         - reference:
+          is_last: true
           key: reference
           keyPascal: Reference
           default: I am Iron man
           object: invoice
+        - invoices:
+          is_object: true
+          key: invoices
+          keyPascal: Invoices
         - add_invoice:
+          is_last: true
           is_array_add: true
           key: invoices
           keyPascal: Invoices

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -14312,6 +14312,7 @@ paths:
           key: purchaseOrders
           keyPascal: PurchaseOrders
           java: PurchaseOrders
+          python: purchase_order
           object: purchaseOrder
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22121,29 +22121,18 @@ paths:
       x-node-requestBody: '{ taxRates: [{ name: "CA State Tax", taxComponents: [{ name: "State Tax", rate: 2.25 }]}]}'
       x-ruby-requestBody: 'tax_rates = { tax_rates: [{ name: "CA State Tax", tax_components: [{ name: "State Tax", rate: 2.25 }]}]}'
       x-example:
-        - taxRates:
-          is_array: true
-          key: taxRates
-          keyPascal: TaxRates
-        - taxRate:
-          is_object: true
-          key: taxRate
-          keyPascal: TaxRate
-        - name:
-          key: name
-          keyPascal: Name
-          default: CA State Tax
-          object: taxRate
         - taxComponent:
           is_object: true
           key: taxComponent
           keyPascal: TaxComponent
+          keySnake: tax_component
         - name:
           key: name
           keyPascal: Name
           default: State Tax
           object: taxComponent
         - rate:
+          is_last: true
           nonString: true
           key: rate
           keyPascal: Rate
@@ -22153,13 +22142,32 @@ paths:
           is_array_add: true
           key: taxRate
           keyPascal: TaxComponents
+          keySnake: tax_components
           java: TaxComponents
           object: taxComponent
+          python: tax_component
+        - taxRate:
+          is_object: true
+          key: taxRate
+          keyPascal: TaxRate
+        - name:
+          key: name
+          keyPascal: Name
+          default: CA State Tax
+          object: taxRate
+        - taxRates:
+          is_array: true
+          key: taxRates
+          keyPascal: TaxRates
+          keySnake: tax_rates
         - add_taxRate:
+          is_last: true
           is_array_add: true
           key: taxRates
           keyPascal: TaxRates
+          keySnake: tax_rates
           java: TaxRates
+          keySnake: tax_rate
           object: taxRate
       responses:
         '200':

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -239,10 +239,6 @@ paths:
       x-ruby-requestBody: '{ accounts: [{ code: "123456", name: "BarFoo", account_id: "00000000-0000-0000-000-000000000000", type: XeroRuby::Accounting::Account::EXPENSE, description: "GoodBye World", tax_type: XeroRuby::Accounting::TaxType::NONE }]}'
       x-node-requestBody: '{ accounts: [{ code: "123456", name: "BarFoo", accountID: "00000000-0000-0000-000-000000000000", type: AccountType.EXPENSE, description: "GoodBye World", taxType: TaxType.INPUT }]}'
       x-example:
-        - accounts:
-          is_array: true
-          key: accounts
-          keyPascal: Accounts
         - account:
           is_object: true
           key: account
@@ -258,10 +254,10 @@ paths:
           default: BarFoo
           object: account
         - type:
-          nonString: true
           key: type
           keyPascal: Type
           default: EXPENSE
+          nonString: true
           php: XeroAPI\XeroPHP\Models\Accounting\AccountType::EXPENSE
           node: AccountType.EXPENSE
           ruby: XeroRuby::Accounting::AccountType::EXPENSE
@@ -270,16 +266,24 @@ paths:
           csharp: Account.ClassEnum.EXPENSE
           object: account
         - description:
+          is_last: true
           key: description
           keyPascal: Description
-          default: Goodbye World
+          default: "Hello World"
           object: account
         - taxType:
+          is_last: true
           key: taxType
           keyPascal: TaxType
+          keySnake: tax_type
           default: NONE
           object: account
         - accounts:
+          is_array: true
+          key: accounts
+          keyPascal: Accounts
+        - accounts:
+          is_last: true
           is_array_add: true
           key: accounts
           keyPascal: Accounts

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -8153,9 +8153,9 @@ paths:
           description: Filter by a comma-separated list of ContactIDs. 
           style: form
           explode: false
-          example: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
-          x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"),UUID.fromString("00000000-0000-0000-000-000000000000"))
-          x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
+          example: '&quot;00000000-0000-0000-000-000000000000&quot;'
+          x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"))
+          x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;'
           schema:
             type: array
             items:

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -13226,6 +13226,7 @@ paths:
           key: paymentDelete
           keyPascal: PaymentDelete
         - status:
+          is_last: true
           key: status
           keyPascal: Status
           default: DELETED

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22139,14 +22139,6 @@ paths:
           keyPascal: Rate
           default: 2.25
           object: taxComponent
-        - add_taxComponent:
-          is_array_add: true
-          key: taxRate
-          keyPascal: TaxComponents
-          keySnake: tax_components
-          java: TaxComponents
-          object: taxComponent
-          python: tax_component
         - taxRate:
           is_object: true
           key: taxRate
@@ -22156,6 +22148,15 @@ paths:
           keyPascal: Name
           default: CA State Tax
           object: taxRate
+        - add_taxComponent:
+          is_array_add: true
+          is_last: true
+          key: taxRate
+          keyPascal: TaxRate
+          keySnake: tax_rate
+          java: TaxComponents
+          object: taxComponent
+          python: tax_component
         - taxRates:
           is_array: true
           key: taxRates

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -10871,7 +10871,7 @@ paths:
           is_list_add: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
-          keySnake: manual_journal_line
+          keySnake: manual_journal_lines
           object: credit
         - debit:
           is_object: true
@@ -10901,7 +10901,7 @@ paths:
           is_list_add: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
-          keySnake: manual_journal_line
+          keySnake: manual_journal_lines
           object: debit
         - manualJournal:
           is_object: true
@@ -10929,7 +10929,7 @@ paths:
           keyPascal: JournalLines
           keySnake: journal_lines
           default: manualJournalLines
-          python: manual_journal_line
+          python: manual_journal_lines
           object: manualJournal
         - manualJournals:
           is_object: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22167,7 +22167,7 @@ paths:
           keyPascal: TaxRates
           keySnake: tax_rates
           java: TaxRates
-          keySnake: tax_rate
+          python: tax_rate
           object: taxRate
       responses:
         '200':

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -16780,7 +16780,7 @@ paths:
           php: XeroAPI\XeroPHP\Models\Accounting\LineAmountTypes::INCLUSIVE
           node: LineAmountTypes.Inclusive
           ruby: XeroRuby::Accounting::INCLUSIVE
-          python_string: INCLUSIVE
+          python_string: LineAmountTypes.INCLUSIVE
           java: com.xero.models.accounting.LineAmountTypes.INCLUSIVE
           csharp: LineAmountTypes.xxx
           object: receipt

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -10861,6 +10861,7 @@ paths:
           default: 400
           object: credit
         - description:
+          is_last: true
           key: description
           keyPascal: Description
           default: "Hello there"
@@ -10870,6 +10871,7 @@ paths:
           is_list_add: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
+          keySnake: manual_journal_line
           object: credit
         - debit:
           is_object: true
@@ -10889,6 +10891,7 @@ paths:
           default: 120
           object: debit
         - description:
+          is_last: true
           key: description
           keyPascal: Description
           default: "Hello there"
@@ -10898,6 +10901,7 @@ paths:
           is_list_add: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
+          keySnake: manual_journal_line
           object: debit
         - manualJournal:
           is_object: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3440,7 +3440,7 @@ paths:
           description: Filter by a comma separated list of ContactIDs. Allows you to retrieve a specific set of contacts in a single call.
           style: form
           explode: false
-          example: "00000000-0000-0000-000-000000000000,00000000-0000-0000-000-000000000000"
+          example: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
           x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"),UUID.fromString("00000000-0000-0000-000-000000000000"))
           x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
           schema:

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -11202,38 +11202,21 @@ paths:
       x-node-requestBody: '{ manualJournals: [{ narration: "Foo bar", journalLines: [{ lineAmount: 100.0, accountCode: "400", description: "Hello there" },{ lineAmount: -100.0, accountCode: "400", description: "Goodbye", tracking: [{ name: "Simpsons", option: "Bart" }]}], date: "2019-03-14" }]}'
       x-ruby-requestBody: 'manual_journals = { manual_journals: [{ narration: "Foo bar", date: "2019-03-14", journal_lines: [{ line_amount: 100.0, account_code: "400", description: "Hello there" },{ line_amount: -100.0, account_code: "400", description: "Goodbye", tracking: [{ name: "Simpsons", option: "Bart" }]}] }]}'
       x-example:
-        - manualJournals:
-          is_array: true
-          key: manualJournals
-          keyPascal: ManualJournals
-        - manualJournal:
-          is_object: true
-          key: manualJournal
-          keyPascal: ManualJournal
-        - narration:
-          key: narration
-          keyPascal: Narration
-          default: Foobar
-          object: manualJournal
         - dateValue:
           is_date: true
           key: dateValue
           keyPascal: Date
+          keySnake: date_value
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.of(2020, Month.OCTOBER, 10)"
           php: "new DateTime('2019-10-10')"
-        - date:
-          is_variable: true
-          nonString: true
-          key: date
-          keyPascal: Date
-          default: dateValue
-          object: manualJournal
+          python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
         - manualJournalLines:
           is_list: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
+          keySnake: manual_journal_lines
         - credit:
           is_object: true
           key: credit
@@ -11242,22 +11225,27 @@ paths:
           nonString: true
           key: lineAmount
           keyPascal: LineAmount
+          keySnake: line_amount
           default: 100.0
           object: credit
         - accountCode:
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: 400
           object: credit
         - description:
+          is_last: true
           key: description
           keyPascal: Description
           default: "Hello there"
           object: credit
         - add_credit:
+          is_last: true
           is_list_add: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
+          keySnake: manual_journal_lines
           object: credit
         - debit:
           is_object: true
@@ -11267,36 +11255,69 @@ paths:
           nonString: true
           key: lineAmount
           keyPascal: LineAmount
+          keySnake: line_amount
           default: -100.0
           object: debit
         - accountCode:
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: 120
           object: debit
         - description:
+          is_last: true
           key: description
           keyPascal: Description
           default: "Hello there"
           object: debit
         - add_debit:
+          is_last: true
           is_list_add: true
           key: manualJournalLines
           keyPascal: ManualJournalLine
+          keySnake: manual_journal_lines
           object: debit
+        - manualJournal:
+          is_object: true
+          key: manualJournal
+          keyPascal: ManualJournal
+          keySnake: manual_journal
+        - narration:
+          key: narration
+          keyPascal: Narration
+          default: Foobar
+          object: manualJournal
+        - date:
+          is_variable: true
+          nonString: true
+          key: date
+          keyPascal: Date
+          default: dateValue
+          python: date_value
+          object: manualJournal
         - set_manualJournalLines:
+          is_last: true
           is_variable: true
           nonString: true
           key: manualJournalLines
           keyPascal: JournalLines
+          keySnake: journal_lines
           default: manualJournalLines
+          python: manual_journal_lines
           object: manualJournal
+        - manualJournals:
+          is_object: true
+          key: manualJournals
+          keyPascal: ManualJournals
         - add_manualJournal:
+          is_last: true
           is_array_add: true
           key: manualJournals
           keyPascal: ManualJournals
+          keySnake: manual_journals
           java: ManualJournals
           php: manualJournals
+          python: manual_journal
           object: manualJournal
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -14638,39 +14659,33 @@ paths:
       x-node-requestBody: '{ purchaseOrders: [ { contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "710" }], date: "2019-03-13" }]}'
       x-ruby-requestBody: 'purchase_orders = { purchase_orders: [{ contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "710" }], date: "2019-03-13" }]}'
       x-example:
-        - purchaseOrders:
-          is_array: true
-          key: purchaseOrders
-          keyPascal: PurchaseOrders
-        - purchaseOrder:
-          is_object: true
-          key: purchaseOrder
-          keyPascal: PurchaseOrder
+        - dateValue:
+          is_date: true
+          key: dateValue
+          keyPascal: Date
+          keySnake: date_value
+          java_datatype: LocalDate
+          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
+          java: "LocalDate.now()"
+          php: "new DateTime('2019-12-10')"
+          python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
         - contact:
           is_object: true
           key: contact
           keyPascal: Contact
         - contactID:
+          is_last: true
           is_uuid: true
           key: contactId
           keyPascal: ContactID
+          keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - set_contact:
-          is_variable: true
-          nonString: true
-          key: contact
-          keyPascal: Contact
-          default: contact
-          object: purchaseOrder
-        - lineItems:
-          is_list: true
-          key: lineItems
-          keyPascal: LineItem
         - lineItem:
           is_object: true
           key: lineItem
           keyPascal: LineItem
+          keySnake: line_item
         - description:
           key: description
           keyPascal: Description
@@ -14686,45 +14701,71 @@ paths:
           nonString: true
           key: unitAmount
           keyPascal: UnitAmount
+          keySnake: unit_amount
           default: 20.0
           object: lineItem
         - accountCode:
+          is_last: true
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: "000"
           object: lineItem
+        - lineItems:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItem
+          keySnake: line_items
         - add_lineitems:
+          is_last: true
           is_list_add: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
+          python: line_item
           object: lineItem
+        - purchaseOrder:
+          is_object: true
+          key: purchaseOrder
+          keyPascal: PurchaseOrder
+          keySnake: purchase_order
+        - set_contact:
+          is_variable: true
+          nonString: true
+          key: contact
+          keyPascal: Contact
+          default: contact
+          object: purchaseOrder
         - set_lineitem:
           is_variable: true
           nonString: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           default: lineItems
+          python: line_items
           object: purchaseOrder
-        - dateValue:
-          is_date: true
-          key: dateValue
-          keyPascal: Date
-          java_datatype: LocalDate
-          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          java: "LocalDate.now()"
-          php: "new DateTime('2020-12-10')"
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date
           keyPascal: Date
           default: dateValue
+          python: date_value
           object: purchaseOrder
+        - purchaseOrders:
+          is_object: true
+          key: purchaseOrders
+          keyPascal: PurchaseOrders
         - add_purchaseOrder:
+          is_last: true
           is_array_add: true
           key: purchaseOrders
           keyPascal: PurchaseOrders
+          keySnake: purchase_orders
           java: PurchaseOrders
+          python: purchase_order
           object: purchaseOrder
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -16020,39 +16061,33 @@ paths:
       x-node-requestBody: '{ quotes: [{ contact: { contactID: "00000000-0000-0000-000-000000000000" }, lineItems: [{ description: "Foobar", quantity: 1.0, unitAmount: 20.0, accountCode: "12775" }], date: "2020-02-01" }]}'
       x-ruby-requestBody: 'quotes = { quotes: [{ contact: { contact_id: "00000000-0000-0000-000-000000000000" }, line_items: [{ description: "Foobar", quantity: 1.0, unit_amount: 20.0, account_code: "12775" }], date: "2020-02-01" }]}'
       x-example:
-        - quotes:
-          is_array: true
-          key: quotes
-          keyPascal: Quotes
-        - quote:
-          is_object: true
-          key: quote
-          keyPascal: Quote
+        - dateValue:
+          is_date: true
+          key: dateValue
+          keyPascal: Date
+          keySnake: date_value
+          java_datatype: LocalDate
+          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
+          java: "LocalDate.now()"
+          php: "new DateTime('2019-12-10')"
+          python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
         - contact:
           is_object: true
           key: contact
           keyPascal: Contact
         - contactID:
+          is_last: true
           is_uuid: true
           key: contactId
           keyPascal: ContactID
+          keySnake: contact_id
           default: 00000000-0000-0000-000-000000000000
           object: contact
-        - set_contact:
-          is_variable: true
-          nonString: true
-          key: contact
-          keyPascal: Contact
-          default: contact
-          object: quote
-        - lineItems:
-          is_list: true
-          key: lineItems
-          keyPascal: LineItem
         - lineItem:
           is_object: true
           key: lineItem
           keyPascal: LineItem
+          keySnake: line_item
         - description:
           key: description
           keyPascal: Description
@@ -16068,41 +16103,64 @@ paths:
           nonString: true
           key: unitAmount
           keyPascal: UnitAmount
+          keySnake: unit_amount
           default: 20.0
           object: lineItem
         - accountCode:
+          is_last: true
           key: accountCode
           keyPascal: AccountCode
+          keySnake: account_code
           default: "000"
           object: lineItem
+        - lineItems:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItem
+          keySnake: line_items
         - add_lineitems:
+          is_last: true
           is_list_add: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           object: lineItem
+          python: line_item
+        - quote:
+          is_object: true
+          key: quote
+          keyPascal: Quote
+        - set_contact:
+          is_variable: true
+          nonString: true
+          key: contact
+          keyPascal: Contact
+          default: contact
+          object: quote
         - set_lineitem:
           is_variable: true
           nonString: true
           key: lineItems
           keyPascal: LineItems
+          keySnake: line_items
           default: lineItems
+          python: line_items
           object: quote
-        - dateValue:
-          is_date: true
-          key: dateValue
-          keyPascal: Date
-          java_datatype: LocalDate
-          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          java: "LocalDate.now()"
-          php: "new DateTime('2019-12-10')"
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date
           keyPascal: Date
           default: dateValue
+          python: date_value
           object: quote
+        - quotes:
+          is_object: true
+          key: quotes
+          keyPascal: Quotes
         - add_quote:
+          is_last: true
           is_array_add: true
           key: quotes
           keyPascal: Quotes

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -10068,6 +10068,7 @@ paths:
           default: ItemCode123
           object: item
         - description:
+          is_last: true
           key: description
           keyPascal: Description
           default: Goodbye

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -21812,14 +21812,6 @@ paths:
       operationId: postSetup
       summary: Allows you to set the chart of accounts, the conversion date and conversion balances
       x-example:
-        - Setup:
-          is_object: true
-          key: setup
-          keyPascal: Setup
-        - accounts:
-          is_list: true
-          key: accounts
-          keyPascal: Account
         - account:
           is_object: true
           key: account
@@ -21835,6 +21827,7 @@ paths:
           default: Business supplies
           object: account
         - type:
+          is_last: true
           key: type
           keyPascal: Type
           default: EXPENSE
@@ -21846,11 +21839,20 @@ paths:
           java: com.xero.models.accounting.AccountType.EXPENSE
           csharp: Account.ClassEnum.EXPENSE
           object: account
+        - accounts:
+          is_list: true
+          key: accounts
+          keyPascal: Account
         - add_accounts:
+          is_last: true
           is_list_add: true
           key: accounts
           keyPascal: Accounts
           object: account
+        - Setup:
+          is_object: true
+          key: setup
+          keyPascal: Setup
         - set_accounts:
           is_variable: true
           nonString: true
@@ -21862,6 +21864,7 @@ paths:
           is_object: true
           key: conversionDate
           keyPascal: ConversionDate
+          keySnake: conversion_date
         - month:
           nonString: true
           key: month
@@ -21869,6 +21872,7 @@ paths:
           default: 10
           object: conversionDate
         - year:
+          is_last: true
           nonString: true
           key: year
           keyPascal: Year
@@ -21879,17 +21883,21 @@ paths:
           nonString: true
           key: conversionDate
           keyPascal: ConversionDate
+          keySnake: conversion_date
           default: conversionDate
           object: setup
         - conversionBalances:
           is_list: true
           key: conversionBalances
           keyPascal: ConversionBalances
+          keySnake: conversion_balances
         - set_conversionBalances:
+          is_last: true
           is_variable: true
           nonString: true
           key: conversionBalances
           keyPascal: ConversionBalances
+          keySnake: conversion_balances
           default: conversionBalances
           object: setup
       responses:

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -12903,24 +12903,43 @@ paths:
       x-node-requestBody: '{ invoice: { invoiceID: "00000000-0000-0000-000-000000000000", lineItems: [], contact: {}, type: Invoice.TypeEnum.ACCPAY }, account: { code: "970" }, date: "2019-03-12", amount: 1.0 }'
       x-ruby-requestBody: 'invoice = { invoice: { invoice_id: "00000000-0000-0000-000-000000000000", line_items: [], contact: {}, type: XeroRuby::Accounting::Invoice::ACCPAY }, account: { code: "970" }, date: "2019-03-12", amount: 1.0 }'
       x-example:
-        - payments:
-          is_array: true
-          key: payments
-          keyPascal: Payments
-        - payment:
-          is_object: true
-          key: payment
-          keyPascal: Payment
+        - dateValue:
+          is_date: true
+          key: dateValue
+          keyPascal: Date
+          keySnake: date_value
+          java_datatype: LocalDate
+          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
+          java: "LocalDate.now()"
+          php: "new DateTime('2020-10-10')"
+          python: "dateutil.parser.parse('2020-10-10T00:00:00Z')"
         - invoice:
           is_object: true
           key: invoice
           keyPascal: Invoice
         - invoiceID:
+          is_last: true
           is_uuid: true
           key: invoiceID
           keyPascal: InvoiceID
+          keySnake: invoice_id
           default: 00000000-0000-0000-000-000000000000
           object: invoice
+        - account:
+          is_object: true
+          key: account
+          keyPascal: Account
+        - accountID:
+          is_last: true
+          key: accountID
+          keyPascal: AccountID
+          keySnake: account_id
+          default: 00000000-0000-0000-000-000000000000
+          object: account
+        - payment:
+          is_object: true
+          key: payment
+          keyPascal: Payment
         - set_invoice:
           is_variable: true
           nonString: true
@@ -12928,15 +12947,6 @@ paths:
           keyPascal: Invoice
           default: invoice
           object: payment
-        - account:
-          is_object: true
-          key: account
-          keyPascal: Account
-        - accountID:
-          key: accountID
-          keyPascal: AccountID
-          default: 00000000-0000-0000-000-000000000000
-          object: account
         - set_account:
           is_variable: true
           nonString: true
@@ -12950,21 +12960,19 @@ paths:
           keyPascal: Amount
           default: 1.0
           object: payment
-        - dateValue:
-          is_date: true
-          key: dateValue
-          keyPascal: Date
-          java_datatype: LocalDate
-          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          java: "LocalDate.now()"
-          php: "new DateTime('2019-12-10')"
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date
           keyPascal: Date
           default: dateValue
+          python: date_value
           object: payment
+        - payments:
+          is_object: true
+          key: payments
+          keyPascal: Payments
         - add_payment:
           is_array_add: true
           key: payments

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22150,23 +22150,24 @@ paths:
           default: CA State Tax
           object: taxRate
         - add_taxComponent:
-          is_array_add: true
           is_last: true
-          key: taxRate
-          keyPascal: TaxRate
+          is_array_add: true
+          key: taxComponents
+          keyPascal: TaxComponents
+          keySnake: tax_components
           java: TaxComponents
           python: tax_component
           object: taxComponent
         - taxRates:
-          is_array: true
+          is_object: true
           key: taxRates
           keyPascal: TaxRates
-          keySnake: tax_rates
         - add_taxRate:
           is_last: true
           is_array_add: true
           key: taxRates
           keyPascal: TaxRates
+          keySnake: tax_rates
           java: TaxRates
           python: tax_rate
           object: taxRate

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -10683,26 +10683,29 @@ paths:
       x-node-requestBody: '{ linkedTransactions: [{ sourceLineItemID: "00000000-0000-0000-000-000000000000", contactID: "00000000-0000-0000-000-000000000000" }]}'
       x-ruby-requestBody: 'linked_transactions = { linked_transactions: [{ source_line_item_id: "00000000-0000-0000-000-000000000000", contact_id: "00000000-0000-0000-000-000000000000" }]}'
       x-example:
-        - linkedTransactions:
-          is_array: true
-          key: linkedTransactions
-          keyPascal: LinkedTransactions
         - linkedTransaction:
           is_object: true
           key: linkedTransaction
           keyPascal: LinkedTransaction
+          keySnake: linked_transaction
         - sourceLineItemID:
           is_uuid: true
           key: sourceLineItemID
           keyPascal: SourceLineItemID
+          keySnake: source_line_item_id
           default: 00000000-0000-0000-000-000000000000
           object: linkedTransaction
         - contactID:
+          is_last: true
           is_uuid: true
           key: contactID
           keyPascal: ContactID
           default: 00000000-0000-0000-000-000000000000
           object: linkedTransaction
+        - linkedTransactions:
+          is_object: true
+          key: linkedTransactions
+          keyPascal: LinkedTransactions
         - add_linkedTransaction:
           is_array_add: true
           key: linkedTransactions

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -16348,10 +16348,28 @@ paths:
       x-node-requestBody: '{ quotes: [{ reference: "I am an update", contact: { contactID: "00000000-0000-0000-000-000000000000" }, date: "2020-02-01" }]}'
       x-ruby-requestBody: 'quotes = { quotes: [{ reference: "I am an update", contact: { contact_id: "00000000-0000-0000-000-000000000000" }, date: "2020-02-01" }]}'
       x-example:
-        - quotes:
-          is_array: true
-          key: quotes
-          keyPascal: Quotes
+        - dateValue:
+          is_date: true
+          key: dateValue
+          keyPascal: Date
+          keySnake: date_value
+          java_datatype: LocalDate
+          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
+          java: "LocalDate.now()"
+          php: "new DateTime('2019-12-10')"
+          python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
+        - contact:
+          is_object: true
+          key: contact
+          keyPascal: Contact
+        - contactID:
+          is_last: true
+          is_uuid: true
+          key: contactId
+          keyPascal: ContactID
+          keySnake: contact_id
+          default: 00000000-0000-0000-000-000000000000
+          object: contact
         - quote:
           is_object: true
           key: quote
@@ -16361,16 +16379,6 @@ paths:
           keyPascal: Reference
           default: I am an update
           object: quote
-        - contact:
-          is_object: true
-          key: contact
-          keyPascal: Contact
-        - contactID:
-          is_uuid: true
-          key: contactId
-          keyPascal: ContactID
-          default: 00000000-0000-0000-000-000000000000
-          object: contact
         - set_contact:
           is_variable: true
           nonString: true
@@ -16378,22 +16386,21 @@ paths:
           keyPascal: Contact
           default: contact
           object: quote
-        - dateValue:
-          is_date: true
-          key: dateValue
-          keyPascal: Date
-          java_datatype: LocalDate
-          default: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          java: "LocalDate.now()"
-          php: "new DateTime('2019-12-10')"
         - date:
+          is_last: true
           is_variable: true
           nonString: true
           key: date
           keyPascal: Date
           default: dateValue
+          python: date_value
           object: quote
+        - quotes:
+          is_object: true
+          key: quotes
+          keyPascal: Quotes
         - add_quote:
+          is_last: true
           is_array_add: true
           key: quotes
           keyPascal: Quotes

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -7984,7 +7984,7 @@ paths:
           description: Filter by a comma-separated list of InvoicesIDs. 
           style: form
           explode: false
-          example: "00000000-0000-0000-000-000000000000,00000000-0000-0000-000-000000000000"
+          example: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
           x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"),UUID.fromString("00000000-0000-0000-000-000000000000"))
           x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
           schema:
@@ -7997,7 +7997,7 @@ paths:
           description: Filter by a comma-separated list of InvoiceNumbers. 
           style: form
           explode: false
-          example: "null"
+          example: '&quot;INV-001&quot;, &quot;INV-002&quot;'
           x-example-java: Arrays.asList("INV-001","INV-002")
           x-example-php: '&quot;INV-001&quot;, &quot;INV-002&quot;'
           schema:
@@ -8009,7 +8009,7 @@ paths:
           description: Filter by a comma-separated list of ContactIDs. 
           style: form
           explode: false
-          example: "00000000-0000-0000-000-000000000000,00000000-0000-0000-000-000000000000"
+          example: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
           x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"),UUID.fromString("00000000-0000-0000-000-000000000000"))
           x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;, &quot;00000000-0000-0000-000-000000000000&quot;'
           schema:
@@ -8021,7 +8021,7 @@ paths:
           name: Statuses
           description: Filter by a comma-separated list Statuses. For faster response times we recommend using these explicit parameters instead of passing OR conditions into the Where filter.
           explode: false
-          example: "null"
+          example: '&quot;DRAFT&quot;, &quot;SUBMITTED&quot;'
           x-example-java: Arrays.asList("DRAFT","SUBMITTED")
           x-example-php: '&quot;DRAFT&quot;, &quot;SUBMITTED&quot;'
           schema:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Using vendor extension to define meta data for use to generate runnable code examples in java, php and python.

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
### Java
![Screen Shot 2021-01-07 at 9 32 45 AM](https://user-images.githubusercontent.com/595967/103952060-93645300-50f4-11eb-84ed-ca717bebe289.png)

### PHP
![Screen Shot 2021-01-07 at 9 36 57 AM](https://user-images.githubusercontent.com/595967/103952076-9bbc8e00-50f4-11eb-866c-437173c67be0.png)

### Python
![Screen Shot 2021-01-07 at 9 37 47 AM](https://user-images.githubusercontent.com/595967/103952011-83e50a00-50f4-11eb-8383-ac98e7242c50.png)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
