### PR TITLE
Dct 148 fix open api linting issues

### DIFF
--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -29,7 +29,7 @@ paths:
           required: false
           name: authEventId
           description: Filter by authEventId
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -43,16 +43,16 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Connection'
-              example: '[
+              example: [
                           {
                             "id": "7cb59f93-2964-421d-bb5e-a0f7a4572a44",
                             "tenantId": "fe79f7dd-b6d4-4a92-ba7b-538af6289c58",
                             "tenantName": "Demo Company (NZ)",
                             "tenantType": "ORGANISATION",
-                            "createdDateUtc": "2019-12-07T18:46:19.5165400",
-                            "updatedDateUtc": "2019-12-07T18:46:19.5187840"
+                            "createdDateUtc": 2019-12-07T18:46:19Z,
+                            "updatedDateUtc": 2019-12-07T18:46:19Z
                           }
-                        ]'
+                        ]
   '/connections/{id}':
     delete:
       security:

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -74,7 +74,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Projects'
-              example: '{
+              example: {
                           "pagination":{
                               "page":1,
                               "pageSize":50,
@@ -145,7 +145,7 @@ paths:
                                 "status":"INPROGRESS"
                               }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error' 
     post:
@@ -162,13 +162,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ProjectCreateOrUpdate'
-            example:
-              '{
-                "contactId":"00000000-0000-0000-000-000000000000",
+            example: {
+                "contactId": 00000000-0000-0000-0000-000000000000,
                 "name":"New Kitchen",
                 "deadlineUtc":"2019-12-10T12:59:59Z",
-                "estimateAmount":"99.99"
-               }'
+                "estimateAmount": 99.99
+            }
       responses:
         '201':
           description: OK/success, returns the new project object
@@ -176,7 +175,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Project'
-              example: '{ 
+              example:  { 
                           "projectId":"ed957eee-bc6f-4f52-a663-aa42e6af9620",
                           "contactId":"216830cb-9a68-487e-928b-c1a7ccc4fc81",
                           "name":"New Kitchen",
@@ -237,7 +236,7 @@ paths:
                               "value":99.99
                           },
                           "status":"INPROGRESS"
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
   '/projects/{projectId}':
@@ -266,7 +265,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Project'
-              example: '{
+              example:  {
                           "projectId":"b021e7cb-1903-4292-b48b-5b27b4271e3e",
                           "contactId":"216830cb-9a68-487e-928b-c1a7ccc4fc81",
                           "name":"FooProject28916",
@@ -327,7 +326,7 @@ paths:
                               "value":99.99
                           },
                           "status":"INPROGRESS"
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error' 
     put:
@@ -354,11 +353,11 @@ paths:
             schema:
               $ref: '#/components/schemas/ProjectCreateOrUpdate'
             example:
-              '{
+               {
                 "name": "New Kitchen",
                 "deadlineUtc": "2017-04-23T18:25:43.511Z",
                 "estimateAmount": 99.99
-                }'
+                }
       responses:
         '204':
           description: Success - return response 204 no content
@@ -389,9 +388,9 @@ paths:
             schema:
               $ref: '#/components/schemas/ProjectPatch'
             example:
-              '{
+               {
                 "status": "INPROGRESS"
-                }'
+                }
       responses:
         '204':
           description: Success - return response 204 no content
@@ -435,7 +434,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProjectUsers'
-              example: '{
+              example:  {
                           "pagination":{
                               "page":1,
                               "pageSize":50,
@@ -454,7 +453,7 @@ paths:
                                 "email":"api@test.xero.com"
                               }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error' 
   /projects/{projectId}/tasks:
@@ -493,8 +492,7 @@ paths:
           description: "taskIds	Search for all tasks that match a comma separated list of taskIds, i.e. GET https://.../tasks?taskIds={taskId},{taskId}"  
           schema:
             type: string
-        - name: chargeType
-          $ref: '#/components/parameters/chargeType'  
+        - $ref: '#/components/parameters/chargeType'  
       responses:
         '200':
           description: OK/success, returns a list of task objects
@@ -502,7 +500,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Tasks'
-              example: '{
+              example:  {
                           "pagination": {
                             "page": 1,
                             "pageSize": 50,
@@ -540,7 +538,7 @@ paths:
                               }
                             }
                           ]
-                        }'
+                        }
     # post:
     #   security:
     #     - OAuth2: [projects, projects.read]
@@ -608,7 +606,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Task'
-              example: '{
+              example:  {
                           "name": "Demolition",
                           "rate": {
                             "currency": "AUD",
@@ -636,7 +634,7 @@ paths:
                             "currency": "AUD",
                             "value": 0
                           }
-                        }'
+                        }
     # put:
     #   security:
     #     - OAuth2: [projects, projects.read]
@@ -788,7 +786,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TimeEntries'
-              example: '{
+              example:  {
                           "pagination":{
                               "page":1,
                               "pageSize":50,
@@ -819,7 +817,7 @@ paths:
                                 "status":"ACTIVE"
                               }
                           ]
-                        }'
+                        }
     post:
       security:
         - OAuth2: [projects, projects.read]
@@ -843,13 +841,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TimeEntryCreateOrUpdate'
-            example: '{
+            example:  {
                         "userId":"740add2a-a703-4b8a-a670-1093919c2040",
                         "taskId":"7be77337-feec-4458-bb1b-dbaa5a4aafce",
                         "dateUtc":"2020-02-26T15:00:00Z",
                         "duration":30,
                         "description":"My description"
-                      }'
+                      }
       responses:
         '200':
           description: OK/success, returns the newly created time entry
@@ -857,7 +855,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TimeEntry'
-              example: '{
+              example:  {
                           "timeEntryId":"c6539534-f1d2-43a6-80df-3bd1f8aca24d",
                           "userId":"740add2a-a703-4b8a-a670-1093919c2040",
                           "projectId":"b021e7cb-1903-4292-b48b-5b27b4271e3e",
@@ -867,7 +865,7 @@ paths:
                           "duration":30,
                           "description":"My description",
                           "status":"ACTIVE"
-                        }'
+                        }
   /projects/{projectId}/time/{timeEntryId}:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -901,7 +899,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TimeEntry'
-              example: '{
+              example:  {
                           "timeEntryId":"3cd35eca-704f-4bca-b258-236028ae8ed1",
                           "userId":"740add2a-a703-4b8a-a670-1093919c2040",
                           "projectId":"b021e7cb-1903-4292-b48b-5b27b4271e3e",
@@ -911,7 +909,7 @@ paths:
                           "duration":45,
                           "description":"My description",
                           "status":"ACTIVE"
-                        }'
+                        }
     put:
       security:
         - OAuth2: [projects, projects.read]
@@ -942,13 +940,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TimeEntryCreateOrUpdate'
-            example: '{
+            example:  {
                         "userId":"740add2a-a703-4b8a-a670-1093919c2040",
                         "taskId":"7be77337-feec-4458-bb1b-dbaa5a4aafce",
                         "dateUtc":"2020-02-27T15:00:00Z",
                         "duration":45,
                         "description":"My UPDATED description"
-                      }'
+                      }
       responses:
         '204':
           description: Success - return response 204 no content
@@ -1055,7 +1053,6 @@ components:
       properties:      
         status:
           $ref: '#/components/schemas/ProjectStatus'
-          type: string
       required:
         - status
     Project:
@@ -1081,7 +1078,6 @@ components:
           description: Name of the project.
         currencyCode:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         minutesLogged:
           type: integer
           example: 0
@@ -1124,7 +1120,6 @@ components:
         estimate:
           $ref: '#/components/schemas/Amount'
         status:
-          type: string
           $ref: '#/components/schemas/ProjectStatus'
       required:
         - name    
@@ -1180,7 +1175,6 @@ components:
       properties:
           currency:
             $ref: '#/components/schemas/CurrencyCode'
-            type: string
           value:
             type: number
             format: double
@@ -1392,17 +1386,15 @@ components:
         taskId:
           type: string
           format: uuid
-          example: '00000000-0000-0000-000-000000000000'
+          example: 00000000-0000-0000-0000-000000000000
           description: Identifier of the task.
         name:
           type: string
           description: Name of the task.
         rate:
           $ref: '#/components/schemas/Amount'
-          type: number
         chargeType:
           $ref: '#/components/schemas/ChargeType'
-          type: string
         estimateMinutes:
           type: number
           format: double
@@ -1410,7 +1402,7 @@ components:
         projectId:
           type: string
           format: uuid
-          example: '00000000-0000-0000-000-000000000000'
+          example: 00000000-0000-0000-0000-000000000000
           description: Identifier of the project task belongs to.
         totalMinutes:
           type: number
@@ -1418,7 +1410,6 @@ components:
           description: Total minutes which have been logged against the task. Logged by assigning a time entry to a task
         totalAmount:
           $ref: '#/components/schemas/Amount'
-          type: number
         minutesInvoiced:
           type: number
           format: double
@@ -1437,10 +1428,8 @@ components:
           description: Minutes logged against this task if its charge type is `NON_CHARGEABLE`.
         amountToBeInvoiced:
           $ref: '#/components/schemas/Amount'
-          type: number
         amountInvoiced:
           $ref: '#/components/schemas/Amount'
-          type: number
         status:
           type: string
           enum:
@@ -1468,7 +1457,6 @@ components:
           $ref: '#/components/schemas/Amount'
         chargeType:
           $ref: '#/components/schemas/ChargeType'
-          type: string
         estimateMinutes:
           type: integer
           description: "Estimated time to perform the task. EstimateMinutes has to be greater than 0 if provided."
@@ -1495,22 +1483,22 @@ components:
         timeEntryId:
           type: string
           format: uuid
-          example: '00000000-0000-0000-000-000000000000'
+          example: 00000000-0000-0000-0000-000000000000
           description: Identifier of the time entry.
         userId:
           type: string
           format: uuid
-          example: '00000000-0000-0000-000-000000000000'
+          example: 00000000-0000-0000-0000-000000000000
           description: The xero user identifier of the person who logged time.
         projectId:
           type: string
           format: uuid
-          example: '00000000-0000-0000-000-000000000000'
+          example: 00000000-0000-0000-0000-000000000000
           description: Identifier of the project, that the task (which the time entry is logged against) belongs to.
         taskId:
           type: string
           format: uuid
-          example: '00000000-0000-0000-000-000000000000'
+          example: 00000000-0000-0000-0000-000000000000
           description: Identifier of the task that time entry is logged against.
         dateUtc:
           type: string
@@ -1540,12 +1528,12 @@ components:
         userId:
           type: string
           format: uuid
-          example: '00000000-0000-0000-000-000000000000'
+          example: 00000000-0000-0000-0000-000000000000
           description: "The xero user identifier of the person logging the time."
         taskId:
           type: string
           format: uuid
-          example: '00000000-0000-0000-000-000000000000'
+          example: 00000000-0000-0000-0000-000000000000
           description: "Identifier of the task that time entry is logged against."
         dateUtc:
           type: string

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -2818,7 +2818,7 @@ paths:
                             "FromBankAccount": {
                               "Code": "090",
                               "Name": "My Savings",
-                              "AccountID": "00000000-0000-0000-000-000000000000",
+                              "AccountID": 00000000-0000-0000-0000-000000000000,
                               "Type": "BANK",
                               "BankAccountNumber": "123455",
                               "Status": "ACTIVE",
@@ -2836,7 +2836,7 @@ paths:
                             "ToBankAccount": {
                               "Code": "088",
                               "Name": "Business Wells Fargo",
-                              "AccountID": "00000000-0000-0000-000-000000000000",
+                              "AccountID": 00000000-0000-0000-0000-000000000000,
                               "Type": "BANK",
                               "BankAccountNumber": "123455",
                               "Status": "ACTIVE",
@@ -3219,7 +3219,7 @@ paths:
           in: path
           name: BankTransferID
           description: Xero generated unique identifier for a bank transfer
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -3247,7 +3247,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BrandingThemes'
-              example: '{
+              example:  {
                           "Id": "d1a1beea-bdfe-4ee4-9dbc-27226a26cd68",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -3260,7 +3260,7 @@ paths:
                               "CreatedDateUTC": "\/Date(1464967643813+0000)\/"
                             }
                           ]
-                        }'
+                        }
   '/BrandingThemes/{BrandingThemeID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -3276,7 +3276,7 @@ paths:
           in: path
           name: BrandingThemeID
           description: Unique identifier for a Branding Theme         
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -3287,7 +3287,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BrandingThemes'
-              example: '{
+              example:  {
                           "Id": "df671650-cf14-4a7f-b609-4166933719bc",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -3300,7 +3300,7 @@ paths:
                               "CreatedDateUTC": "\/Date(1464967643813+0000)\/"
                             }
                           ]
-                        }'
+                        }
   '/BrandingThemes/{BrandingThemeID}/PaymentServices':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -3316,7 +3316,7 @@ paths:
           in: path
           name: BrandingThemeID
           description: Unique identifier for a Branding Theme  
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid 
@@ -3327,7 +3327,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaymentServices'
-              example: '{
+              example:  {
                           "Id": "bfd5adbe-0e92-48f0-8c5a-39072f6c4ed3",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -3346,7 +3346,7 @@ paths:
                               "PayNowText": "Pay Now"
                             }
                           ]
-                        }'
+                        }
     post:
       security:
         - OAuth2: [paymentservices]
