### PR TITLE
Make AppliedAmount a monetary field

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -24617,6 +24617,7 @@ components:
           type: number
           format: double 
           example: 2.00
+          x-is-money: true
         Payments:
           description: See Payments 
           type: array


### PR DESCRIPTION
Credit Note Applied Amount should be a monetary field

Reported by @mogest  -> https://github.com/XeroAPI/xero-ruby/issues/117

## Description
We use OpenAPI Spec's vendor extension pattern to handle non conforming cases that fuel the logic in the templates of our SDK generation. This specifically helps ruby SDK put type as BigDecimal instead of float, as well as other similar type changes in the other 5 SDKs.

## Release Notes
Monetary field changed to proper type

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
