### PR TITLE
update filterby parameter to string from a enum

### DIFF
--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -74,12 +74,7 @@ paths:
           description: A string that can be used to filter the list to only return assets containing the text. Checks it against the AssetName, AssetNumber, Description and AssetTypeName fields.
           schema: 
             type: string
-            example: Draft
-            enum:
-            - AssetName
-            - AssetNumber
-            - Description
-            - AssetTypeName
+            example: "Company Car"
       responses:
         '200':
           description: search results matching criteria


### PR DESCRIPTION
filterby parameter for GET assets acts as an keyword search against the AssetName, AssetNumber, Description and AssetTypeName fields

## Description
This PR changes the enum type to string

## Release Notes
It is currently being interpreted as enum which is blocking its function. 

## Screenshots (if appropriate):
Searching for AssetCode will return only the matching item: 
![image](https://user-images.githubusercontent.com/41350731/106991011-85742180-67c9-11eb-8044-002223d99931.png)

API documentation also confirms so: 
![image](https://user-images.githubusercontent.com/41350731/106991070-9d4ba580-67c9-11eb-9ccd-d68d8a3e1736.png)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