@@ -3388,7 +3388,7 @@ paths:
           in: path
           name: BrandingThemeID
           description: Unique identifier for a Branding Theme 
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -3399,7 +3399,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaymentServices'
-              example: '{  
+              example:  {  
                          "Id": "918feecb-067a-4ed9-841b-571c04eaada3",
                          "Status": "OK",
                          "ProviderName": "Xero API Partner",
@@ -3413,7 +3413,7 @@ paths:
                                "PayNowText": "Pay Now"
                             }
                          ]
-                      }'
+                      }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -3461,7 +3461,7 @@ paths:
           description: Filter by a comma separated list of ContactIDs. Allows you to retrieve a specific set of contacts in a single call.
           style: form
           explode: false
-          example: '&quot;00000000-0000-0000-000-000000000000&quot;'
+          example: ['&quot;00000000-0000-0000-000-000000000000&quot;']
           x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"))
           x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;'
           schema:
@@ -4361,7 +4361,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact 
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -4543,7 +4543,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -4678,7 +4678,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -4697,7 +4697,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -4705,7 +4705,7 @@ paths:
           in: path
           name: AttachmentID
           description: Unique identifier for a Attachment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -4739,7 +4739,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -4777,7 +4777,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -4833,7 +4833,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -4892,7 +4892,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -4918,7 +4918,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -4964,7 +4964,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -5136,7 +5136,7 @@ paths:
           in: path
           name: ContactGroupID
           description: Unique identifier for a Contact Group
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -5221,7 +5221,7 @@ paths:
           in: path
           name: ContactGroupID
           description: Unique identifier for a Contact Group
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -5305,7 +5305,7 @@ paths:
           in: path
           name: ContactGroupID
           description: Unique identifier for a Contact Group
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -5373,7 +5373,7 @@ paths:
           in: path
           name: ContactGroupID
           description: Unique identifier for a Contact Group
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -5396,7 +5396,7 @@ paths:
           in: path
           name: ContactGroupID
           description: Unique identifier for a Contact Group
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -5404,7 +5404,7 @@ paths:
           in: path
           name: ContactID
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6098,7 +6098,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6381,7 +6381,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6536,7 +6536,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6578,7 +6578,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6586,7 +6586,7 @@ paths:
           in: path
           name: AttachmentID
           description: Unique identifier for a Attachment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6620,7 +6620,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6659,7 +6659,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6716,7 +6716,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6777,7 +6777,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6866,7 +6866,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6943,7 +6943,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -6989,7 +6989,7 @@ paths:
           in: path
           name: CreditNoteID
           description: Unique identifier for a Credit Note
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -7359,7 +7359,7 @@ paths:
           in: path
           name: EmployeeID
           description: Unique identifier for a Employee
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -7678,7 +7678,7 @@ paths:
           in: path
           name: ExpenseClaimID
           description: Unique identifier for a ExpenseClaim
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -7875,7 +7875,7 @@ paths:
           in: path
           name: ExpenseClaimID
           description: Unique identifier for a ExpenseClaim
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -7998,7 +7998,7 @@ paths:
           in: path
           name: ExpenseClaimID
           description: Unique identifier for a ExpenseClaim
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -8044,7 +8044,7 @@ paths:
           in: path
           name: ExpenseClaimID
           description: Unique identifier for a ExpenseClaim
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -8965,7 +8965,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9166,7 +9166,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9308,7 +9308,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9335,7 +9335,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9385,7 +9385,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9393,7 +9393,7 @@ paths:
           in: path
           name: AttachmentID
           description: Unique identifier for an Attachment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9427,7 +9427,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9466,7 +9466,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9523,7 +9523,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9583,7 +9583,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9627,7 +9627,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9659,7 +9659,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -9705,7 +9705,7 @@ paths:
           in: path
           name: InvoiceID
           description: Unique identifier for an Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10047,7 +10047,7 @@ paths:
           in: path
           name: ItemID
           description: Unique identifier for an Item
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10134,7 +10134,7 @@ paths:
           in: path
           name: ItemID
           description: Unique identifier for an Item
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10195,7 +10195,7 @@ paths:
           in: path
           name: ItemID
           description: Unique identifier for an Item
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10220,7 +10220,7 @@ paths:
           in: path
           name: ItemID
           description: Unique identifier for an Item
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10266,7 +10266,7 @@ paths:
           in: path
           name: ItemID
           description: Unique identifier for an Item
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10485,7 +10485,7 @@ paths:
           in: path
           name: JournalID
           description: Unique identifier for a Journal
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10561,21 +10561,21 @@ paths:
         - in: query
           name: LinkedTransactionID
           description: The Xero identifier for an Linked Transaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
         - in: query
           name: SourceTransactionID
           description: Filter by the SourceTransactionID. Get the linked transactions created from a particular ACCPAY invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
         - in: query
           name: ContactID
           description: Filter by the ContactID. Get all the linked transactions that have been assigned to a particular customer.
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10588,7 +10588,7 @@ paths:
         - in: query
           name: TargetTransactionID
           description: Filter by the TargetTransactionID. Get all the linked transactions allocated to a particular ACCREC invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10711,7 +10711,7 @@ paths:
           in: path
           name: LinkedTransactionID
           description: Unique identifier for a LinkedTransaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10790,7 +10790,7 @@ paths:
           in: path
           name: LinkedTransactionID
           description: Unique identifier for a LinkedTransaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -10875,7 +10875,7 @@ paths:
           in: path
           name: LinkedTransactionID
           description: Unique identifier for a LinkedTransaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -11433,7 +11433,7 @@ paths:
           in: path
           name: ManualJournalID
           description: Unique identifier for a ManualJournal
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -11633,7 +11633,7 @@ paths:
           in: path
           name: ManualJournalID
           description: Unique identifier for a ManualJournal
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -11717,7 +11717,7 @@ paths:
           in: path
           name: ManualJournalID
           description: Unique identifier for a ManualJournal
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -11766,7 +11766,7 @@ paths:
           in: path
           name: ManualJournalID
           description: Unique identifier for a ManualJournal
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -11774,7 +11774,7 @@ paths:
           in: path
           name: AttachmentID
           description: Unique identifier for a Attachment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -11808,7 +11808,7 @@ paths:
           in: path
           name: ManualJournalID
           description: Unique identifier for a ManualJournal
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -11847,7 +11847,7 @@ paths:
           in: path
           name: ManualJournalID
           description: Unique identifier for a ManualJournal
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -11904,7 +11904,7 @@ paths:
           in: path
           name: ManualJournalID
           description: Unique identifier for a ManualJournal
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -11963,7 +11963,7 @@ paths:
           in: path
           name: ManualJournalID
           description: Xero generated unique identifier for a manual journal
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -12009,7 +12009,7 @@ paths:
           in: path
           name: ManualJournalID
           description: Xero generated unique identifier for a manual journal
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -12169,7 +12169,7 @@ paths:
           in: path
           name: OrganisationID
           description: The unique Xero identifier for an organisation
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -12384,7 +12384,7 @@ paths:
           in: path
           name: OverpaymentID
           description: Unique identifier for a Overpayment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -12597,7 +12597,7 @@ paths:
           in: path
           name: OverpaymentID
           description: Unique identifier for a Overpayment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -12676,7 +12676,7 @@ paths:
           in: path
           name: OverpaymentID
           description: Unique identifier for a Overpayment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -12722,7 +12722,7 @@ paths:
           in: path
           name: OverpaymentID
           description: Unique identifier for a Overpayment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -13304,7 +13304,7 @@ paths:
           in: path
           name: PaymentID
           description: Unique identifier for a Payment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -13436,7 +13436,7 @@ paths:
           in: path
           name: PaymentID
           description: Unique identifier for a Payment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -13546,7 +13546,7 @@ paths:
           in: path
           name: PaymentID
           description: Unique identifier for a Payment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -13592,7 +13592,7 @@ paths:
           in: path
           name: PaymentID
           description: Unique identifier for a Payment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -13840,7 +13840,7 @@ paths:
           in: path
           name: PrepaymentID
           description: Unique identifier for a PrePayment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -14050,7 +14050,7 @@ paths:
           in: path
           name: PrepaymentID
           description: Unique identifier for Prepayment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -14127,7 +14127,7 @@ paths:
           in: path
           name: PrepaymentID
           description: Unique identifier for a PrePayment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -14173,7 +14173,7 @@ paths:
           in: path
           name: PrepaymentID
           description: Unique identifier for a PrePayment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -14951,7 +14951,7 @@ paths:
           in: path
           name: PurchaseOrderID
           description: Unique identifier for an Purchase Order
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -14978,7 +14978,7 @@ paths:
           in: path
           name: PurchaseOrderID
           description: Unique identifier for a PurchaseOrder
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -15154,7 +15154,7 @@ paths:
           in: path
           name: PurchaseOrderID
           description: Unique identifier for a PurchaseOrder
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -15445,7 +15445,7 @@ paths:
           in: path
           name: PurchaseOrderID
           description: Unique identifier for a PurchaseOrder
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -15491,7 +15491,7 @@ paths:
           in: path
           name: PurchaseOrderID
           description: Unique identifier for a PurchaseOrder
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -15517,7 +15517,7 @@ paths:
           in: path
           name: PurchaseOrderID
           description: Unique identifier for Purchase Orders object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -15573,7 +15573,7 @@ paths:
           in: path
           name: PurchaseOrderID
           description: Unique identifier for Purchase Order object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -15581,7 +15581,7 @@ paths:
           in: path
           name: AttachmentID
           description: Unique identifier for Attachment object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -15615,7 +15615,7 @@ paths:
           in: path
           name: PurchaseOrderID
           description: Unique identifier for Purchase Order object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -15654,7 +15654,7 @@ paths:
           in: path
           name: PurchaseOrderID
           description: Unique identifier for Purchase Order object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -15798,7 +15798,7 @@ paths:
         - in: query
           name: ContactID
           description: Filter for quotes belonging to a particular contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16297,7 +16297,7 @@ paths:
           in: path
           name: QuoteID
           description: Unique identifier for an Quote
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16441,7 +16441,7 @@ paths:
           in: path
           name: QuoteID
           description: Unique identifier for an Quote
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16529,7 +16529,7 @@ paths:
           in: path
           name: QuoteID
           description: Unique identifier for an Quote
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16575,7 +16575,7 @@ paths:
           in: path
           name: QuoteID
           description: Unique identifier for an Quote
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16602,7 +16602,7 @@ paths:
           in: path
           name: QuoteID
           description: Unique identifier for an Quote
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16629,7 +16629,7 @@ paths:
           in: path
           name: QuoteID
           description: Unique identifier for Quote object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16671,7 +16671,7 @@ paths:
           in: path
           name: QuoteID
           description: Unique identifier for Quote object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16679,7 +16679,7 @@ paths:
           in: path
           name: AttachmentID
           description: Unique identifier for Attachment object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16713,7 +16713,7 @@ paths:
           in: path
           name: QuoteID
           description: Unique identifier for Quote object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16752,7 +16752,7 @@ paths:
           in: path
           name: QuoteID
           description: Unique identifier for Quote object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -17244,7 +17244,7 @@ paths:
           in: path
           name: ReceiptID
           description: Unique identifier for a Receipt
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -17446,7 +17446,7 @@ paths:
           in: path
           name: ReceiptID
           description: Unique identifier for a Receipt
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -17593,7 +17593,7 @@ paths:
           in: path
           name: ReceiptID
           description: Unique identifier for a Receipt
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -17635,7 +17635,7 @@ paths:
           in: path
           name: ReceiptID
           description: Unique identifier for a Receipt
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -17643,7 +17643,7 @@ paths:
           in: path
           name: AttachmentID
           description: Unique identifier for a Attachment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -17677,7 +17677,7 @@ paths:
           in: path
           name: ReceiptID
           description: Unique identifier for a Receipt
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -17716,7 +17716,7 @@ paths:
           in: path
           name: ReceiptID
           description: Unique identifier for a Receipt
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -17773,7 +17773,7 @@ paths:
           in: path
           name: ReceiptID
           description: Unique identifier for a Receipt
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -17832,7 +17832,7 @@ paths:
           in: path
           name: ReceiptID
           description: Unique identifier for a Receipt
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -17878,7 +17878,7 @@ paths:
           in: path
           name: ReceiptID
           description: Unique identifier for a Receipt
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18011,7 +18011,7 @@ paths:
           in: path
           name: RepeatingInvoiceID
           description: Unique identifier for a Repeating Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18113,7 +18113,7 @@ paths:
           in: path
           name: RepeatingInvoiceID
           description: Unique identifier for a Repeating Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18169,7 +18169,7 @@ paths:
           in: path
           name: RepeatingInvoiceID
           description: Unique identifier for a Repeating Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18177,7 +18177,7 @@ paths:
           in: path
           name: AttachmentID
           description: Unique identifier for a Attachment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18211,7 +18211,7 @@ paths:
           in: path
           name: RepeatingInvoiceID
           description: Unique identifier for a Repeating Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18250,7 +18250,7 @@ paths:
           in: path
           name: RepeatingInvoiceID
           description: Unique identifier for a Repeating Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18307,7 +18307,7 @@ paths:
           in: path
           name: RepeatingInvoiceID
           description: Unique identifier for a Repeating Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18366,7 +18366,7 @@ paths:
           in: path
           name: RepeatingInvoiceID
           description: Unique identifier for a Repeating Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18412,7 +18412,7 @@ paths:
           in: path
           name: RepeatingInvoiceID
           description: Unique identifier for a Repeating Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18549,7 +18549,7 @@ paths:
           required: true
           name: contactId
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -18828,7 +18828,7 @@ paths:
           required: true
           name: contactId
           description: Unique identifier for a Contact
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -19206,13 +19206,13 @@ paths:
         - in: query
           name: trackingOptionID1
           description: The tracking option 1 for the Balance Sheet report
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
         - in: query
           name: trackingOptionID2
           description: The tracking option 2 for the Balance Sheet report
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
         - in: query
