### PR TITLE
Fix invalid integer formats

### DIFF
--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -141,9 +141,9 @@ components:
           description: access token provided during authentication flow
           type: string
         expires_in:
-          description: time in milliseconds until access token expires.
-          type: number
-          format: int
+          description: time in seconds until access token expires.
+          type: integer
+          format: int64
         token_type:
           description: type of token i.e. Bearer
           type: string

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -27833,38 +27833,38 @@ components:
       properties:
         Total:
           description: The total number of accounts in the org
-          type: number
-          format: integer
+          type: integer
+          format: int32
         New:
           description: The number of new accounts created
-          type: number
-          format: integer
+          type: integer
+          format: int32
         Updated:
           description: The number of accounts updated
-          type: number
-          format: integer
+          type: integer
+          format: int32
         Deleted:
           description: The number of accounts deleted
-          type: number
-          format: integer
+          type: integer
+          format: int32
         Locked:
           description: The number of locked accounts
-          type: number
-          format: integer
+          type: integer
+          format: int32
         System:
           description: The number of system accounts
-          type: number
-          format: integer
+          type: integer
+          format: int32
         Errored:
           description: The number of accounts that had an error
-          type: number
-          format: integer
+          type: integer
+          format: int32
         Present:
           type: boolean
         NewOrUpdated:
           description: The number of new or updated accounts
-          type: number
-          format: integer
+          type: integer
+          format: int32
     ImportSummaryOrganisation:
       type: object
       properties:


### PR DESCRIPTION
For identity and accounting APIs, some OpenAPI integer properties had an invalid format. The generator was producing warnings, but falling back to a float or double.

## Description

Some model properties were `type: number` and `format: int` or `format: integer`. This is invalid for OpenAPI v3.0.x The supported formats are here:

https://swagger.io/specification/#dataTypeFormat

The fix changes these to: `type: integer` and `format: int64` for the identity model (I have no idea how big that number can get) and `type: integer` and `format: int32` for the accountancy API (those numbers are counts of present and updated accounts and records, which I am *assuming* an `int32` will be sufficient for just for practical reasons. The int32/int64 choices were just my assumptions and can be changed.

## Release Notes

The OpenAPI generator was accepting the invalid format, but falling back to `type: number` and `format: float`, and these values are by no means floating point.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Whether this is a breaking change may depend on how strictly typed the generated language is. However, since the generator (if using the standard `openapitools` generator) would have been generating warnings for some time, I would argue there has been fair warning that a fix would be coming ;-)