@@ -20138,7 +20138,7 @@ paths:
           required: true
           name: ReportID
           description: Unique identifier for a Report
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
       responses:
@@ -20939,25 +20939,25 @@ paths:
         - in: query
           name: trackingCategoryID
           description: The trackingCategory 1 for the ProfitAndLoss report 
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
         - in: query
           name: trackingCategoryID2
           description: The trackingCategory 2 for the ProfitAndLoss report 
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
         - in: query
           name: trackingOptionID
           description: The tracking option 1 for the ProfitAndLoss report 
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
         - in: query
           name: trackingOptionID2
           description: The tracking option 2 for the ProfitAndLoss report 
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
         - in: query
@@ -22772,7 +22772,7 @@ paths:
           in: path
           name: TrackingCategoryID
           description: Unique identifier for a TrackingCategory
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -22823,7 +22823,7 @@ paths:
           in: path
           name: TrackingCategoryID
           description: Unique identifier for a TrackingCategory
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -22869,7 +22869,7 @@ paths:
           in: path
           name: TrackingCategoryID
           description: Unique identifier for a TrackingCategory
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -22923,7 +22923,7 @@ paths:
           in: path
           name: TrackingCategoryID
           description: Unique identifier for a TrackingCategory
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -22988,7 +22988,7 @@ paths:
           in: path
           name: TrackingCategoryID
           description: Unique identifier for a TrackingCategory
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -22996,7 +22996,7 @@ paths:
           in: path
           name: TrackingOptionID
           description: Unique identifier for a Tracking Option
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -23045,7 +23045,7 @@ paths:
           in: path
           name: TrackingCategoryID
           description: Unique identifier for a TrackingCategory
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -23053,7 +23053,7 @@ paths:
           in: path
           name: TrackingOptionID
           description: Unique identifier for a Tracking Option
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -23155,7 +23155,7 @@ paths:
           in: path
           name: UserID
           description: Unique identifier for a User
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -23645,7 +23645,7 @@ components:
           description: Unique ID for the file
           type: string
           format: uuid
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
         FileName:
           description: Name of the file
           type: string
@@ -23752,19 +23752,19 @@ components:
           description: Xero generated unique identifier for bank transaction
           type: string
           format: uuid
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
         PrepaymentID:
           description: Xero generated unique identifier for a Prepayment. This will be returned on BankTransactions with a Type of SPEND-PREPAYMENT or RECEIVE-PREPAYMENT
           readOnly: true
           type: string
           format: uuid
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
         OverpaymentID:
           description: Xero generated unique identifier for an Overpayment. This will be returned on BankTransactions with a Type of SPEND-OVERPAYMENT or RECEIVE-OVERPAYMENT
           readOnly: true
           type: string
           format: uuid
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
         UpdatedDateUTC:
           description: Last modified date UTC format
           type: string
@@ -23805,7 +23805,7 @@ components:
           description: LineItem unique ID
           type: string
           format: uuid
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
         Description:
           description: Description needs to be at least 1 char long. A line item with just
             a description (i.e no unit amount or quantity) can be created by
@@ -23863,7 +23863,7 @@ components:
           x-is-money: true
         RepeatingInvoiceID:
           description:  The Xero identifier for a Repeating Invoice
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           type: string
           format: uuid
       type: object
@@ -23875,12 +23875,12 @@ components:
           description: The Xero identifier for a tracking category
           type: string
           format: uuid
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
         TrackingOptionID:
           description: The Xero identifier for a tracking category option
           type: string
           format: uuid
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
         Name:
           description: The name of the tracking category
           maxLength: 100

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -14,7 +14,6 @@ paths:
   /Accounts:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
-        type: string
     get:
       security:
         - OAuth2: [accounting.settings]
@@ -46,7 +45,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Accounts'
-              example: '{
+              example: {
                       "Accounts": [{
                         "AccountID": "ebd06280-af70-4bed-97c6-7451a454ad85",
                         "Code": "091",
@@ -66,7 +65,7 @@ paths:
                         "Description": "Income from any normal business activity",
                         "EnablePaymentsToAccount": false
                       }]
-                    }'
+                    }
       
     put:
       security:
@@ -118,7 +117,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Accounts'
-              example: '{
+              example: {
                           "Id": "11814c9d-3b5e-492e-93b0-fad16bf3244f",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -140,14 +139,14 @@ paths:
                               "UpdatedDateUTC": "\/Date(1550793549320+0000)\/"
                             }
                           ]
-                        }'
+                        }
         '400':
           description: Validation Error - some data was incorrect returns response of type Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: '{
+              example: {
                           "ErrorNumber": 10,
                           "Type": "ValidationException",
                           "Message": "A validation exception occurred",
@@ -165,7 +164,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
       requestBody:
         required: true
         description: Account object in body of request 
@@ -173,13 +172,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Account'
-            example: '{
+            example: {
                         "Code":"123456",
                         "Name":"Foobar",
                         "Type":"EXPENSE",
                         "Description":"Hello World"
-                      }'
-  '/Accounts/{AccountID}':
+                      }
+  /Accounts/{AccountID}:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -194,7 +193,7 @@ paths:
           in: path
           name: AccountID
           description: Unique identifier for retrieving single object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -205,7 +204,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Accounts'
-              example: '{
+              example:  {
                           "Id": "323455cc-9511-4451-a873-248d2983f38e",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -227,7 +226,7 @@ paths:
                               "UpdatedDateUTC": "\/Date(1550797359120+0000)\/"
                             }
                           ]
-                        }'
+                        }
     post:
       security:
         - OAuth2: [accounting.settings]
@@ -293,7 +292,7 @@ paths:
           in: path
           name: AccountID
           description: Unique identifier for retrieving single object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -304,7 +303,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Accounts'
-              example: '{
+              example:  {
                           "Id": "9012e75c-ec08-40a9-ae15-153fc1f35c4d",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -326,14 +325,14 @@ paths:
                               "UpdatedDateUTC": "\/Date(1550795389333+0000)\/"
                             }
                           ]
-                        }'
+                        }
         '400':
           description: Validation Error - some data was incorrect returns response of type Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: '{
+              example:  {
                           "ErrorNumber": 10,
                           "Type": "ValidationException",
                           "Message": "A validation exception occurred",
@@ -351,7 +350,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
       requestBody:
         required: true
         description: Request of type Accounts array with one Account 
@@ -359,7 +358,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Accounts'
-            example: '{  
+            example:  {  
                         "Accounts":[  
                           {  
                               "Code":"123456",
@@ -376,7 +375,7 @@ paths:
                               "UpdatedDateUTC":"2019-02-21T16:29:47.96-08:00"
                           }
                         ]
-                      }'
+                      }
     delete:
       security:
         - OAuth2: [accounting.settings]
@@ -390,7 +389,7 @@ paths:
           in: path
           name: AccountID
           description: Unique identifier for retrieving single object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -401,7 +400,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Accounts'
-              example: '{
+              example:  {
                           "Id": "76bb0543-8efe-4acc-b7f6-67dfcdec37b4",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -423,14 +422,14 @@ paths:
                               "UpdatedDateUTC": "\/Date(1550798217210+0000)\/"
                             }
                           ]
-                        }'
+                        }
         '400':
           description: Validation Error - some data was incorrect returns response of type Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: '{
+              example:  {
                           "ErrorNumber": 10,
                           "Type": "ValidationException",
                           "Message": "A validation exception occurred",
@@ -448,8 +447,8 @@ paths:
                               ]
                             }
                           ]
-                        }'
-  '/Accounts/{AccountID}/Attachments':
+                        }
+  /Accounts/{AccountID}/Attachments:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -464,7 +463,7 @@ paths:
           in: path
           name: AccountID
           description: Unique identifier for Account object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -476,7 +475,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "439c1573-3cd8-4697-a9f6-81fa651ee8f3",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -490,50 +489,8 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
-  '/Accounts/{AccountID}/Attachments/{AttachmentID}':
-    parameters:
-      - $ref: '#/components/parameters/requiredHeader'
-    get:
-      security:
-        - OAuth2: [accounting.attachments.read]
-      tags:
-        - Accounting
-      operationId: getAccountAttachmentById
-      summary: Allows you to retrieve specific Attachment on Account
-      parameters:
-        - required: true
-          in: path
-          name: AccountID
-          description: Unique identifier for Account object
-          example: "00000000-0000-0000-000-000000000000"
-          schema:
-            type: string
-            format: uuid
-        - required: true
-          in: path
-          name: AttachmentID
-          description: Unique identifier for Attachment object
-          example: "00000000-0000-0000-000-000000000000"
-          schema:
-            type: string
-            format: uuid
-        - required: true
-          in: header
-          name: contentType
-          description: The mime type of the attachment file you are retrieving i.e image/jpg, application/pdf 
-          example: image/jpg
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Success - return response of attachment for Account as binary data 
-          content:
-             application/octet-stream:
-              schema:
-                type: string
-                format: binary
-  '/Accounts/{AccountID}/Attachments/{FileName}':
+                        }
+  /Accounts/{AccountID}/Attachments/{FileName}:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -548,7 +505,7 @@ paths:
           in: path
           name: AccountID
           description: Unique identifier for Account object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -587,7 +544,7 @@ paths:
           in: path
           name: AccountID
           description: Unique identifier for Account object
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -606,7 +563,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                         "Id": "c8d6413a-1da2-4faa-9848-21f60443e906",
                         "Status": "OK",
                         "ProviderName": "Xero API Partner",
@@ -620,7 +577,7 @@ paths:
                             "ContentLength": 2878711
                           }
                         ]
-                      }'
+                      }
         '400':
           description: Validation Error - some data was incorrect returns response of type Error
           content:
@@ -648,7 +605,7 @@ paths:
           in: path
           name: AccountID
           description: Unique identifier for Account object
-          example: 00000000-0000-0000-000-000000000000
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -667,7 +624,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "724cdff5-bcd1-4c5c-977e-e864c24258e0",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -681,7 +638,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -1076,7 +1033,7 @@ paths:
                             }
                           ]
                         }'
-  '/BatchPayments/{BatchPaymentID}/History':
+  /BatchPayments/{BatchPaymentID}/History:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -1091,7 +1048,7 @@ paths:
           in: path
           name: BatchPaymentID
           description: Unique identifier for BatchPayment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -1102,7 +1059,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HistoryRecords'
-              example: '{
+              example:  {
                           "Id": "c58e2f9c-baad-42a4-8bb7-f32b6f88fa04",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -1116,7 +1073,7 @@ paths:
                               "Details": ""
                             }
                           ]
-                        }'
+                        }
     put:
       security:
         - OAuth2: [accounting.transactions]
@@ -1156,7 +1113,7 @@ paths:
           in: path
           name: BatchPaymentID
           description: Unique identifier for BatchPayment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -1167,7 +1124,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HistoryRecords'
-              example: '{
+              example:  {
                           "Id": "d7525479-3392-44c0-bb37-ff4a0b5df5bd",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -1180,7 +1137,7 @@ paths:
                               "ValidationErrors": []
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -1856,7 +1813,7 @@ paths:
                           }
                         ]
                       }'
-  '/BankTransactions/{BankTransactionID}':
+  /BankTransactions/{BankTransactionID}:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -1871,7 +1828,7 @@ paths:
           in: path
           name: BankTransactionID
           description: Xero generated unique identifier for a bank transaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2133,7 +2090,7 @@ paths:
           in: path
           name: BankTransactionID
           description: Xero generated unique identifier for a bank transaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2354,7 +2311,7 @@ paths:
           in: path
           name: BankTransactionID
           description: Xero generated unique identifier for a bank transaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2366,7 +2323,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example: {
                           "Id": "c50798e1-29e9-4a30-a452-bb6e42e400c8",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -2387,7 +2344,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
   '/BankTransactions/{BankTransactionID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -2403,7 +2360,7 @@ paths:
           in: path
           name: BankTransactionID
           description: Xero generated unique identifier for a bank transaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2411,7 +2368,7 @@ paths:
           in: path
           name: AttachmentID
           description: Xero generated unique identifier for an attachment
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2445,7 +2402,7 @@ paths:
           in: path
           name: BankTransactionID
           description: Xero generated unique identifier for a bank transaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2484,7 +2441,7 @@ paths:
           in: path
           name: BankTransactionID
           description: Xero generated unique identifier for a bank transaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2503,7 +2460,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "572ad2fe-8c23-45aa-82f9-864485327685",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -2517,7 +2474,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -2541,7 +2498,7 @@ paths:
           in: path
           name: BankTransactionID
           description: Xero generated unique identifier for a bank transaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2560,7 +2517,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "572ad2fe-8c23-45aa-82f9-864485327685",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -2574,7 +2531,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -2600,7 +2557,7 @@ paths:
           in: path
           name: BankTransactionID
           description: Xero generated unique identifier for a bank transaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2646,7 +2603,7 @@ paths:
           in: path
           name: BankTransactionID
           description: Xero generated unique identifier for a bank transaction
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2688,7 +2645,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BankTransfers'
-              example: '{
+              example:  {
                           "Id": "dfc0d130-9007-4a98-a5ef-6f01700f18e2",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -2733,7 +2690,7 @@ paths:
                               "HasAttachments": false
                             }
                           ]
-                        }'
+                        }
 
     put:
       security:
@@ -2818,7 +2775,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BankTransfers'
-              example: '{
+              example:  {
                           "Id": "ae767b68-affd-4e17-bac0-83eaf1854dcd",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -2845,7 +2802,7 @@ paths:
                               "ValidationErrors": []
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -2855,7 +2812,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/BankTransfers'
-            example: '{
+            example:  {
                         "BankTransfers": [
                           {
                             "FromBankAccount": {
@@ -2897,7 +2854,7 @@ paths:
                             "Amount": "50.00"
                           }
                         ]
-                      }'
+                      }
   '/BankTransfers/{BankTransferID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -2913,7 +2870,7 @@ paths:
           in: path
           name: BankTransferID
           description: Xero generated unique identifier for a bank transfer
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2924,7 +2881,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BankTransfers'
-              example: '{
+              example:  {
                           "Id": "1a5fa46d-5ece-4ef2-89b1-77c293b5d833",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -2962,7 +2919,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
       
   '/BankTransfers/{BankTransferID}/Attachments':
     parameters:
@@ -2979,7 +2936,7 @@ paths:
           in: path
           name: BankTransferID
           description: Xero generated unique identifier for a bank transfer
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -2991,7 +2948,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "5cb6b587-7b02-46b6-97fe-d8ad8f20321b",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -3005,7 +2962,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
   '/BankTransfers/{BankTransferID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -3021,7 +2978,7 @@ paths:
           in: path
           name: BankTransferID
           description: Xero generated unique identifier for a bank transfer
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -3029,7 +2986,7 @@ paths:
           in: path
           name: AttachmentID
           description: Xero generated unique identifier for an Attachment to a bank transfer
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -3063,7 +3020,7 @@ paths:
           in: path
           name: BankTransferID
           description: Xero generated unique identifier for a bank transfer
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -3101,7 +3058,7 @@ paths:
           in: path
           name: BankTransferID
           description: Xero generated unique identifier for a bank transfer
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -3120,7 +3077,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "c7810140-19c2-4ff7-b3ec-b7e95ce7becf",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -3134,7 +3091,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -3157,7 +3114,7 @@ paths:
           in: path
           name: BankTransferID
           description: Xero generated unique identifier for a bank transfer
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -3176,7 +3133,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "b73ba149-76a9-4e7c-a5c6-b9230022f416",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -3190,7 +3147,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -3216,7 +3173,7 @@ paths:
           in: path
           name: BankTransferID
           description: Xero generated unique identifier for a bank transfer
-          example: "00000000-0000-0000-000-000000000000"
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Accounting API
+  title: Xero Accounting API
   version: "2.8.2"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -5345,7 +5345,7 @@ paths:
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
-        description: Contacts with array of contacts specifiying the ContactID to be added to ContactGroup in body of request
+        description: Contacts with array of contacts specifying the ContactID to be added to ContactGroup in body of request
         required: true
         content:
           application/json:
@@ -7086,7 +7086,7 @@ paths:
                 $ref: '#/components/schemas/Currencies'
       requestBody:
         required: true
-        description: Currency obejct in the body of request
+        description: Currency object in the body of request
         content:
             application/json:
               schema:
@@ -7179,7 +7179,7 @@ paths:
       summary: Allows you to create new employees used in Xero payrun
       x-hasAccountingValidationError: true
       x-node-requestBody: '{ employees: [{ firstName: "Nick", lastName: "Fury", externalLink: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
-      x-ruby-requestBody: 'employees = { employees: [{ first_name: "Nick", last_name: "Fury", externalink: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
+      x-ruby-requestBody: 'employees = { employees: [{ first_name: "Nick", last_name: "Fury", externallink: { url: "http://twitter.com/#!/search/Nick+Fury" }}]}'
       x-example:
         - employee:
           is_object: true
@@ -9800,7 +9800,7 @@ paths:
                             {
                               "ItemID": "a4544d51-48f6-441f-a623-99ecbced6ab7",
                               "Code": "abc65591",
-                              "Description": "Barfoo",
+                              "Description": "Bar foo",
                               "UpdatedDateUTC": "\/Date(1552331873580+0000)\/",
                               "PurchaseDetails": {},
                               "SalesDetails": {},
@@ -10580,7 +10580,7 @@ paths:
             format: uuid
         - in: query
           name: Status
-          description: Filter by the combination of ContactID and Status. Get  the linked transactions associaed to a  customer and with a status
+          description: Filter by the combination of ContactID and Status. Get  the linked transactions associated to a  customer and with a status
           example: "APPROVED"
           schema:
             type: string
@@ -10936,7 +10936,7 @@ paths:
                               "LineAmountTypes": "NoTax",
                               "UpdatedDateUTC": "\/Date(1552357188083+0000)\/",
                               "ManualJournalID": "0b159335-606b-485f-b51b-97b3b32bad32",
-                              "Narration": "Reversal: These aren''t the droids you are looking for",
+                              "Narration": "Reversal: These aren't the droids you are looking for",
                               "JournalLines": [],
                               "ShowOnCashBasisReports": true,
                               "HasAttachments": false
@@ -10947,7 +10947,7 @@ paths:
                               "LineAmountTypes": "NoTax",
                               "UpdatedDateUTC": "\/Date(1552357188147+0000)\/",
                               "ManualJournalID": "99cb8353-ce73-4a5d-8e0d-8b0edf86cfc4",
-                              "Narration": "These aren''t the droids you are looking for",
+                              "Narration": "These aren't the droids you are looking for",
                               "JournalLines": [],
                               "ShowOnCashBasisReports": true,
                               "HasAttachments": true
@@ -11455,10 +11455,10 @@ paths:
                               "LineAmountTypes": "NoTax",
                               "UpdatedDateUTC": "\/Date(1552357188147+0000)\/",
                               "ManualJournalID": "99cb8353-ce73-4a5d-8e0d-8b0edf86cfc4",
-                              "Narration": "These aren''t the droids you are looking for",
+                              "Narration": "These aren't the droids you are looking for",
                               "JournalLines": [
                                 {
-                                  "Description": "These aren''t the droids you are looking for",
+                                  "Description": "These aren't the droids you are looking for",
                                   "TaxType": "NONE",
                                   "TaxAmount": 0.00,
                                   "LineAmount": 100.00,
@@ -12162,7 +12162,7 @@ paths:
       tags:
         - Accounting
       operationId: getOrganisationCISSettings
-      summary: Allows you To verify if an organisation is using contruction industry scheme, you can retrieve the CIS settings for the organistaion.
+      summary: Allows you To verify if an organisation is using construction industry scheme, you can retrieve the CIS settings for the organistaion.
       parameters:
         - required: true
           in: path

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -2851,7 +2851,7 @@ paths:
                               "HasAttachments": false,
                               "UpdatedDateUTC": "2016-06-03T08:31:14.517-07:00"
                             },
-                            "Amount": "50.00"
+                            "Amount": 50.00
                           }
                         ]
                       }
@@ -3461,7 +3461,7 @@ paths:
           description: Filter by a comma separated list of ContactIDs. Allows you to retrieve a specific set of contacts in a single call.
           style: form
           explode: false
-          example: ['&quot;00000000-0000-0000-000-000000000000&quot;']
+          example: [00000000-0000-0000-0000-000000000000]
           x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"))
           x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;'
           schema:
@@ -3798,7 +3798,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: '{
+              example:  {
                           "ErrorNumber": 10,
                           "Type": "ValidationException",
                           "Message": "A validation exception occurred",
@@ -3853,7 +3853,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
       requestBody:
         required: true
         description: Contacts with an array of Contact objects to create in body of request
@@ -4106,7 +4106,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: '{
+              example:  {
                           "ErrorNumber": 10,
                           "Type": "ValidationException",
                           "Message": "A validation exception occurred",
@@ -4161,7 +4161,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
       requestBody:
         required: true
         content:
@@ -4658,7 +4658,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                         "Id": "0f63b631-a205-496d-b1d2-e6b13a9b497b",
                         "Status": "OK",
                         "ProviderName": "Xero API Partner",
@@ -4672,7 +4672,7 @@ paths:
                             "ContentLength": 2878711
                           }
                         ]
-                      }'
+                      }
       parameters:
         - required: true
           in: path
@@ -4796,7 +4796,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "8543ae1a-297c-49b8-bf91-47decac452d5",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -4810,7 +4810,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -4852,7 +4852,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "a5eddf71-86aa-42f5-99e2-0aaf9caf96b6",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -4866,7 +4866,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -5095,7 +5095,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: '{
+              example:  {
                           "ErrorNumber": 10,
                           "Type": "ValidationException",
                           "Message": "A validation exception occurred",
@@ -5112,7 +5112,7 @@ paths:
                               ]
                             }
                           ]
-                        }'          
+                        }          
       requestBody:
         description: ContactGroups with an array of names in request body
         required: true
@@ -6548,7 +6548,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "2bb15054-3868-4f85-a9c6-0402ec8c1201",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -6562,7 +6562,7 @@ paths:
                               "ContentLength": 76091
                             }
                           ]
-                        }'
+                        }
   '/CreditNotes/{CreditNoteID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -6678,7 +6678,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "27253066-8c4d-4e34-a251-7a749b72de40",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -6692,7 +6692,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -6736,7 +6736,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "22a8d402-5dea-40ed-9d01-26896429f649",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -6750,7 +6750,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -7032,7 +7032,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Currencies'
-              example: '{
+              example:  {
                           "Id": "e6803fc8-8035-4251-b3e4-39d6b2de0f4a",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -7043,7 +7043,7 @@ paths:
                               "Description": "New Zealand Dollar"
                             }
                           ]
-                        }'
+                        }
     put:
       security:
         - OAuth2: [accounting.settings]
@@ -7091,10 +7091,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Currency'
-              example: '{
+              example:  {
                           "Code": "USD",
                           "Description": "United States Dollar"
-                        }'
+                        }
   /Employees:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -7129,7 +7129,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Employees' 
-              example: ' {
+              example:   {
                           "Id": "593cbccc-5cd2-4cd2-be5e-150f0843709e",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -7169,7 +7169,7 @@ paths:
                               "UpdatedDateUTC": "\/Date(1552324737990+0000)\/"
                             }
                           ]
-                        }'     
+                        }     
     put:
       security:
         - OAuth2: [accounting.settings]
@@ -7218,7 +7218,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Employees'
-              example: '{
+              example:  {
                           "Id": "0d6a08e7-6936-4828-a1bc-e4595e0ef778",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -7236,7 +7236,7 @@ paths:
                               "UpdatedDateUTC": "\/Date(1552324736463+0000)\/"
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -7246,7 +7246,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Employees'
-              example: '{
+              example:  {
                           "Employees": [
                             {
                               "FirstName": "Nick",
@@ -7256,7 +7256,7 @@ paths:
                               }
                             }
                           ]
-                        }'
+                        }
     post:
       security:
         - OAuth2: [accounting.settings]
@@ -7305,7 +7305,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Employees'
-              example: '{
+              example:  {
                           "Id": "0d6a08e7-6936-4828-a1bc-e4595e0ef778",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -7323,7 +7323,7 @@ paths:
                               "UpdatedDateUTC": "\/Date(1552324736463+0000)\/"
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -7333,7 +7333,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Employees'
-              example: '{
+              example:  {
                           "Employees": [
                             {
                               "FirstName": "Nick",
@@ -7343,7 +7343,7 @@ paths:
                               }
                             }
                           ]
-                        }'
+                        }
   '/Employees/{EmployeeID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -7370,7 +7370,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Employees'
-              example: '{
+              example:  {
                           "Id": "417a529e-4f8d-4b1a-8816-7100245cf8b2",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -7388,7 +7388,7 @@ paths:
                               "UpdatedDateUTC": "\/Date(1552324681593+0000)\/"
                             }
                           ]
-                        }'
+                        }
   /ExpenseClaims:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -8085,7 +8085,7 @@ paths:
           description: Filter by a comma-separated list of InvoicesIDs. 
           style: form
           explode: false
-          example: '&quot;00000000-0000-0000-000-000000000000&quot;'
+          example: [00000000-0000-0000-0000-000000000000]
           x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"))
           x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;'
           schema:
@@ -8098,7 +8098,7 @@ paths:
           description: Filter by a comma-separated list of InvoiceNumbers. 
           style: form
           explode: false
-          example: '&quot;INV-001&quot;, &quot;INV-002&quot;'
+          example: ["INV-001","INV-002"]
           x-example-java: Arrays.asList("INV-001","INV-002")
           x-example-php: '&quot;INV-001&quot;, &quot;INV-002&quot;'
           schema:
@@ -8110,7 +8110,7 @@ paths:
           description: Filter by a comma-separated list of ContactIDs. 
           style: form
           explode: false
-          example: '&quot;00000000-0000-0000-000-000000000000&quot;'
+          example: [00000000-0000-0000-0000-000000000000]
           x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-000-000000000000"))
           x-example-php: '&quot;00000000-0000-0000-000-000000000000&quot;'
           schema:
@@ -8122,7 +8122,7 @@ paths:
           name: Statuses
           description: Filter by a comma-separated list Statuses. For faster response times we recommend using these explicit parameters instead of passing OR conditions into the Where filter.
           explode: false
-          example: '&quot;DRAFT&quot;, &quot;SUBMITTED&quot;'
+          example: ['DRAFT', 'SUBMITTED']
           x-example-java: Arrays.asList("DRAFT","SUBMITTED")
           x-example-php: '&quot;DRAFT&quot;, &quot;SUBMITTED&quot;'
           schema:
@@ -9347,7 +9347,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: ' {
+              example:   {
                             "Id": "7e357a45-69f5-4e8f-8d7b-15da8ef50aab",
                             "Status": "OK",
                             "ProviderName": "Provider Name Example",
@@ -9369,7 +9369,6 @@ paths:
                               }
                             ]
                           }
-'
   '/Invoices/{InvoiceID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -9485,7 +9484,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "acd7d618-5fef-4d45-849c-a339ea31a973",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -9499,7 +9498,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -9543,7 +9542,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                             "Id": "971fbd18-c850-453a-825f-63f2fee096ee",
                             "Status": "OK",
                             "ProviderName": "Provider Name Example",
@@ -9557,7 +9556,7 @@ paths:
                                 "ContentLength": 2878711
                               }
                             ]
-                          }'
+                          }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -9594,7 +9593,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnlineInvoices'
-              example: '{
+              example:  {
                           "Id": "d20705fb-fe1c-4366-835b-98de7474da3c",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -9604,7 +9603,7 @@ paths:
                               "OnlineInvoiceUrl": "https://in.xero.com/bCWCCfytGdTXoJam9HENWlQt07G6zcDaj4gQojHu"
                             }
                           ]
-                        }'
+                        }
   '/Invoices/{InvoiceID}/Email':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -9643,7 +9642,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RequestEmpty'
-            example: '{}'
+            example: {}
   '/Invoices/{InvoiceID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -9733,7 +9732,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/InvoiceReminders'
-              example: '{
+              example:  {
                           "Id": "c7cd0953-c012-4be8-b618-63ce4c2c3494",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -9743,7 +9742,7 @@ paths:
                               "Enabled": false
                             }
                           ]
-                        }'
+                        }
   /Items:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -9776,7 +9775,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Items'
-              example: '{
+              example:  {
                           "Id": "8487e8d7-5fb3-4f02-b949-dec8f1e38182",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -9811,7 +9810,7 @@ paths:
                               "IsPurchased": true
                             }
                           ]
-                        }'
+                        }
     put:
       security:
         - OAuth2: [accounting.settings]
@@ -9891,7 +9890,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Items'
-              example: '{
+              example:  {
                           "Id": "ae7ef7c8-9024-4d42-8d59-5f26ed3f508b",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -9915,7 +9914,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -9925,7 +9924,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Items'
-            example: '{
+            example:  {
                         "Items": [
                           {
                             "Code": "code123",
@@ -9937,7 +9936,7 @@ paths:
                             }
                           }
                         ]
-                      }'
+                      }
     post:
       security:
         - OAuth2: [accounting.settings]
@@ -9990,7 +9989,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Items'
-              example: '{
+              example:  {
                           "Id": "ae7ef7c8-9024-4d42-8d59-5f26ed3f508b",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -10014,7 +10013,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -10023,7 +10022,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Items'
-            example: '{
+            example:  {
                         "Items": [
                           {
                             "Code": "ItemCode123",
@@ -10031,7 +10030,7 @@ paths:
                             "Description": "Item Description ABC"
                           }
                         ]
-                      }'
+                      }
   '/Items/{ItemID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -10059,7 +10058,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Items'
-              example: '{
+              example:  {
                           "Id": "0bbd8a92-9ba7-4711-8040-8d6a609ca7e8",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -10091,7 +10090,7 @@ paths:
                               "ValidationErrors": []
                             }
                           ]
-                        }'
+                        }
     post:
       security:
         - OAuth2: [accounting.settings]
@@ -10146,7 +10145,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Items'
-              example: '{
+              example:  {
                           "Id": "24feb629-6b14-499e-9aa1-fc2c596c0280",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -10166,7 +10165,7 @@ paths:
                               "ValidationErrors": []
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -10175,14 +10174,14 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Items'
-            example: '{
+            example:  {
                         "Items": [
                           {
                             "Code": "ItemCode123",
                             "Description": "Description 123"
                           }
                         ]
-                      }'
+                      }
     delete:
       security:
         - OAuth2: [accounting.settings]
@@ -10305,7 +10304,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Journals'
-              example: '{
+              example:  {
                           "Id": "49a09a97-df50-4679-8043-02c86e0dcf5f",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -10469,7 +10468,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
   '/Journals/{JournalID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -10496,7 +10495,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Journals'
-              example: '{
+              example:  {
                           "Id": "39ab8367-eb14-420d-83a9-e01ddddd21f8",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -10540,7 +10539,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
   /LinkedTransactions:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -10599,7 +10598,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LinkedTransactions'
-              example: '{
+              example:  {
                           "Id": "516aabd0-e670-48d5-b0eb-10dce4494dd8",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -10618,7 +10617,7 @@ paths:
                               "SourceTransactionTypeCode": "ACCPAY"
                             }
                           ]
-                        }'
+                        }
     put:
       security:
         - OAuth2: [accounting.transactions]
@@ -10657,7 +10656,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LinkedTransactions'
-              example: '{
+              example:  {
                           "Id": "f32b30e5-32d1-42a8-bcc9-5b22828f725c",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -10678,7 +10677,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -10688,14 +10687,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LinkedTransaction'
-              example: '{
+              example:  {
                           "LinkedTransactions": [
                             {
                               "SourceTransactionID": "a848644a-f20f-4630-98c3-386bd7505631",
                               "SourceLineItemID": "b0df260d-3cc8-4ced-9bd6-41924f624ed3"
                             }
                           ]
-                        }'
+                        }
   '/LinkedTransactions/{LinkedTransactionID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -10722,7 +10721,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LinkedTransactions'
-              example: '{
+              example:  {
                           "Id": "171ca542-874d-44e2-8930-db9bccd7d88b",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -10741,7 +10740,7 @@ paths:
                               "SourceTransactionTypeCode": "ACCPAY"
                             }
                           ]
-                        }'
+                        }
     post:
       security:
         - OAuth2: [accounting.transactions]
@@ -10801,7 +10800,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LinkedTransactions'
-              example: '{
+              example:  {
                           "Id": "bd364af7-08f0-432b-81db-c1e5ba05f3dd",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -10818,14 +10817,14 @@ paths:
                               "SourceTransactionTypeCode": "ACCPAY"
                             }
                           ]
-                        }'
+                        }
         '400':
           description: Success - return response of type LinkedTransactions array with updated LinkedTransaction
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: '{
+              example:  {
                           "ErrorNumber": 10,
                           "Type": "ValidationException",
                           "Message": "A validation exception occurred",
@@ -10848,21 +10847,21 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
       requestBody:
         required: true
         content:
             application/json:
               schema:
                 $ref: '#/components/schemas/LinkedTransactions'
-              example: '{
+              example:  {
                           "LinkedTransactions": [
                             {
-                              "SourceTransactionID": "00000000-0000-0000-000-000000000000",
-                              "SourceLineItemID": "00000000-0000-0000-000-000000000000"
+                              "SourceTransactionID": 00000000-0000-0000-0000-000000000000,
+                              "SourceLineItemID": 00000000-0000-0000-0000-000000000000
                             }
                           ]
-                        }'
+                        }
     delete:
       security:
         - OAuth2: [accounting.transactions]
@@ -10925,7 +10924,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{
+              example:  {
                           "Id": "8a508ec1-b578-48bf-97df-020c918fbf7d",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -10965,7 +10964,7 @@ paths:
                               "HasAttachments": false
                             }
                           ]
-                        }'
+                        }
     put:
       security:
         - OAuth2: [accounting.transactions]
@@ -11103,7 +11102,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{
+              example:  {
                           "Id": "45dfa608-0fcb-4f30-a377-c82cd348569c",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -11156,7 +11155,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -11166,7 +11165,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{
+              example:  {
                           "ManualJournals": [
                             {
                               "Narration": "Journal Desc",
@@ -11191,7 +11190,7 @@ paths:
                               "Date": "2019-03-14"
                             }
                           ]
-                        }'
+                        }
     post:
       security:
         - OAuth2: [accounting.transactions]
@@ -11329,7 +11328,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{
+              example:  {
                           "Id": "45dfa608-0fcb-4f30-a377-c82cd348569c",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -11382,7 +11381,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -11392,7 +11391,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{
+              example:  {
                           "ManualJournals": [
                             {
                               "Narration": "Journal Desc",
@@ -11417,7 +11416,7 @@ paths:
                               "Date": "2019-03-14"
                             }
                           ]
-                        }'
+                        }
   '/ManualJournals/{ManualJournalID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -11444,7 +11443,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{
+              example:  {
                           "Id": "7321fc21-1a13-4f40-ae47-df59cff5676d",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -11499,7 +11498,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
     post:
       security:
         - OAuth2: [accounting.transactions]
@@ -11644,7 +11643,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{
+              example:  {
                           "Id": "b694559c-686c-4047-b657-661ba6c0dd1f",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -11684,7 +11683,7 @@ paths:
                               "Attachments": []
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -11693,15 +11692,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManualJournals'
-              example: '{
+              example:  {
                           "ManualJournals": [
                             {
                               "Narration": "Hello Xero",
-                              "ManualJournalID": "00000000-0000-0000-000-000000000000",
+                              "ManualJournalID": 00000000-0000-0000-0000-000000000000,
                               "JournalLines": []
                             }
                           ]
-                        }'
+                        }
   '/ManualJournals/{ManualJournalID}/Attachments':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -11729,7 +11728,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "5fa4b3ef-7945-45a7-9bab-10e830673dfb",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -11750,7 +11749,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
   '/ManualJournals/{ManualJournalID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -11866,7 +11865,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "e1cb9deb-a8f0-477f-b4d1-cf0c6c39e080",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -11880,7 +11879,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -11923,7 +11922,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "a864994c-e7d7-4dee-b5ca-0a729fde2f39",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -11937,7 +11936,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -12037,7 +12036,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Organisations'
-              example: '{
+              example:  {
                           "Id": "27b7a645-a3ee-43c8-b2c6-a2fa7b84c8c5",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -12076,7 +12075,7 @@ paths:
                               "PaymentTerms": {}
                             }
                           ]
-                        }'
+                        }
   '/Organisation/Actions':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -12094,7 +12093,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Actions'
-              example: '{
+              example:  {
                           "Id": "f02c0dd1-1917-4d57-9853-997f6bcaf2bc",
                           "Status": "OK",
                           "ProviderName": "Java OA2 dev 01",
@@ -12153,7 +12152,7 @@ paths:
                               "Status": "ALLOWED"
                             }
                           ]
-                        }'
+                        }
   '/Organisation/{OrganisationID}/CISSettings':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -12735,7 +12734,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: '{
+              example:  {
                           "ErrorNumber": 10,
                           "Type": "ValidationException",
                           "Message": "A validation exception occurred",
@@ -12751,7 +12750,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
       requestBody:
         $ref: '#/components/requestBodies/historyRecords'
   /Payments:
@@ -13447,7 +13446,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Payments'
-              example: '{
+              example:  {
                           "Id": "ee23328c-4a8b-4ee7-8fb6-9796ffab9cb0",
                           "Status": "OK",
                           "ProviderName": "provider-name",
@@ -13515,7 +13514,7 @@ paths:
                               "HasValidationErrors": false
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -13524,13 +13523,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaymentDelete'
-              example: '{  
+              example:  {  
                           "Payments":[  
                             {  
                               "Status":"DELETED"
                             }
                           ]
-                        }'
+                        }
   '/Payments/{PaymentID}/History':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -13605,7 +13604,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: '{
+              example:  {
                           "ErrorNumber": 10,
                           "Type": "ValidationException",
                           "Message": "A validation exception occurred",
@@ -13621,7 +13620,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
       requestBody:
         $ref: '#/components/requestBodies/historyRecords'
   /PaymentServices:
@@ -13641,7 +13640,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaymentServices'
-              example: '{
+              example:  {
                           "Id": "ab82a7dd-5070-4e82-b841-0af52909fe04",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -13655,7 +13654,7 @@ paths:
                               "PayNowText": "Time To Pay"
                             }
                           ]
-                        }'
+                        }
     put:
       security:
         - OAuth2: [paymentservices]
@@ -13709,7 +13708,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaymentServices'
-              example: '{
+              example:  {
                           "Id": "7ed8b3c0-2155-49ee-a583-f2dce6607dfb",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -13728,7 +13727,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -13738,7 +13737,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaymentServices'
-              example: '{
+              example:  {
                           "PaymentServices": [
                             {
                               "PaymentServiceName": "PayUpNow",
@@ -13746,7 +13745,7 @@ paths:
                               "PayNowText": "Time To Pay"
                             }
                           ]
-                        }'
+                        }
   /Prepayments:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -14186,7 +14185,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: ' {
+              example:   {
                             "ErrorNumber": 10,
                             "Type": "ValidationException",
                             "Message": "A validation exception occurred",
@@ -14202,7 +14201,7 @@ paths:
                                 ]
                               }
                             ]
-                          }'
+                          }
       requestBody:
         $ref: '#/components/requestBodies/historyRecords'
   /PurchaseOrders:
@@ -15529,7 +15528,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                   "Id": "dfc29f55-8ddd-4921-a82c-bcc0798d207f",
                   "Status": "OK",
                   "ProviderName": "Xero API Partner",
@@ -15557,7 +15556,7 @@ paths:
                           "ContentLength": 146384
                       }
                   ]
-              }'
+              }
   '/PurchaseOrders/{PurchaseOrderID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -15673,7 +15672,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "aeff9be0-54c2-45dd-8e3d-aa4f8af0fbd7",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -15687,7 +15686,7 @@ paths:
                               "ContentLength": 98715
                             }
                           ]
-                        }'
+                        }
         '400':
           description: Validation Error - some data was incorrect returns response of type Error
           content:
@@ -15715,7 +15714,7 @@ paths:
           in: path
           name: PurchaseOrderID
           description: Unique identifier for Purchase Order object
-          example: 00000000-0000-0000-000-000000000000
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -15734,7 +15733,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "c728a4a4-179e-4bbd-a2d5-63e7f9ceba92",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -15748,7 +15747,7 @@ paths:
                               "ContentLength": 82529
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -16641,7 +16640,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "439c1573-3cd8-4697-a9f6-81fa651ee8f3",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -16655,7 +16654,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
   '/Quotes/{QuoteID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -16771,7 +16770,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                         "Id": "c8d6413a-1da2-4faa-9848-21f60443e906",
                         "Status": "OK",
                         "ProviderName": "Xero API Partner",
@@ -16785,7 +16784,7 @@ paths:
                             "ContentLength": 2878711
                           }
                         ]
-                      }'
+                      }
         '400':
           description: Validation Error - some data was incorrect returns response of type Error
           content:
@@ -16813,7 +16812,7 @@ paths:
           in: path
           name: QuoteID
           description: Unique identifier for Quote object
-          example: 00000000-0000-0000-000-000000000000
+          example: 00000000-0000-0000-0000-000000000000
           schema:
             type: string
             format: uuid
@@ -16832,7 +16831,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "724cdff5-bcd1-4c5c-977e-e864c24258e0",
                           "Status": "OK",
                           "ProviderName": "Xero API Partner",
@@ -16846,7 +16845,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -17605,7 +17604,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "d379c04d-d3aa-4034-95b8-af69a449bd78",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -17619,7 +17618,7 @@ paths:
                               "ContentLength": 495727
                             }
                           ]
-                        }'
+                        }
   '/Receipts/{ReceiptID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -17735,7 +17734,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "aeca1ea8-8fd9-4757-96a6-397dc4957a69",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -17749,7 +17748,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -17792,7 +17791,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "01c9a720-b1f1-4477-8de8-ff46d945fd1d",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -17806,7 +17805,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -17891,7 +17890,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-              example: '{
+              example:  {
                           "ErrorNumber": 10,
                           "Type": "ValidationException",
                           "Message": "A validation exception occurred",
@@ -17907,7 +17906,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
       requestBody:
         $ref: '#/components/requestBodies/historyRecords'
   /RepeatingInvoices:
@@ -18125,7 +18124,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "b88b807b-3087-474b-a4f9-d8f1b4f5a899",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -18153,7 +18152,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
   '/RepeatingInvoices/{RepeatingInvoiceID}/Attachments/{AttachmentID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -18269,7 +18268,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                             "Id": "61b24d5c-4d6e-468f-9de1-abbc234b239a",
                             "Status": "OK",
                             "ProviderName": "Provider Name Example",
@@ -18283,7 +18282,7 @@ paths:
                                 "ContentLength": 2878711
                               }
                             ]
-                          }'
+                          }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -18326,7 +18325,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Attachments'
-              example: '{
+              example:  {
                           "Id": "219de8c0-ee70-48af-a000-594eba14b417",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -18340,7 +18339,7 @@ paths:
                               "ContentLength": 2878711
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -18447,7 +18446,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Reports'
-              example: '{
+              example:  {
                           "Id": "8b474ddb-9ef4-457c-8640-1c0e3670ea0e",
                           "Status": "OK",
                           "ProviderName": "Java Public Example",
@@ -18533,7 +18532,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
   '/Reports/AgedPayablesByContact':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -18578,7 +18577,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReportWithRows'
-              example: '{
+              example:  {
                           "Id": "5a33f9d4-44a6-4467-a812-4f025506ee35",
                           "Status": "OK",
                           "ProviderName": "Java Public Example",
@@ -18812,7 +18811,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
   '/Reports/AgedReceivablesByContact':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -18857,7 +18856,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReportWithRows'
-              example: '{
+              example:  {
                           "Id": "b977b607-955d-47cb-92fd-7c29b3dd755c",
                           "Status": "OK",
                           "ProviderName": "Java Public Example",
@@ -19168,7 +19167,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
   '/Reports/BalanceSheet':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -19234,7 +19233,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReportWithRows'
-              example: '{
+              example:  {
                         "Id": "2ddba304-6ed3-4da4-b185-3b6289699653",
                         "Status": "OK",
                         "ProviderName": "Provider Name Example",
@@ -19966,7 +19965,7 @@ paths:
                             ]
                           }
                         ]
-                      }'
+                      }
   '/Reports/BankSummary':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -19999,7 +19998,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReportWithRows'
-              example: '{
+              example:  {
                           "Id": "ae58d0ec-9c5c-455f-b96e-690107579257",
                           "Status": "OK",
                           "ProviderName": "Java Public Example",
@@ -20105,7 +20104,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
   '/Reports':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -20185,7 +20184,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReportWithRows'
-              example: '{
+              example:  {
                           "Id": "9f1e2722-0d98-4669-890f-f8f4217c968b",
                           "Status": "OK",
                           "ProviderName": "provider-name",
@@ -20402,7 +20401,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
   '/Reports/ExecutiveSummary':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -20428,7 +20427,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReportWithRows'
-              example: '{
+              example:  {
                           "Id": "068d3505-ac37-43f3-8135-f912a5963d8a",
                           "Status": "OK",
                           "ProviderName": "provider-name",
@@ -20894,7 +20893,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
   '/Reports/ProfitAndLoss':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -20963,13 +20962,13 @@ paths:
         - in: query
           name: standardLayout
           description: Return the standard layout for the ProfitAndLoss report 
-          example: "true"
+          example: true
           schema:
             type: boolean
         - in: query
           name: paymentsOnly
           description: Return cash only basis for the ProfitAndLoss report 
-          example: "false"
+          example: false
           schema:
             type: boolean     
       responses:
@@ -21000,7 +20999,7 @@ paths:
         - in: query
           name: paymentsOnly
           description: Return cash only basis for the Trial Balance report 
-          example: "true"
+          example: true
           schema:
             type: boolean
       responses:
@@ -21010,7 +21009,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReportWithRows'
-              example: '{
+              example:  {
                           "Id": "0b3ee35e-b97c-4b3c-b7e2-9a465233e329",
                           "Status": "OK",
                           "ProviderName": "Java Public Example",
@@ -22090,7 +22089,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
   /Setup:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -22299,7 +22298,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaxRates'
-              example: '{
+              example:  {
                           "Id": "455d494d-9706-465b-b584-7086ca406b27",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -22411,7 +22410,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
     put:
       security:
         - OAuth2: [accounting.settings]
@@ -22479,7 +22478,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaxRates'
-              example: '{
+              example:  {
                           "Id": "9d2c5e56-fab4-450b-a5ff-d47409508eab",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -22507,7 +22506,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -22517,7 +22516,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaxRates'
-              example: '{
+              example:  {
                           "TaxRates": [
                             {
                               "Name": "CA State Tax",
@@ -22529,7 +22528,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
     post:
       security:
         - OAuth2: [accounting.settings]
@@ -22597,7 +22596,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaxRates'
-              example: '{
+              example:  {
                           "Id": "12f4c453-2e25-41aa-a52f-6faaf6c05832",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -22625,7 +22624,7 @@ paths:
                               ]
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -22634,7 +22633,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TaxRates'
-            example: '{
+            example:  {
                         "TaxRates": [
                           {
                             "Name": "State Tax NY",
@@ -22648,7 +22647,7 @@ paths:
                             "ReportTaxType": "INPUT"
                           }
                         ]
-                      }'
+                      }
   /TrackingCategories:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -22687,7 +22686,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrackingCategories'
-              example: '{
+              example:  {
                           "Id": "cec55068-8061-48e5-ac83-c77e7c54cf3d",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -22706,7 +22705,7 @@ paths:
                               "Options": []
                             }
                           ]
-                        }'
+                        }
     put:
       security:
         - OAuth2: [accounting.settings]
@@ -22733,7 +22732,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrackingCategories'
-              example: '{
+              example:  {
                           "Id": "1a9f8e03-9916-4a42-93a9-e8fa4902d49c",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -22746,7 +22745,7 @@ paths:
                               "Options": []
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -22756,7 +22755,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TrackingCategory'
-            example: '{ name: "FooBar" }'
+            example: { name: "FooBar" }
   '/TrackingCategories/{TrackingCategoryID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -22783,7 +22782,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrackingCategories'
-              example: '{
+              example:  {
                           "Id": "b75b8862-39c0-45a8-82b8-30ab4831996b",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -22796,7 +22795,7 @@ paths:
                               "Options": []
                             }
                           ]
-                        }'
+                        }
     post:
       security:
         - OAuth2: [accounting.settings]
@@ -22834,7 +22833,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrackingCategories'
-              example: '{
+              example:  {
                           "Id": "55438774-f87d-4731-b586-799cf0f914ed",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -22847,7 +22846,7 @@ paths:
                               "Options": []
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -22856,7 +22855,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TrackingCategory'
-            example: '{ "Name": "Avengers" }'
+            example:  { "Name": "Avengers" }
     delete:
       security:
         - OAuth2: [accounting.settings]
@@ -22880,7 +22879,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrackingCategories'
-              example: '{
+              example:  {
                           "Id": "ca7f8145-c8a5-4366-a2fb-784edc0cfbb7",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -22893,7 +22892,7 @@ paths:
                               "Options": []
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
   '/TrackingCategories/{TrackingCategoryID}/Options':
@@ -22934,7 +22933,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrackingOptions'
-              example: '{
+              example:  {
                           "Id": "923be702-d124-4f5c-a568-760906538d8e",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -22950,7 +22949,7 @@ paths:
                               "IsActive": true
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -22960,7 +22959,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TrackingOption'
-            example: '{ name: " Bar" }'
+            example:  { name: " Bar" }
   '/TrackingCategories/{TrackingCategoryID}/Options/{TrackingOptionID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -23007,7 +23006,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrackingOptions'
-              example: '{
+              example:  {
                           "Id": "923be702-d124-4f5c-a568-760906538d8e",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -23023,7 +23022,7 @@ paths:
                               "IsActive": true
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
       requestBody:
@@ -23032,7 +23031,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/TrackingOption'
-            example: '{ name: "Vision" }'
+            example:  { name: "Vision" }
     delete:
       security:
         - OAuth2: [accounting.settings]
@@ -23064,7 +23063,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrackingOptions'
-              example: '{
+              example:  {
                           "Id": "d985866e-0831-418f-a07c-4d843ff66d25",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -23080,7 +23079,7 @@ paths:
                               "IsActive": false
                             }
                           ]
-                        }'
+                        }
         '400':
           $ref: '#/components/responses/400Error'
   /Users:
@@ -23114,7 +23113,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Users'
-              example: '{
+              example:  {
                           "Id": "17932a4e-4948-4d50-8672-4ef0e1dd90c5",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -23139,7 +23138,7 @@ paths:
                               "OrganisationRole": "FINANCIALADVISER"
                             }
                           ]
-                        }'
+                        }
   '/Users/{UserID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -23166,7 +23165,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Users'
-              example: '{
+              example:  {
                           "Id": "51250ce8-1b35-4ba4-b404-dc94ff75bd87",
                           "Status": "OK",
                           "ProviderName": "Provider Name Example",
@@ -23182,7 +23181,7 @@ paths:
                               "OrganisationRole": "FINANCIALADVISER"
                             }
                           ]
-                        }'
+                        }
 components:
   securitySchemes:
     OAuth2:
@@ -23243,13 +23242,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/HistoryRecords'
-          example: '{  
+          example:  {  
                       "HistoryRecords": [  
                         {  
                           "Details": "Hello World"
                         }
                       ]
-                    }'
+                    }
   parameters:
     requiredHeader: 
       in: header
@@ -23304,7 +23303,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/HistoryRecords'
-          example: '{
+          example:  {
                       "Id": "d7525479-3392-44c0-bb37-ff4a0b5df5bd",
                       "Status": "OK",
                       "ProviderName": "Xero API Partner",
@@ -23317,14 +23316,14 @@ components:
                           "ValidationErrors": []
                         }
                       ]
-                    }'
+                    }
     HistoryRetrieved:
       description: Success - return response of HistoryRecords array of 0 to N HistoryRecord
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/HistoryRecords'
-          example: '{
+          example:  {
                       "Id": "cd54cc7b-b721-4207-b11d-7d13c7902f91",
                       "Status": "OK",
                       "ProviderName": "Xero API Partner",
@@ -23345,7 +23344,7 @@ components:
                           "Details": "Bank transfer from Business Wells Fargo to My Savings on November 12, 2016 for 20.00."
                         }
                       ]
-                    }'
+                    }
   schemas:
     AddressForOrganisation:
       externalDocs:
@@ -23485,7 +23484,7 @@ components:
             Customer defined alpha numeric account code e.g 200 or SALES (max
             length = 10)
           type: string
-          example: 4400
+          example: '4400'
         Name:
           description: Name of account (max length = 150)
           maxLength: 150
@@ -23495,10 +23494,9 @@ components:
           description: The Xero identifier for an account – specified as a string following  the endpoint name   e.g. /297c2dc5-cc47-4afd-8ec8-74990b8761e9
           type: string
           format: uuid
-          example: 00000000-0000-0000-000-000000000000
+          example: 00000000-0000-0000-0000-000000000000
         Type:
           $ref: '#/components/schemas/AccountType'
-          type: string
         BankAccountNumber:
           description: For bank accounts only (Account Type BANK)
           type: string
@@ -23525,7 +23523,6 @@ components:
           - ''
         CurrencyCode:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         TaxType:
           description: The tax type from TaxRates
           type: string
@@ -23587,7 +23584,7 @@ components:
           readOnly: true
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         UpdatedDateUTC:
           description: Last modified date UTC format
           type: string
@@ -23711,7 +23708,6 @@ components:
           type: string
         CurrencyCode:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         CurrencyRate:
           description: Exchange rate to base currency when money is spent or received. e.g.0.7500 Only used for bank transactions in non base currency. If this
             isn’t specified for non base currency accounts then either the
@@ -23732,7 +23728,6 @@ components:
             - VOIDED
         LineAmountTypes:
           $ref: '#/components/schemas/LineAmountTypes'
-          type: string
         SubTotal:
           description: Total of bank transaction excluding taxes
           type: number
@@ -23776,7 +23771,7 @@ components:
           readOnly: true
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         StatusAttributeString:
           description: A string to indicate if a invoice status
           type: string
@@ -23942,7 +23937,7 @@ components:
           readOnly: true
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         CreatedDateUTC:
           description: UTC timestamp of creation date of bank transfer
           type: string
@@ -24238,7 +24233,6 @@ components:
           type: boolean
         DefaultCurrency:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         XeroNetworkKey:
           description: Store XeroNetworkKey for contacts.
           type: string
@@ -24304,7 +24298,7 @@ components:
           description: A boolean to indicate if a contact has an attachment
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         ValidationErrors:
           description: Displays validation errors returned from the API
           type: array
@@ -24314,7 +24308,7 @@ components:
           description: A boolean to indicate if a contact has an validation errors
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         StatusAttributeString:
           description: Status of object
           type: string
@@ -24489,7 +24483,6 @@ components:
           - VOIDED
         LineAmountTypes:
           $ref: '#/components/schemas/LineAmountTypes'
-          type: string
         LineItems:
           description: See Invoice Line Items
           type: array
@@ -24530,8 +24523,6 @@ components:
           readOnly: true
         CurrencyCode:
           description: The specified currency code
-          $ref: '#/components/schemas/CurrencyCode'
-          type: string
         FullyPaidOnDate:
           description: Date when credit note was fully paid(UTC format)
           type: string
@@ -24589,12 +24580,12 @@ components:
           description: boolean to indicate if a credit note has an attachment
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         HasErrors:
           description: A boolean to indicate if a credit note has an validation errors
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         ValidationErrors: 
           description: Displays array of validation error messages from the API
           type: array
@@ -24657,7 +24648,6 @@ components:
       properties:
         Code:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         Description:
           description: Name of Currency
           type: string
@@ -25194,7 +25184,6 @@ components:
           x-is-msdate: true
         LineAmountTypes:
           $ref: '#/components/schemas/LineAmountTypes'
-          type: string
         InvoiceNumber:
           description: ACCREC – Unique alpha numeric code identifying invoice (when missing will auto-generate from your Organisation Invoice Settings) (max
             length = 255)
@@ -25213,7 +25202,6 @@ components:
           type: string
         CurrencyCode:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         CurrencyRate:
           description: The currency rate for a multicurrency invoice. If no rate is
             specified, the XE.com day rate is used. (max length = [18].[6])
@@ -25291,7 +25279,7 @@ components:
           readOnly: true
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         IsDiscounted:
           description: boolean to indicate if an invoice has a discount
           readOnly: true
@@ -25360,7 +25348,7 @@ components:
           description: A boolean to indicate if a invoice has an validation errors
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         StatusAttributeString:
           description: A string to indicate if a invoice status
           type: string
@@ -25603,10 +25591,9 @@ components:
         AccountCode:
           description: See Accounts
           type: string
-          example: 090
+          example: '090'
         AccountType:
           $ref: '#/components/schemas/AccountType'
-          type: string
         AccountName:
           description: See AccountCodes
           type: string
@@ -25750,7 +25737,6 @@ components:
           x-is-msdate: true
         LineAmountTypes:
           $ref: '#/components/schemas/LineAmountTypes'
-          type: string
         Status:
           description: See Manual Journal Status Codes
           type: string
@@ -25772,7 +25758,7 @@ components:
           readOnly: true
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         UpdatedDateUTC:
           description: Last modified date UTC format
           type: string
@@ -25818,7 +25804,7 @@ components:
         AccountCode:
           description: See Accounts
           type: string
-          example: 720
+          example: '720'
         AccountID:
           description: See Accounts
           type: string
@@ -25931,10 +25917,8 @@ components:
             - TRUST
         BaseCurrency:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         CountryCode:
           $ref: '#/components/schemas/CountryCode'
-          type: string
         IsDemoCompany:
           description: Boolean to describe if organisation is a demo company.
           type: boolean
@@ -26012,7 +25996,6 @@ components:
           readOnly: true
         Timezone:
           $ref: '#/components/schemas/TimeZone'
-          type: string
         OrganisationEntityType:
           description: Organisation Entity Type
           type: string
@@ -26510,7 +26493,6 @@ components:
             - VOIDED
         LineAmountTypes:
           $ref: '#/components/schemas/LineAmountTypes'
-          type: string
         LineItems:
           description: See Overpayment Line Items
           type: array
@@ -26539,7 +26521,6 @@ components:
           readOnly: true
         CurrencyCode:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         OverpaymentID:
           description: Xero generated unique identifier
           type: string
@@ -26575,7 +26556,7 @@ components:
           readOnly: true
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         Attachments:
           description: See Attachments
           type: array
@@ -26689,12 +26670,12 @@ components:
           description: A boolean to indicate if a contact has an validation errors
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         HasValidationErrors:
           description: A boolean to indicate if a contact has an validation errors
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         StatusAttributeString:
           description: A string to indicate if a invoice status
           type: string
@@ -26739,7 +26720,6 @@ components:
             - VOIDED
         LineAmountTypes:
           $ref: '#/components/schemas/LineAmountTypes'
-          type: string
         LineItems:
           description: See Prepayment Line Items
           type: array
@@ -26772,7 +26752,6 @@ components:
           readOnly: true
         CurrencyCode:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         PrepaymentID:
           description: Xero generated unique identifier
           type: string
@@ -26803,7 +26782,7 @@ components:
           readOnly: true
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         Attachments:
           description: See Attachments
           type: array
@@ -26840,7 +26819,6 @@ components:
           x-is-msdate: true
         LineAmountTypes:
           $ref: '#/components/schemas/LineAmountTypes'
-          type: string
         PurchaseOrderNumber:
           description: Unique alpha numeric code identifying purchase order (when missing
             will auto-generate from your Organisation Invoice Settings)
@@ -26854,7 +26832,6 @@ components:
           format: uuid
         CurrencyCode:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         Status:
           description: See Purchase Order Status Codes
           type: string
@@ -26923,7 +26900,7 @@ components:
           readOnly: true
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         UpdatedDateUTC:
           description: Last modified date UTC format
           type: string
@@ -26979,7 +26956,6 @@ components:
           type: string
         Contact:
           $ref: '#/components/schemas/Contact'
-          type: string
         LineItems:
           description: See LineItems
           type: array
@@ -27001,10 +26977,8 @@ components:
           type: string
         Status:
           $ref: '#/components/schemas/QuoteStatusCodes'
-          type: string
         CurrencyCode:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         CurrencyRate:
           description: The currency rate for a multicurrency quote
           type: number
@@ -27053,8 +27027,6 @@ components:
           readOnly: true
         LineAmountTypes:
           $ref: '#/components/schemas/QuoteLineAmountTypes'
-          type: string
-          description: See Quote Line Amount Types
         StatusAttributeString:
           description: A string to indicate if a invoice status
           type: string
@@ -27110,7 +27082,6 @@ components:
           type: string
         LineAmountTypes:
           $ref: '#/components/schemas/LineAmountTypes'
-          type: string
         SubTotal:
           description: Total of receipt excluding taxes
           type: number
@@ -27154,7 +27125,7 @@ components:
           readOnly: true
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         Url:
           description: URL link to a source document – shown as “Go to [appName]” in the Xero app
           readOnly: true
@@ -27204,7 +27175,6 @@ components:
             $ref: '#/components/schemas/LineItem'
         LineAmountTypes:
           $ref: '#/components/schemas/LineAmountTypes'
-          type: string
         Reference:
           description: ACCREC only – additional reference number
           type: string
@@ -27214,7 +27184,6 @@ components:
           format: uuid
         CurrencyCode:
           $ref: '#/components/schemas/CurrencyCode'
-          type: string
         Status:
           description:  One of the following - DRAFT or AUTHORISED – See Invoice Status
             Codes
@@ -27251,7 +27220,7 @@ components:
           readOnly: true
           type: boolean
           default: "false"
-          example: "false"
+          example: false
         Attachments: 
           description: Displays array of attachments from the API
           type: array

--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -68,13 +68,13 @@ paths:
             enum: 
             - asc
             - desc
-            example: ASC
+            example: asc
         - name: filterBy
           in: query
           description: A string that can be used to filter the list to only return assets containing the text. Checks it against the AssetName, AssetNumber, Description and AssetTypeName fields.
           schema: 
             type: string
-            example: Draft
+            example: AssetName
             enum:
             - AssetName
             - AssetNumber
@@ -87,7 +87,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Assets'
-              example: '{ 
+              example:  { 
                           "pagination":{ 
                             "page":1,
                             "pageSize":10,
@@ -110,13 +110,14 @@ paths:
                               "assetId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
                               "assetName":"Computer47822",
                               "assetNumber":"123478074",
-                              "purchaseDate":"2020-01-01T00:00:00",
+                              "purchaseDate":"2020-01-01",
                               "purchasePrice":100.0000,
                               "disposalPrice":0.0,
                               "assetStatus":"Draft",
                               "trackingItems":[ 
                             ],
-                            "bookDepreciationSetting":{ 
+                            "bookDepreciationSetting":{
+                              "name": "setting1", 
                               "depreciableObjectId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
                               "depreciableObjectType":"Asset",
                               "bookEffectiveDateOfChangeId":"5da77739-7f22-4109-b0a0-67480fb89af0",
@@ -126,7 +127,8 @@ paths:
                               "depreciationCalculationMethod":"None"
                             },
                             "bookDepreciationDetail":{ 
-                              "depreciationStartDate":"2020-01-02T00:00:00",
+                              "name": "detail1", 
+                              "depreciationStartDate":"2020-01-02",
                               "priorAccumDepreciationAmount":0.000000,
                               "currentAccumDepreciationAmount":0.000000,
                               "currentCapitalGain":0.000000,
@@ -146,7 +148,7 @@ paths:
                             "assetId":"52ea3adf-f04a-4577-8fd2-43c52a256bd5",
                             "assetName":"Computer4148",
                             "assetNumber":"123466620",
-                            "purchaseDate":"2020-01-01T00:00:00",
+                            "purchaseDate":"2020-01-01",
                             "purchasePrice":100.0000,
                             "disposalPrice":0.0,
                             "assetStatus":"Draft",
@@ -154,6 +156,7 @@ paths:
 
                             ],
                             "bookDepreciationSetting":{ 
+                              "name":"setting",
                               "depreciableObjectId":"52ea3adf-f04a-4577-8fd2-43c52a256bd5",
                               "depreciableObjectType":"Asset",
                               "bookEffectiveDateOfChangeId":"c0d5280f-28b6-4329-b5b7-36e08c662010",
@@ -163,7 +166,8 @@ paths:
                               "depreciationCalculationMethod":"None"
                             },
                             "bookDepreciationDetail":{ 
-                              "depreciationStartDate":"2020-01-02T00:00:00",
+                              "name":"detail",
+                              "depreciationStartDate":"2020-01-02",
                               "priorAccumDepreciationAmount":0.000000,
                               "currentAccumDepreciationAmount":0.000000,
                               "currentCapitalGain":0.000000,
@@ -181,7 +185,7 @@ paths:
                             "isDeleteEnabledForDate":false
                           }
                         ]
-                      }'
+                      }
         '400':
           description: bad input parameter
     post:
@@ -200,16 +204,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Asset'
-              example: '{ 
+              example:  { 
                           "assetId":"2257c64a-77ca-444c-a5ea-fa9a588c7039",
                           "assetName":"Computer74863",
                           "assetNumber":"123477544",
-                          "purchaseDate":"2020-01-01T00:00:00",
+                          "purchaseDate":"2020-01-01",
                           "purchasePrice":100.0000,
                           "disposalPrice":23.2300,
                           "assetStatus":"Draft",
                           "trackingItems":[],
                           "bookDepreciationSetting":{ 
+                            "name": "setting",
                             "depreciableObjectId":"2257c64a-77ca-444c-a5ea-fa9a588c7039",
                             "depreciableObjectType":"Asset",
                             "bookEffectiveDateOfChangeId":"b58a2ace-1213-4681-9f11-2e30f57b5b8c",
@@ -219,7 +224,8 @@ paths:
                             "depreciationCalculationMethod":"None"
                           },
                           "bookDepreciationDetail":{ 
-                            "depreciationStartDate":"2020-01-02T00:00:00",
+                            "name": "detail",
+                            "depreciationStartDate":"2020-01-02",
                             "priorAccumDepreciationAmount":0.000000,
                             "currentAccumDepreciationAmount":0.000000,
                             "currentCapitalGain":0.000000,
@@ -232,7 +238,7 @@ paths:
                           "accountingBookValue":76.770000,
                           "taxValues":[],
                           "isDeleteEnabledForDate":true
-                        }'
+                        }
         '400':
           description: 'invalid input, object invalid'
           content:
@@ -259,7 +265,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Asset'
-            example: '{ 
+            example:  { 
                         "assetName":"Computer74863",
                         "assetNumber":"123477544",
                         "purchaseDate":"2020-01-01",
@@ -267,12 +273,14 @@ paths:
                         "disposalPrice":23.23,
                         "assetStatus":"Draft",
                         "bookDepreciationSetting":{ 
+                          "name":"Setting",
                           "depreciationMethod":"StraightLine",
                           "averagingMethod":"ActualDays",
                           "depreciationRate":0.5,
                           "depreciationCalculationMethod":"None"
                         },
                         "bookDepreciationDetail":{ 
+                          "name":"Detail",
                           "currentCapitalGain":5.32,
                           "currentGainLoss":3.88,
                           "depreciationStartDate":"2020-01-02",
@@ -280,7 +288,7 @@ paths:
                           "currentAccumDepreciationAmount":2.25
                         },
                         "AccountingBookValue":99.5
-                      }'
+                      }
         description: Fixed asset you are creating
   /Assets/{id}:
     parameters:
@@ -311,11 +319,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Asset'
-              example: '{ 
+              example:  { 
                           "assetId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
                           "assetName":"Computer47822",
                           "assetNumber":"123478074",
-                          "purchaseDate":"2020-01-01T00:00:00",
+                          "purchaseDate":"2020-01-01",
                           "purchasePrice":100.0000,
                           "disposalPrice":23.0000,
                           "assetStatus":"Draft",
@@ -323,6 +331,7 @@ paths:
 
                           ],
                           "bookDepreciationSetting":{ 
+                            "name":"setting",
                             "depreciableObjectId":"68f17094-af97-4f1b-b36b-013b45b6ad3c",
                             "depreciableObjectType":"Asset",
                             "bookEffectiveDateOfChangeId":"5da77739-7f22-4109-b0a0-67480fb89af0",
@@ -332,7 +341,8 @@ paths:
                             "depreciationCalculationMethod":"None"
                           },
                           "bookDepreciationDetail":{ 
-                            "depreciationStartDate":"2020-01-02T00:00:00",
+                            "name":"detail",
+                            "depreciationStartDate":"2020-01-02",
                             "priorAccumDepreciationAmount":0.000000,
                             "currentAccumDepreciationAmount":0.000000,
                             "currentCapitalGain":0.000000,
@@ -348,10 +358,10 @@ paths:
                           "taxDepreciationDetailsCanChange":true
                           },
                           "accountingBookValue":77.000000,
-                          "taxValues":[ 
+                          "taxValues":[ 1.000
                           ],
                           "isDeleteEnabledForDate":true
-                        }'
+                        }
         '400':
           description: bad input parameter
   /AssetTypes:
@@ -375,7 +385,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AssetType'
-              example: '[ 
+              example:  [ 
                           { 
                             "assetTypeId":"710255c6-d2ed-4463-b992-06c8685add5e",
                             "assetTypeName":"Computer Equipment",
@@ -383,6 +393,7 @@ paths:
                             "depreciationExpenseAccountId":"0fbd1820-9dd0-454a-9515-6ec076a84cf7",
                             "accumulatedDepreciationAccountId":"512eac06-6894-47cd-b421-673b4ca2693a",
                             "bookDepreciationSetting":{ 
+                              "name":"setting",
                               "depreciableObjectId":"710255c6-d2ed-4463-b992-06c8685add5e",
                               "depreciableObjectType":"AssetType",
                               "bookEffectiveDateOfChangeId":"39b9c2e9-62b1-4efc-ab75-fa9152ffaa5f",
@@ -403,6 +414,7 @@ paths:
                             "depreciationExpenseAccountId":"adc14376-c960-43f0-b7f3-4063e5098039",
                             "accumulatedDepreciationAccountId":"9195cadd-8645-41e6-9f67-7bcd421defe8",
                             "bookDepreciationSetting":{ 
+                              "name":"setting",
                               "depreciableObjectId":"1a398a67-9d9d-4783-8689-14a8efce89d9",
                               "depreciableObjectType":"AssetType",
                               "bookEffectiveDateOfChangeId":"6d09a96d-7768-4f28-95e8-c9ac870fe36e",
@@ -416,7 +428,7 @@ paths:
                             "locks":0,
                             "lockPrivateUseAccount":false
                           }
-                        ]'
+                        ]
         '400':
           description: bad input parameter
     post:
@@ -435,13 +447,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssetType'
-              example: '{ 
+              example:  { 
                           "assetTypeId":"85509b5d-308e-420d-9532-b85105058916",
                           "assetTypeName":"Machinery11004",
                           "fixedAssetAccountId":"3d8d063a-c148-4bb8-8b3c-a5e2ad3b1e82",
                           "depreciationExpenseAccountId":"d1602f69-f900-4616-8d34-90af393fa368",
                           "accumulatedDepreciationAccountId":"9195cadd-8645-41e6-9f67-7bcd421defe8",
                           "bookDepreciationSetting":{ 
+                            "name":"setting",
                             "depreciableObjectId":"00000000-0000-0000-0000-000000000000",
                             "depreciableObjectType":"None",
                             "depreciationMethod":"DiminishingValue100",
@@ -451,7 +464,7 @@ paths:
                           },
                           "locks":0,
                           "lockPrivateUseAccount":false
-                        }'
+                        }
         '400':
           description: 'invalid input, object invalid'
           content:
@@ -488,18 +501,19 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AssetType'
-            example: '{ 
+            example:  { 
                         "assetTypeName":"Machinery11004",
                         "fixedAssetAccountId":"3d8d063a-c148-4bb8-8b3c-a5e2ad3b1e82",
                         "depreciationExpenseAccountId":"d1602f69-f900-4616-8d34-90af393fa368",
                         "accumulatedDepreciationAccountId":"9195cadd-8645-41e6-9f67-7bcd421defe8",
                         "bookDepreciationSetting":{ 
+                          "name":"setting",
                           "depreciationMethod":"DiminishingValue100",
                           "averagingMethod":"ActualDays",
                           "depreciationRate":0.05,
                           "depreciationCalculationMethod":"None"
                         }
-                      }'
+                      }
         description: Asset type to add
   /Settings:
     parameters:
@@ -520,12 +534,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Setting'
-              example: '{ 
+              example:  { 
+                          "name":"setting",
                           "assetNumberPrefix":"FA-",
                           "assetNumberSequence":"0007",
-                          "assetStartDate":"2016-01-01T00:00:00",
+                          "assetStartDate":"2016-01-01",
                           "optInForTax":false
-                        }'
+                        }
         '400':
           description: bad input parameter
 components:
@@ -603,24 +618,24 @@ components:
           type: string
           format: date
           description: "The date the asset was purchased YYYY-MM-DD"
-          example: "2015-07-01T00:00:00"
+          example: "2015-07-01"
         purchasePrice:
           type: number
           format: double
           x-is-money: true
           description: "The purchase price of the asset"
-          example: "1000.0000"
+          example: 1000.0000
         disposalDate:
           type: string
           format: date
           description: "The date the asset was disposed"
-          example: "2020-07-01T00:00:00"          
+          example: "2020-07-01"          
         disposalPrice:
           type: number
           format: double
           x-is-money: true
           description: "The price the asset was disposed at"
-          example: "1.0000"
+          example: 1.0000
         assetStatus:
           $ref: '#/components/schemas/AssetStatus'
         warrantyExpiryDate:
@@ -774,7 +789,7 @@ components:
         depreciationStartDate:
           type: string
           format: date
-          example: "2015-07-01T00:00:00"
+          example: "2015-07-01"
           description: "YYYY-MM-DD"
         costLimit:
           type: number
@@ -815,12 +830,12 @@ components:
         assetStartDate:
           type: string
           format: date
-          example: "2015-07-31T00:00:00"
+          example: "2015-07-31"
           description: "The date depreciation calculations started on registered fixed assets in Xero"
         lastDepreciationDate:
           type: string
           format: date
-          example: "2015-07-01T00:00:00"
+          example: "2015-07-01"
           description: "The last depreciation date"
         defaultGainOnDisposalAccountId:
           type: string

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -285,14 +285,14 @@ paths:
                           "startDate":"2019-08-01",
                           "endDate":"2019-08-15",
                           "startBalance":{ 
-                              "amount":"100.0000",
+                              "amount": 100.0000,
                               "creditDebitIndicator":"CREDIT"
                           },
                           "endBalance":{ 
-                              "amount":"150.0000",
+                              "amount": 150.0000,
                               "creditDebitIndicator":"CREDIT"
                           },
-                          "statementLineCount":"1",
+                          "statementLineCount": 1,
                           "errors":[ 
                               { 
                                 "type":"duplicate-statement",
@@ -309,14 +309,14 @@ paths:
                           "startDate":"2019-08-01",
                           "endDate":"2019-08-15",
                           "startBalance":{ 
-                              "amount":"100.0000",
+                              "amount": 100.0000,
                               "creditDebitIndicator":"CREDIT"
                           },
                           "endBalance":{ 
-                              "amount":"150.0000",
+                              "amount": 150.0000,
                               "creditDebitIndicator":"CREDIT"
                           },
-                          "statementLineCount":"1"
+                          "statementLineCount": 1
                         }
                     ]
                   }
@@ -459,18 +459,18 @@ paths:
                         "startDate":"2019-08-11",
                         "endDate":"2019-08-11",
                         "startBalance":{ 
-                            "amount":"100",
+                            "amount": 100,
                             "creditDebitIndicator":"CREDIT"
                         },
                         "endBalance":{ 
-                            "amount":"150",
+                            "amount": 150,
                             "creditDebitIndicator":"CREDIT"
                         },
                         "statementLines":[ 
                             { 
                               "postedDate":"2019-08-11",
                               "description":"My new line",
-                              "amount":"50",
+                              "amount": 50,
                               "creditDebitIndicator":"CREDIT",
                               "transactionId":"123446422",
                               "payeeName":"StarLord90315",
@@ -484,18 +484,18 @@ paths:
                         "startDate":"2019-08-11",
                         "endDate":"2019-08-11",
                         "startBalance":{ 
-                            "amount":"100",
+                            "amount": 100,
                             "creditDebitIndicator":"CREDIT"
                         },
                         "endBalance":{ 
-                            "amount":"150",
+                            "amount": 150,
                             "creditDebitIndicator":"CREDIT"
                         },
                         "statementLines":[ 
                             { 
                               "postedDate":"2019-08-11",
                               "description":"My new line",
-                              "amount":"50",
+                              "amount": 50,
                               "creditDebitIndicator":"CREDIT",
                               "transactionId":"123449402",
                               "payeeName":"StarLord56705",
@@ -540,14 +540,14 @@ paths:
                     "startDate":"2019-08-11",
                     "endDate":"2019-10-11",
                     "startBalance":{ 
-                        "amount":"100.0000",
+                        "amount": 100.0000,
                         "creditDebitIndicator":"CREDIT"
                     },
                     "endBalance":{ 
-                        "amount":"150.0000",
+                        "amount": 150.0000,
                         "creditDebitIndicator":"CREDIT"
                     },
-                    "statementLineCount":"1"
+                    "statementLineCount": 1
                   }
         '404':
           description: Statement not found
@@ -629,7 +629,7 @@ components:
         id:
           type: string
           format: uuid
-          example: "0d3cf8d-95dc-4466-8dc0-47e6d1197e28"
+          example: 151250a2-e59d-4714-962a-9f431693ea4d
           description: GUID used to identify the Account.
         accountToken:
           type: string
@@ -744,7 +744,7 @@ components:
           type: number
           format: double
           x-is-money: true
-          example: "9.0000"
+          example: 9.0000
           description: decimal(19,4) unsigned Opening/closing balance amount.
         creditDebitIndicator:
           $ref: '#/components/schemas/CreditDebitIndicator'
@@ -756,7 +756,7 @@ components:
           type: number
           format: double
           x-is-money: true
-          example: "10.1340"
+          example: 10.1340
         creditDebitIndicator:
           $ref: '#/components/schemas/CreditDebitIndicator'
     StatementLines:
@@ -781,7 +781,7 @@ components:
           type: number
           format: double
           x-is-money: true
-          example: "5.00"
+          example: 5.00
           description: Transaction amount
         creditDebitIndicator: 
           $ref: '#/components/schemas/CreditDebitIndicator'


### PR DESCRIPTION
Fix linting errors found when running Spectral Linter for OpenAPIv3

## Description
Fix linting errors found when running Spectral Linter for OpenAPIv3
Also fixed a few spelling errors in api.accounting.yaml

## Release Notes
The Open API spec will be used as reference for our public API docs.
We encounter some problems during development when ingesting the yaml files and
have decided to run a linter (spectral) and fix any issues found

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
