### PR TITLE
Added C# specific values for NetStandard examples, Bug Fixes

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -28,6 +28,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status==&quot;ACTIVE&quot; AND Type==&quot;BANK&quot;
+          x-example-csharp: Status==/"ACTIVE/"
           x-example-java: Status==&quot;&apos; + Account.StatusEnum.ACTIVE+ &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Account::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Account::ACTIVE}
@@ -102,7 +103,7 @@ paths:
           ruby: XeroRuby::Accounting::AccountType::EXPENSE
           python: AccountType.EXPENSE
           java: com.xero.models.accounting.AccountType.EXPENSE
-          csharp: Account.ClassEnum.EXPENSE
+          csharp: AccountType.EXPENSE
           object: account
         - description:
           is_last: true
@@ -262,7 +263,7 @@ paths:
           ruby: XeroRuby::Accounting::AccountType::EXPENSE
           python: AccountType.EXPENSE
           java: com.xero.models.accounting.AccountType.EXPENSE
-          csharp: Account.ClassEnum.EXPENSE
+          csharp: AccountType.EXPENSE
           object: account
         - description:
           key: description
@@ -286,6 +287,7 @@ paths:
           key: accounts
           keyPascal: Accounts
           java: Accounts
+          csharp: Account
           object: account
       parameters:
         - required: true
@@ -708,6 +710,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="AUTHORISED"
+          x-example-csharp: Status==/&quot;AUTHORISED/&quot;
           x-example-java: Status==&quot;&apos; + BatchPayment.StatusEnum.AUTHORISED + &apos;&quot;
           x-example-php: Status==&quot;&apos; . XeroAPI\XeroPHP\Models\Accounting\BatchPayment::STATUS_AUTHORISED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::BatchPayment::AUTHORISED}
@@ -839,7 +842,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.now()"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           node: "'2020-12-10'"
           php: "new DateTime('2020-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -906,6 +909,7 @@ paths:
           key: amount
           keyPascal: Amount
           default: 1.00
+          is_money: true
           object: payment
         - set_invoice:
           is_last: true
@@ -971,6 +975,7 @@ paths:
           keySnake: batch_payments
           java: BatchPayments
           python: batch_payment
+          csharp: BatchPayment
           object: batchPayment
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -1156,6 +1161,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -1208,6 +1214,7 @@ paths:
           description: Filter by an any element
           example: Status=="AUTHORISED"
           x-example-java: Status==&quot;&apos; + BankTransaction.StatusEnum.AUTHORISED + &apos;&quot;
+          x-example-csharp: Status==/"AUTHORISED/"
           x-example-php: Status==&quot;&apos; . XeroAPI\XeroPHP\Models\Accounting\BankTransaction::STATUS_AUTHORISED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::BankTransaction::AUTHORISED}
           schema:
@@ -1383,6 +1390,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -1390,6 +1398,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -1442,6 +1451,7 @@ paths:
           keySnake: line_items
           java: LineItems
           python: line_item
+          csharp: LineItem
           object: lineItem
         - set_bankaccount:
           is_last: true
@@ -1465,6 +1475,7 @@ paths:
           keySnake: bank_transactions
           java: BankTransactions
           python: bank_transaction
+          csharp: BankTransaction
           object: bankTransaction
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -1632,6 +1643,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -1639,6 +1651,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -1686,11 +1699,12 @@ paths:
           object: bankTransaction
         - add_lineitems:
           is_array_add: true
-          key: lineItems
+          key: bankTransaction
           keyPascal: LineItems
           keySnake: line_items
           java: LineItems
           python: line_item
+          csharp: LineItem
           object: lineItem
         - set_bankaccount:
           is_last: true
@@ -1714,6 +1728,7 @@ paths:
           keySnake: bank_transactions
           java: BankTransactions
           python: bank_transaction
+          csharp: BankTransaction
           object: bankTransaction
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -2046,6 +2061,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -2053,6 +2069,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -2105,11 +2122,12 @@ paths:
           object: bankTransaction
         - add_lineitems:
           is_array_add: true
-          key: lineItems
+          key: bankTransaction
           keyPascal: LineItems
           keySnake: line_items
           java: LineItems
           python: line_item
+          csharp: LineItem
           object: lineItem
         - set_bankaccount:
           is_last: true
@@ -2133,6 +2151,7 @@ paths:
           keySnake: bank_transactions
           java: BankTransactions
           python: bank_transaction
+          csharp: BankTransaction
           object: bankTransaction
       parameters:
         - required: true
@@ -2645,6 +2664,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -2801,6 +2821,7 @@ paths:
           key: amount
           keyPascal: Amount
           default: 1.0
+          is_money: true
           object: bankTransfer
         - bankTransfers:
           is_object: true
@@ -2814,6 +2835,7 @@ paths:
           keySnake: bank_transfers
           java: BankTransfers
           python: bank_transfer
+          csharp: BankTransfer
           object: bankTransfer
       responses:
         '200':
@@ -3259,6 +3281,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -3492,6 +3515,7 @@ paths:
           name: where
           description: Filter by an any element
           example: ContactStatus==&quot;ACTIVE&quot;
+          x-example-csharp: ContactStatus==/&quot;ACTIVE/&quot;
           x-example-java: ContactStatus==&quot;&apos; + Contact.ContactStatusEnum.ACTIVE + &apos;&quot;
           x-example-php: ContactStatus==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Contact::CONTACT_STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: ContactStatus==#{XeroRuby::Accounting::Contact::ACTIVE}
@@ -3709,7 +3733,7 @@ paths:
           ruby: XeroRuby::Accounting::PhoneType::MOBILE
           python_string: MOBILE
           java: com.xero.models.accounting.Phone.PhoneTypeEnum.MOBILE
-          csharp: Phone.TypeEnum.MOBILE
+          csharp: Phone.PhoneTypeEnum.MOBILE
           object: phone
         - phones:
           is_list: true
@@ -3754,6 +3778,7 @@ paths:
           key: contacts
           keyPascal: Contacts
           java: Contacts
+          csharp: Contact
           object: contact
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -4061,6 +4086,7 @@ paths:
           key: contacts
           keyPascal: Contacts
           java: Contacts
+          csharp: Contact
           object: contact
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -4583,6 +4609,7 @@ paths:
           key: contacts
           keyPascal: Contacts
           java: Contacts
+          csharp: Contact
           object: contact
       parameters:
         - required: true
@@ -5004,6 +5031,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -5036,6 +5064,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="ACTIVE"
+          x-example-csharp: Status==/"ACTIVE/"
           x-example-java: Status==&quot;&apos; + ContactGroup.StatusEnum.ACTIVE + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\ContactGroup::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::ContactGroup::ACTIVE}
@@ -5110,6 +5139,7 @@ paths:
           keySnake: contact_groups
           java: ContactGroups
           python: contact_group
+          csharp: ContactGroup
           object: contactGroup
       responses:
         '200':
@@ -5259,6 +5289,7 @@ paths:
           keySnake: contact_groups
           java: ContactGroups
           python: contact_group
+          csharp: ContactGroup
           object: contactGroup
       parameters:
         - required: true
@@ -5343,6 +5374,7 @@ paths:
           key: contacts
           keyPascal: Contacts
           java: Contacts
+          csharp: Contact
           object: contact
       parameters:
         - required: true
@@ -5474,6 +5506,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="DRAFT"
+          x-example-csharp: Status==/"DRAFT/"
           x-example-java: Status==&quot;&apos; + CreditNote.StatusEnum.DRAFT + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\CreditNote::STATUS_DRAFT . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::CreditNote::DRAFT}
@@ -5599,7 +5632,7 @@ paths:
           default: "LocalDate.now()"
           java: "LocalDate.now()"
           node: "'2020-12-10'"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           php: "new DateTime('2020-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
         - contact:
@@ -5629,6 +5662,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -5636,6 +5670,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -5649,6 +5684,7 @@ paths:
           key: lineItems
           keyPascal: LineItems
           keySnake: line_items
+          csharp: LineItem
         - add_lineitems:
           is_last: true
           is_list_add: true
@@ -5672,7 +5708,7 @@ paths:
           ruby: XeroRuby::Accounting::CreditNote::ACCPAYCREDIT
           python_string: ACCPAYCREDIT
           java: com.xero.models.accounting.CreditNote.TypeEnum.ACCPAYCREDIT
-          csharp: CreditNote.xxx
+          csharp: CreditNote.TypeEnum.ACCPAYCREDIT
           object: creditNote
         - set_contact:
           is_variable: true
@@ -5711,6 +5747,7 @@ paths:
           keySnake: credit_notes
           java: CreditNotes
           python: credit_note
+          csharp: CreditNote
           object: creditNote
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -5873,7 +5910,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.now()"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           node: "'2020-12-10'"
           php: "new DateTime('2020-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -5904,6 +5941,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -5911,6 +5949,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -5947,7 +5986,7 @@ paths:
           ruby: XeroRuby::Accounting::CreditNote::ACCPAYCREDIT
           python_string: ACCPAYCREDIT
           java: com.xero.models.accounting.CreditNote.TypeEnum.ACCPAYCREDIT
-          csharp: CreditNote.xxx
+          csharp: CreditNote.TypeEnum.ACCPAYCREDIT
           object: creditNote
         - set_contact:
           is_variable: true
@@ -5986,6 +6025,7 @@ paths:
           keySnake: credit_notes
           java: CreditNotes
           python: credit_note
+          csharp: CreditNote
           object: creditNote
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -6295,7 +6335,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.now()"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           node: "'2020-12-10'"
           php: "new DateTime('2020-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -6326,6 +6366,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -6333,6 +6374,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -6369,7 +6411,7 @@ paths:
           ruby: XeroRuby::Accounting::CreditNote::ACCPAYCREDIT
           python_string: ACCPAYCREDIT
           java: com.xero.models.accounting.CreditNote.TypeEnum.ACCPAYCREDIT
-          csharp: CreditNote.xxx
+          csharp: CreditNote.TypeEnum.ACCPAYCREDIT
           object: creditNote
         - status:
           nonString: true
@@ -6381,7 +6423,7 @@ paths:
           ruby: XeroRuby::Accounting::CreditNote::AUTHORISED
           python_string: AUTHORISED
           java: com.xero.models.accounting.CreditNote.StatusEnum.AUTHORISED
-          csharp: CreditNote.xxx
+          csharp: CreditNote.TypeEnum.ACCPAYCREDIT
           object: creditNote
         - reference:
           key: reference
@@ -6425,6 +6467,7 @@ paths:
           keySnake: credit_notes
           java: CreditNotes
           python: credit_note
+          csharp: CreditNote
           object: creditNote
       parameters:
         - required: true
@@ -6861,7 +6904,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.now()"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           node: "'2020-12-10'"
           php: "new DateTime('2020-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -6885,6 +6928,7 @@ paths:
           key: amount
           keyPascal: Amount
           default: 1.0
+          is_money: true
           object: allocation
         - date:
           is_variable: true
@@ -6912,6 +6956,7 @@ paths:
           key: allocations
           keyPascal: Allocations
           java: Allocations
+          csharp: Allocation
           object: allocation
       parameters:
         - required: true
@@ -7035,6 +7080,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord 
           object: historyRecord 
       parameters:
         - required: true
@@ -7067,6 +7113,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Code=="USD"
+          x-example-csharp: Code==/"USD/"
           x-example-php: Code==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\CurrencyCode::USD . &apos;&quot;
           x-ruby-param: Code==#{XeroRuby::Accounting::CurrencyCode::USD}
           schema:
@@ -7121,7 +7168,7 @@ paths:
           ruby: XeroRuby::Accounting::CurrencyCode::USD
           python: CurrencyCode.USD
           java: com.xero.models.accounting.CurrencyCode.USD
-          csharp: CurrencyCode.xxx
+          csharp: CurrencyCode.USD
           object: currency
         - description:
           is_last: true
@@ -7163,6 +7210,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="ACTIVE"
+          x-example-csharp: Status==/"ACTIVE/"
           x-example-java: Status==&quot;&apos; + Employee.StatusEnum.ACTIVE + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Employee::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Employee::ACTIVE}
@@ -7260,6 +7308,7 @@ paths:
           key: employees
           keyPascal: Employees
           java: Employees
+          csharp: Employee
           object: employee
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -7347,6 +7396,7 @@ paths:
           key: employees
           keyPascal: Employees
           java: Employees
+          csharp: Employee
           object: employee
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -7457,6 +7507,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="SUBMITTED"
+          x-example-csharp: Status==/"SUBMITTED/"
           x-example-java: Status==&quot;&apos; + ExpenseClaim.StatusEnum.SUBMITTED + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\ExpenseClaim::STATUS_SUBMITTED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::ExpenseClaim::SUBMITTED}
@@ -7522,7 +7573,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.now()"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           node: "'2020-12-10'"
           php: "new DateTime('2020-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -7583,7 +7634,7 @@ paths:
           ruby: XeroRuby::Accounting::ExpenseClaim::SUBMITTED
           python_string: SUBMITTED
           java: com.xero.models.accounting.ExpenseClaim.StatusEnum.SUBMITTED
-          csharp: ExpenseClaim.xxx
+          csharp: ExpenseClaim.StatusEnum.SUBMITTED
           object: expenseClaim
         - set_user:
           is_variable: true
@@ -7612,6 +7663,7 @@ paths:
           keySnake: expense_claims
           java: ExpenseClaims
           python: expense_claim
+          csharp: ExpenseClaim
           object: expenseClaim
       requestBody:
         required: true
@@ -7835,7 +7887,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.now()"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           node: "'2020-12-10'"
           php: "new DateTime('2020-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -7896,7 +7948,7 @@ paths:
           ruby: XeroRuby::Accounting::ExpenseClaim::SUBMITTED
           python_string: SUBMITTED
           java: com.xero.models.accounting.ExpenseClaim.StatusEnum.SUBMITTED
-          csharp: ExpenseClaim.xxx
+          csharp: ExpenseClaim.StatusEnum.SUBMITTED
           object: expenseClaim
         - set_user:
           is_variable: true
@@ -7925,6 +7977,7 @@ paths:
           keySnake: expense_claims
           java: ExpenseClaims
           python: expense_claim
+          csharp: ExpenseClaim
           object: expenseClaim
       parameters:
         - required: true
@@ -8094,6 +8147,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -8127,6 +8181,7 @@ paths:
           example: Status=="DRAFT"
           x-example-java: Status==&quot;&apos; + Invoice.StatusEnum.DRAFT + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Invoice::STATUS_DRAFT . &apos;&quot;
+          x-example-csharp: Status==\"DRAFT\"
           x-ruby-param: Status==#{XeroRuby::Accounting::Invoice::DRAFT}
           schema:
             type: string
@@ -8144,6 +8199,7 @@ paths:
           example: '&quot;00000000-0000-0000-0000-000000000000&quot;'
           x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-0000-000000000000"))
           x-example-php: '&quot;00000000-0000-0000-0000-000000000000&quot;'
+          x-example-csharp: new List&lt;Guid&gt;{Guid.Parse("00000000-0000-0000-0000-000000000000")};
           schema:
             type: array
             items:
@@ -8157,6 +8213,7 @@ paths:
           example: '&quot;INV-001&quot;, &quot;INV-002&quot;'
           x-example-java: Arrays.asList("INV-001","INV-002")
           x-example-php: '&quot;INV-001&quot;, &quot;INV-002&quot;'
+          x-example-csharp: new List&lt;string&gt;{&quotINV-001&quot,&quotINV-002&quot};
           schema:
             type: array
             items:
@@ -8169,6 +8226,7 @@ paths:
           example: '&quot;00000000-0000-0000-0000-000000000000&quot;'
           x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-0000-000000000000"))
           x-example-php: '&quot;00000000-0000-0000-0000-000000000000&quot;'
+          x-example-csharp: new List&lt;Guid&gt;{Guid.Parse(&quot00000000-0000-0000-0000-000000000000&quot)};
           schema:
             type: array
             items:
@@ -8181,6 +8239,7 @@ paths:
           example: '&quot;DRAFT&quot;, &quot;SUBMITTED&quot;'
           x-example-java: Arrays.asList("DRAFT","SUBMITTED")
           x-example-php: '&quot;DRAFT&quot;, &quot;SUBMITTED&quot;'
+          x-example-csharp: new List&lt;string&gt;{&quotDRAFT&quot,&quotSUBMITTED&quot};
           schema:
             type: array
             items:
@@ -8364,7 +8423,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          csharp: "new DateTime('XXXX')"
+          csharp: "new DateTime(2020, 10, 10)"
           php: "new DateTime('2020-10-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-10-10T00:00:00Z')"
@@ -8374,9 +8433,10 @@ paths:
           keyPascal: Date
           keySnake: due_date_value
           java_datatype: LocalDate
+          csharp_datatype: DateTime
           default: "LocalDate.of(2020, Month.OCTOBER, 28)"
           java: "LocalDate.of(2020, Month.OCTOBER, 28)"
-          csharp: "new DateTime('XXXX')"
+          csharp: "new DateTime(2020, 10, 10)"
           php: "new DateTime('2020-10-28')"
           node: "'2020-10-28'"
           python: "dateutil.parser.parse('2020-10-28T00:00:00Z')"
@@ -8440,6 +8500,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -8447,6 +8508,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           key: accountCode
@@ -8488,7 +8550,7 @@ paths:
           ruby: XeroRuby::Accounting::Invoice::ACCREC
           python_string: ACCREC
           java: com.xero.models.accounting.Invoice.TypeEnum.ACCREC
-          csharp: Invoice.xxx
+          csharp: Invoice.TypeEnum.ACCREC
           object: invoice
         - set_contact:
           is_variable: true
@@ -8539,7 +8601,7 @@ paths:
           ruby: XeroRuby::Accounting::Invoice::DRAFT
           python_string: DRAFT 
           java: com.xero.models.accounting.Invoice.StatusEnum.DRAFT
-          csharp: Invoice.xxx
+          csharp: Invoice.StatusEnum.DRAFT
           object: invoice
         - invoices:
           is_object: true
@@ -8551,6 +8613,7 @@ paths:
           key: invoices
           keyPascal: Invoices
           java: Invoices
+          csharp: Invoice
           object: invoice
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -8738,7 +8801,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          csharp: "new DateTime('XXXX')"
+          csharp: "new DateTime(2020, 10, 10)"
           php: "new DateTime('2020-10-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-10-10T00:00:00Z')"
@@ -8750,7 +8813,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 28)"
           java: "LocalDate.of(2020, Month.OCTOBER, 28)"
-          csharp: "new DateTime('XXXX')"
+          csharp: "new DateTime(2020, 10, 10)"
           php: "new DateTime('2020-10-28')"
           node: "'2020-10-28'"
           python: "dateutil.parser.parse('2020-10-28T00:00:00Z')"
@@ -8781,6 +8844,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -8788,6 +8852,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -8823,7 +8888,7 @@ paths:
           ruby: XeroRuby::Accounting::Invoice::ACCREC
           python_string: ACCREC
           java: com.xero.models.accounting.Invoice.TypeEnum.ACCREC
-          csharp: Invoice.xxx
+          csharp: Invoice.TypeEnum.ACCREC
           object: invoice
         - set_contact:
           is_variable: true
@@ -8874,7 +8939,7 @@ paths:
           ruby: XeroRuby::Accounting::Invoice::DRAFT
           python_string: DRAFT 
           java: com.xero.models.accounting.Invoice.StatusEnum.DRAFT
-          csharp: Invoice.xxx
+          csharp: Invoice.StatusEnum.DRAFT
           object: invoice
         - invoices:
           is_object: true
@@ -8886,6 +8951,7 @@ paths:
           key: invoices
           keyPascal: Invoices
           java: Invoices
+          csharp: Invoice
           object: invoice
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -9263,6 +9329,7 @@ paths:
           key: invoices
           keyPascal: Invoices
           java: Invoices
+          csharp: Invoice
           object: invoice
       parameters:
         - required: true
@@ -9801,6 +9868,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -9935,6 +10003,7 @@ paths:
           key: cOGSAccountCode
           keyPascal: CoGSAccountCode
           keySnake: cogs_account_code
+          keyCsharp: COGSAccountCode
           default: 500
           object: purchaseDetails
         - item:
@@ -9982,6 +10051,7 @@ paths:
           key: items
           keyPascal: Items
           java: Items
+          csharp: Item
           object: item
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -10081,6 +10151,7 @@ paths:
           key: items
           keyPascal: Items
           java: Items
+          csharp: Item
           object: item
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -10230,6 +10301,7 @@ paths:
           key: items
           keyPascal: Items
           java: Items
+          csharp: Item
           object: item
       parameters:
         - required: true
@@ -10362,6 +10434,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -10886,6 +10959,7 @@ paths:
           keySnake: linked_transactions
           java: LinkedTransactions
           python: linked_transaction
+          csharp: LinkedTransaction
           object: linkedTransaction
       parameters:
         - required: true
@@ -11003,6 +11077,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="DRAFT"
+          x-example-csharp: Status==/"DRAFT/"
           x-example-java: Status==&quot;&apos; + ManualJournal.StatusEnum.DRAFT + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\ManualJournal::STATUS_DRAFT . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::ManualJournal::DRAFT}
@@ -11087,7 +11162,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          csharp: "new DateTime('XXXX')"
+          csharp: "new DateTime(2020, 10, 10)"
           php: "new DateTime('2019-10-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -11106,6 +11181,7 @@ paths:
           keyPascal: LineAmount
           keySnake: line_amount
           default: 100.0
+          is_money: true
           object: credit
         - accountCode:
           key: accountCode
@@ -11136,6 +11212,7 @@ paths:
           keyPascal: LineAmount
           keySnake: line_amount
           default: -100.0
+          is_money: true
           object: debit
         - accountCode:
           key: accountCode
@@ -11197,6 +11274,7 @@ paths:
           java: ManualJournals
           php: manualJournals
           python: manual_journal
+          csharp: ManualJournal
           object: manualJournal
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -11315,7 +11393,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          csharp: "new DateTime('XXXX')"
+          csharp: "new DateTime(2020, 10, 10)"
           php: "new DateTime('2020-10-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -11334,6 +11412,7 @@ paths:
           keyPascal: LineAmount
           keySnake: line_amount
           default: 100.0
+          is_money: true
           object: credit
         - accountCode:
           key: accountCode
@@ -11364,6 +11443,7 @@ paths:
           keyPascal: LineAmount
           keySnake: line_amount
           default: -100.0
+          is_money: true
           object: debit
         - accountCode:
           key: accountCode
@@ -11425,6 +11505,7 @@ paths:
           java: ManualJournals
           php: manualJournals
           python: manual_journal
+          csharp: ManualJournal
           object: manualJournal
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -11625,7 +11706,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.of(2020, Month.OCTOBER, 10)"
-          csharp: "new DateTime('XXXX')"
+          csharp: "new DateTime(2020, 10, 10)"
           php: "new DateTime('2020-10-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -11644,6 +11725,7 @@ paths:
           keyPascal: LineAmount
           keySnake: line_amount
           default: 100.0
+          is_money: true
           object: credit
         - accountCode:
           key: accountCode
@@ -11674,6 +11756,7 @@ paths:
           keyPascal: LineAmount
           keySnake: line_amount
           default: -100.0
+          is_money: true
           object: debit
         - accountCode:
           key: accountCode
@@ -11735,6 +11818,7 @@ paths:
           java: ManualJournals
           php: manualJournals
           python: manual_journal
+          csharp: ManualJournal
           object: manualJournal
       parameters:
         - required: true
@@ -12111,6 +12195,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -12304,6 +12389,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="AUTHORISED"
+          x-example-csharp: Status==/"AUTHORISED/"
           x-example-java: Status==&quot;&apos; + Overpayment.StatusEnum.AUTHORISED + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Overpayment::STATUS_AUTHORISED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Overpayment::AUTHORISED}
@@ -12648,7 +12734,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.now()"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           node: "'2020-12-10'"
           php: "new DateTime('2020-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -12673,6 +12759,7 @@ paths:
           key: amount
           keyPascal: Amount
           default: 1.0
+          is_money: true
           object: allocation
         - date:
           is_variable: true
@@ -12700,6 +12787,7 @@ paths:
           key: allocations
           keyPascal: Allocations
           java: Allocations
+          csharp: Allocation
           object: allocation
       parameters:
         - required: true
@@ -12825,6 +12913,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -12879,6 +12968,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="AUTHORISED"
+          x-example-csharp: Status==/"AUTHORISED/"
           x-example-java: Status==&quot;&apos; + Payment.StatusEnum.AUTHORISED + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Payment::STATUS_AUTHORISED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Payment::AUTHORISED}
@@ -13025,7 +13115,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           php: "new DateTime('2020-10-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-10-10T00:00:00Z')"
@@ -13047,6 +13137,7 @@ paths:
           keyPascal: Account
         - accountID:
           is_last: true
+          is_uuid: true
           key: accountID
           keyPascal: AccountID
           keySnake: account_id
@@ -13075,6 +13166,7 @@ paths:
           key: amount
           keyPascal: Amount
           default: 1.0
+          is_money: true
           object: payment
         - date:
           is_last: true
@@ -13095,6 +13187,7 @@ paths:
           key: payments
           keyPascal: Payments
           java: Payments
+          csharp: Payment
           object: payment
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -13224,7 +13317,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           php: "new DateTime('2020-10-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-10-10T00:00:00Z')"
@@ -13246,6 +13339,7 @@ paths:
           keyPascal: Account
         - accountID:
           is_last: true
+          is_uuid: true
           key: accountID
           keyPascal: AccountID
           keySnake: account_id
@@ -13274,6 +13368,7 @@ paths:
           key: amount
           keyPascal: Amount
           default: 1.0
+          is_money: true
           object: payment
         - date:
           is_last: true
@@ -13294,6 +13389,7 @@ paths:
           key: payments
           keyPascal: Payments
           java: Payments
+          csharp: Payment
           object: payment
       responses:
         '200':
@@ -13699,6 +13795,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -13814,6 +13911,7 @@ paths:
           key: paymentServices
           keyPascal: PaymentServices
           java: PaymentServices
+          csharp: PaymentService
           object: paymentService
       responses:
         '200':
@@ -13876,6 +13974,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="AUTHORISED"
+          x-example-csharp: Status==/"AUTHORISED/"
           x-example-java: Status==&quot;&apos; + Prepayment.StatusEnum.AUTHORISED + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Prepayment::STATUS_AUTHORISED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Prepayment::AUTHORISED}
@@ -14107,7 +14206,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.now()"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           node: "'2020-12-10'"
           php: "new DateTime('2020-12-10')"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -14139,6 +14238,7 @@ paths:
           key: amount
           keyPascal: Amount
           default: 1.0
+          is_money: true
           object: allocation
         - date:
           is_last: true
@@ -14159,6 +14259,7 @@ paths:
           key: allocations
           keyPascal: Allocations
           java: Allocations
+          csharp: Allocation
           object: allocation
       parameters:
         - required: true
@@ -14282,6 +14383,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -14544,7 +14646,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           php: "new DateTime('2020-12-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -14575,6 +14677,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -14582,6 +14685,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -14645,6 +14749,7 @@ paths:
           keySnake: purchase_orders
           java: PurchaseOrders
           python: purchase_order
+          csharp: PurchaseOrder
           object: purchaseOrder
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -14809,7 +14914,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           php: "new DateTime('2020-12-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -14840,6 +14945,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -14847,6 +14953,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -14910,6 +15017,7 @@ paths:
           keySnake: purchase_orders
           java: PurchaseOrders
           python: purchase_order
+          csharp: PurchaseOrder
           object: purchaseOrder
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -15267,6 +15375,7 @@ paths:
           keySnake: purchase_orders
           java: PurchaseOrders
           python: purchase_order
+          csharp: PurchaseOrder
           object: purchaseOrder
       parameters:
         - required: true
@@ -15604,6 +15713,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -16027,7 +16137,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           php: "new DateTime('2020-12-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -16058,6 +16168,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -16065,6 +16176,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -16125,6 +16237,7 @@ paths:
           key: quotes
           keyPascal: Quotes
           java: Quotes
+          csharp: Quote
           object: quote
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -16226,7 +16339,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           php: "new DateTime('2020-12-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -16257,6 +16370,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -16264,6 +16378,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -16324,6 +16439,7 @@ paths:
           key: quotes
           keyPascal: Quotes
           java: Quotes
+          csharp: Quote
           object: quote
       parameters:
         - $ref: '#/components/parameters/summarizeErrors'
@@ -16509,7 +16625,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           php: "new DateTime('2020-12-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-12-03T00:00:00Z')"
@@ -16560,6 +16676,7 @@ paths:
           key: quotes
           keyPascal: Quotes
           java: Quotes
+          csharp: Quote
           object: quote
       parameters:
         - required: true
@@ -16694,6 +16811,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -16998,6 +17116,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="DRAFT"
+          x-example-csharp: Status==/"DRAFT/"
           x-example-java: Status==&quot;&apos; + Receipt.StatusEnum.DRAFT + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Receipt::STATUS_DRAFT . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Receipt::DRAFT}
@@ -17114,6 +17233,7 @@ paths:
           key: quantity
           keyPascal: Quantity
           default: 1.0
+          is_money: true
           object: lineItem
         - unitAmount:
           nonString: true
@@ -17121,6 +17241,7 @@ paths:
           keyPascal: UnitAmount
           keySnake: unit_amount
           default: 20.0
+          is_money: true
           object: lineItem
         - accountCode:
           is_last: true
@@ -17180,7 +17301,7 @@ paths:
           ruby: XeroRuby::Accounting::INCLUSIVE
           python: LineAmountTypes.INCLUSIVE
           java: com.xero.models.accounting.LineAmountTypes.INCLUSIVE
-          csharp: LineAmountTypes.xxx
+          csharp: LineAmountTypes.Exclusive
           object: receipt
         - status:
           is_last: true
@@ -17193,7 +17314,7 @@ paths:
           ruby: XeroRuby::Accounting::Receipt::DRAFT
           python_string: DRAFT
           java: com.xero.models.accounting.Receipt.StatusEnum.DRAFT
-          csharp: Receipt.xxx
+          csharp: Receipt.StatusEnum.DRAFT
           object: receipt
         - receipts:
           is_object: true
@@ -17205,6 +17326,7 @@ paths:
           key: receipts
           keyPascal: Receipts
           java: Receipts
+          csharp: Receipt
           object: receipt
       parameters:
         - $ref: '#/components/parameters/unitdp'
@@ -17516,7 +17638,7 @@ paths:
           java_datatype: LocalDate
           default: "LocalDate.of(2020, Month.OCTOBER, 10)"
           java: "LocalDate.now()"
-          csharp: "new DateTime('XXXX')"
+          csharp: "DateTime.Now"
           php: "new DateTime('2020-12-10')"
           node: "'2020-10-10'"
           python: "dateutil.parser.parse('2020-10-10T00:00:00Z')"
@@ -17566,6 +17688,7 @@ paths:
           key: receipts
           keyPascal: Receipts
           java: Receipts
+          csharp: Receipt
           object: receipt
       parameters:
         - required: true
@@ -17998,6 +18121,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -18051,6 +18175,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="DRAFT"
+          x-example-csharp: Status==/"DRAFT/"
           x-example-java: Status==&quot;&apos; + RepeatingInvoice.StatusEnum.DRAFT + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\RepeatingInvoice::STATUS_DRAFT . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::RepeatingInvoice::DRAFT}
@@ -18532,6 +18657,7 @@ paths:
           keySnake: history_records
           java: HistoryRecords
           python: history_record
+          csharp: HistoryRecord
           object: historyRecord 
       parameters:
         - required: true
@@ -22253,7 +22379,7 @@ paths:
           ruby: XeroRuby::Accounting::AccountType::EXPENSE
           python: AccountType.EXPENSE
           java: com.xero.models.accounting.AccountType.EXPENSE
-          csharp: Account.ClassEnum.EXPENSE
+          csharp: AccountType.EXPENSE
           object: account
         - accounts:
           is_list: true
@@ -22401,6 +22527,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="ACTIVE"
+          x-example-csharp: Status==/"ACTIVE/"
           x-example-java: Status==&quot;&apos; + TaxRate.StatusEnum.ACTIVE + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\TaxRate::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::TaxRate::ACTIVE}
@@ -22565,6 +22692,7 @@ paths:
           key: rate
           keyPascal: Rate
           default: 2.25
+          is_money: true
           object: taxComponent
         - taxRate:
           is_object: true
@@ -22584,6 +22712,7 @@ paths:
           keySnake: tax_components
           java: TaxComponents
           python: tax_component
+          csharp: TaxComponent
           object: taxComponent
         - taxRates:
           is_object: true
@@ -22597,6 +22726,7 @@ paths:
           keySnake: tax_rates
           java: TaxRates
           python: tax_rate
+          csharp: TaxRate
           object: taxRate
       responses:
         '200':
@@ -22683,6 +22813,7 @@ paths:
           key: rate
           keyPascal: Rate
           default: 2.25
+          is_money: true
           object: taxComponent
         - taxRate:
           is_object: true
@@ -22702,6 +22833,7 @@ paths:
           keySnake: tax_components
           java: TaxComponents
           python: tax_component
+          csharp: TaxComponent
           object: taxComponent
         - taxRates:
           is_object: true
@@ -22715,6 +22847,7 @@ paths:
           keySnake: tax_rates
           java: TaxRates
           python: tax_rate
+          csharp: TaxRate
           object: taxRate
       responses:
         '200':
@@ -22790,6 +22923,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="ACTIVE"
+          x-example-csharp: Status==/"ACTIVE/"
           x-example-java: Status==&quot;&apos; + TrackingCategory.StatusEnum.ACTIVE + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\TrackingCategory::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::TrackingCategory::ACTIVE}

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1444,8 +1444,13 @@ paths:
           keyPascal: Contact
           default: contact
           object: bankTransaction
+        - line_items:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItems
+          csharp: LineItem
         - add_lineitems:
-          is_array_add: true
+          is_list_add: true
           key: lineItems
           keyPascal: LineItems
           keySnake: line_items
@@ -1463,6 +1468,13 @@ paths:
           python: bank_account
           default: bankAccount
           object: bankTransaction
+        - set_lineitems:
+          is_variable: true
+          nonString: true
+          key: lineItems
+          keyPascal: LineItems
+          object: bankTransaction
+          default: lineItems
         - bankTransactions:
           is_object: true
           key: bankTransactions
@@ -1699,7 +1711,7 @@ paths:
           object: bankTransaction
         - add_lineitems:
           is_array_add: true
-          key: bankTransaction
+          key: lineItems
           keyPascal: LineItems
           keySnake: line_items
           java: LineItems
@@ -6929,6 +6941,7 @@ paths:
           keyPascal: Amount
           default: 1.0
           is_money: true
+          csharp: new decimal(1.0)
           object: allocation
         - date:
           is_variable: true
@@ -11486,7 +11499,7 @@ paths:
           is_last: true
           is_variable: true
           nonString: true
-          key: journalLines
+          key: manualJournalLines
           keyPascal: JournalLines
           keySnake: journal_lines
           default: manualJournalLines
@@ -11799,7 +11812,7 @@ paths:
           is_last: true
           is_variable: true
           nonString: true
-          key: journalLines
+          key: manualJournalLines
           keyPascal: JournalLines
           keySnake: journal_lines
           default: manualJournalLines
@@ -22693,6 +22706,21 @@ paths:
           keyPascal: Rate
           default: 2.25
           is_money: true
+          object: taxComponent      
+        - taxComponents:
+          is_list: true
+          key: taxComponents
+          keyPascal: TaxComponents
+          csharp: TaxComponent
+        - add_taxComponent:
+          is_last: true
+          is_list_add: true
+          key: taxComponents
+          keyPascal: TaxComponents
+          keySnake: tax_components
+          java: TaxComponents
+          python: tax_component
+          csharp: TaxComponent
           object: taxComponent
         - taxRate:
           is_object: true
@@ -22704,16 +22732,13 @@ paths:
           keyPascal: Name
           default: CA State Tax
           object: taxRate
-        - add_taxComponent:
-          is_last: true
-          is_array_add: true
-          key: taxRate
+        - addTaxComponents:
+          is_variable: true
+          nonString: true
+          key: taxComponents
           keyPascal: TaxComponents
-          keySnake: tax_components
-          java: TaxComponents
-          python: tax_component
-          csharp: TaxComponent
-          object: taxComponent
+          object: taxRate
+          default: taxComponents
         - taxRates:
           is_object: true
           key: taxRates

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22733,7 +22733,7 @@ paths:
           keyPascal: Name
           default: CA State Tax
           object: taxRate
-        - addTaxComponents:
+        - set_taxComponents:
           is_variable: true
           nonString: true
           key: taxComponents

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -710,7 +710,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="AUTHORISED"
-          x-example-csharp: Status==/&quot;AUTHORISED/&quot;
+          x-example-csharp: Status==\&quot;AUTHORISED\&quot;
           x-example-java: Status==&quot;&apos; + BatchPayment.StatusEnum.AUTHORISED + &apos;&quot;
           x-example-php: Status==&quot;&apos; . XeroAPI\XeroPHP\Models\Accounting\BatchPayment::STATUS_AUTHORISED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::BatchPayment::AUTHORISED}
@@ -3527,7 +3527,7 @@ paths:
           name: where
           description: Filter by an any element
           example: ContactStatus==&quot;ACTIVE&quot;
-          x-example-csharp: ContactStatus==/&quot;ACTIVE/&quot;
+          x-example-csharp: ContactStatus==\&quot;ACTIVE\&quot;
           x-example-java: ContactStatus==&quot;&apos; + Contact.ContactStatusEnum.ACTIVE + &apos;&quot;
           x-example-php: ContactStatus==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Contact::CONTACT_STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: ContactStatus==#{XeroRuby::Accounting::Contact::ACTIVE}
@@ -3547,6 +3547,7 @@ paths:
           example: '&quot;00000000-0000-0000-0000-000000000000&quot;'
           x-example-java: Arrays.asList(UUID.fromString("00000000-0000-0000-0000-000000000000"))
           x-example-php: '&quot;00000000-0000-0000-0000-000000000000&quot;'
+          x-example-csharp: new List&lt;Guid&gt;{Guid.Parse("00000000-0000-0000-0000-000000000000")};
           schema:
             type: array
             items:
@@ -7126,7 +7127,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Code=="USD"
-          x-example-csharp: Code==/"USD/"
+          x-example-csharp: Code==\"USD\"
           x-example-php: Code==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\CurrencyCode::USD . &apos;&quot;
           x-ruby-param: Code==#{XeroRuby::Accounting::CurrencyCode::USD}
           schema:

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1709,8 +1709,13 @@ paths:
           keyPascal: Contact
           default: contact
           object: bankTransaction
-        - add_lineitems:
-          is_array_add: true
+        - lineItems:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItems
+          csharp: LineItem
+        - add_lineitem:
+          is_list_add: true
           key: lineItems
           keyPascal: LineItems
           keySnake: line_items
@@ -1718,6 +1723,13 @@ paths:
           python: line_item
           csharp: LineItem
           object: lineItem
+        - set_lineitems:
+          is_variable: true
+          nonString: true
+          key: lineItems
+          keyPascal: LineItems
+          object: bankTransaction
+          default: lineItems
         - set_bankaccount:
           is_last: true
           is_variable: true
@@ -2132,15 +2144,26 @@ paths:
           keyPascal: Contact
           default: contact
           object: bankTransaction
-        - add_lineitems:
-          is_array_add: true
-          key: bankTransaction
+        - lineItems:
+          is_list: true
+          key: lineItems
+          keyPascal: LineItems
+          csharp: LineItem
+        - add_lineitem:
+          is_list_add: true
+          key: lineItems
           keyPascal: LineItems
           keySnake: line_items
           java: LineItems
           python: line_item
-          csharp: LineItem
           object: lineItem
+        - set_lineitems:
+          is_variable: true
+          nonString: true
+          key: lineItems
+          keyPascal: LineItems
+          object: bankTransaction
+          default: lineItems
         - set_bankaccount:
           is_last: true
           is_variable: true
@@ -4054,7 +4077,7 @@ paths:
           ruby: XeroRuby::Accounting::PhoneType::MOBILE
           python_string: MOBILE
           java: com.xero.models.accounting.Phone.PhoneTypeEnum.MOBILE
-          csharp: Phone.TypeEnum.MOBILE
+          csharp: Phone.PhoneTypeEnum.MOBILE
           object: phone
         - phones:
           is_list: true
@@ -5976,6 +5999,7 @@ paths:
           key: lineItems
           keyPascal: LineItems
           keySnake: line_items
+          csharp: LineItem
         - add_lineitems:
           is_last: true
           is_list_add: true
@@ -6401,6 +6425,7 @@ paths:
           key: lineItems
           keyPascal: LineItems
           keySnake: line_items
+          csharp: LineItem
         - add_lineitems:
           is_last: true
           is_list_add: true
@@ -6436,7 +6461,7 @@ paths:
           ruby: XeroRuby::Accounting::CreditNote::AUTHORISED
           python_string: AUTHORISED
           java: com.xero.models.accounting.CreditNote.StatusEnum.AUTHORISED
-          csharp: CreditNote.TypeEnum.ACCPAYCREDIT
+          csharp: CreditNote.StatusEnum.AUTHORISED
           object: creditNote
         - reference:
           key: reference
@@ -22841,6 +22866,21 @@ paths:
           default: 2.25
           is_money: true
           object: taxComponent
+        - taxComponents:
+          is_list: true
+          key: taxComponents
+          keyPascal: TaxComponents
+          csharp: TaxComponent
+        - add_taxComponent:
+          is_last: true
+          is_list_add: true
+          key: taxComponents
+          keyPascal: TaxComponents
+          keySnake: tax_components
+          java: TaxComponents
+          python: tax_component
+          csharp: TaxComponent
+          object: taxComponent
         - taxRate:
           is_object: true
           key: taxRate
@@ -22851,16 +22891,13 @@ paths:
           keyPascal: Name
           default: CA State Tax
           object: taxRate
-        - add_taxComponent:
-          is_last: true
-          is_array_add: true
-          key: taxRate
+        - set_taxComponents:
+          is_variable: true
+          nonString: true
+          key: taxComponents
           keyPascal: TaxComponents
-          keySnake: tax_components
-          java: TaxComponents
-          python: tax_component
-          csharp: TaxComponent
-          object: taxComponent
+          object: taxRate
+          default: taxComponents
         - taxRates:
           is_object: true
           key: taxRates

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -28,7 +28,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status==&quot;ACTIVE&quot; AND Type==&quot;BANK&quot;
-          x-example-csharp: Status==/"ACTIVE/"
+          x-example-csharp: Status==\"ACTIVE\"
           x-example-java: Status==&quot;&apos; + Account.StatusEnum.ACTIVE+ &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Account::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Account::ACTIVE}
@@ -1214,7 +1214,7 @@ paths:
           description: Filter by an any element
           example: Status=="AUTHORISED"
           x-example-java: Status==&quot;&apos; + BankTransaction.StatusEnum.AUTHORISED + &apos;&quot;
-          x-example-csharp: Status==/"AUTHORISED/"
+          x-example-csharp: Status==\"AUTHORISED\"
           x-example-php: Status==&quot;&apos; . XeroAPI\XeroPHP\Models\Accounting\BankTransaction::STATUS_AUTHORISED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::BankTransaction::AUTHORISED}
           schema:
@@ -5076,7 +5076,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="ACTIVE"
-          x-example-csharp: Status==/"ACTIVE/"
+          x-example-csharp: Status==\"ACTIVE\"
           x-example-java: Status==&quot;&apos; + ContactGroup.StatusEnum.ACTIVE + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\ContactGroup::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::ContactGroup::ACTIVE}
@@ -5518,7 +5518,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="DRAFT"
-          x-example-csharp: Status==/"DRAFT/"
+          x-example-csharp: Status==\"DRAFT\"
           x-example-java: Status==&quot;&apos; + CreditNote.StatusEnum.DRAFT + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\CreditNote::STATUS_DRAFT . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::CreditNote::DRAFT}
@@ -7223,7 +7223,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="ACTIVE"
-          x-example-csharp: Status==/"ACTIVE/"
+          x-example-csharp: Status==\"ACTIVE\"
           x-example-java: Status==&quot;&apos; + Employee.StatusEnum.ACTIVE + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Employee::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Employee::ACTIVE}
@@ -7520,7 +7520,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="SUBMITTED"
-          x-example-csharp: Status==/"SUBMITTED/"
+          x-example-csharp: Status==\"SUBMITTED\"
           x-example-java: Status==&quot;&apos; + ExpenseClaim.StatusEnum.SUBMITTED + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\ExpenseClaim::STATUS_SUBMITTED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::ExpenseClaim::SUBMITTED}
@@ -11090,7 +11090,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="DRAFT"
-          x-example-csharp: Status==/"DRAFT/"
+          x-example-csharp: Status==\"DRAFT\"
           x-example-java: Status==&quot;&apos; + ManualJournal.StatusEnum.DRAFT + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\ManualJournal::STATUS_DRAFT . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::ManualJournal::DRAFT}
@@ -12402,7 +12402,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="AUTHORISED"
-          x-example-csharp: Status==/"AUTHORISED/"
+          x-example-csharp: Status==\"AUTHORISED\"
           x-example-java: Status==&quot;&apos; + Overpayment.StatusEnum.AUTHORISED + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Overpayment::STATUS_AUTHORISED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Overpayment::AUTHORISED}
@@ -12981,7 +12981,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="AUTHORISED"
-          x-example-csharp: Status==/"AUTHORISED/"
+          x-example-csharp: Status==\"AUTHORISED\"
           x-example-java: Status==&quot;&apos; + Payment.StatusEnum.AUTHORISED + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Payment::STATUS_AUTHORISED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Payment::AUTHORISED}
@@ -13987,7 +13987,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="AUTHORISED"
-          x-example-csharp: Status==/"AUTHORISED/"
+          x-example-csharp: Status==\"AUTHORISED\"
           x-example-java: Status==&quot;&apos; + Prepayment.StatusEnum.AUTHORISED + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Prepayment::STATUS_AUTHORISED . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Prepayment::AUTHORISED}
@@ -17129,7 +17129,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="DRAFT"
-          x-example-csharp: Status==/"DRAFT/"
+          x-example-csharp: Status==\"DRAFT\"
           x-example-java: Status==&quot;&apos; + Receipt.StatusEnum.DRAFT + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\Receipt::STATUS_DRAFT . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::Receipt::DRAFT}
@@ -18188,7 +18188,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="DRAFT"
-          x-example-csharp: Status==/"DRAFT/"
+          x-example-csharp: Status==\"DRAFT\"
           x-example-java: Status==&quot;&apos; + RepeatingInvoice.StatusEnum.DRAFT + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\RepeatingInvoice::STATUS_DRAFT . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::RepeatingInvoice::DRAFT}
@@ -22540,7 +22540,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="ACTIVE"
-          x-example-csharp: Status==/"ACTIVE/"
+          x-example-csharp: Status==\"ACTIVE\"
           x-example-java: Status==&quot;&apos; + TaxRate.StatusEnum.ACTIVE + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\TaxRate::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::TaxRate::ACTIVE}
@@ -22948,7 +22948,7 @@ paths:
           name: where
           description: Filter by an any element
           example: Status=="ACTIVE"
-          x-example-csharp: Status==/"ACTIVE/"
+          x-example-csharp: Status==\"ACTIVE\"
           x-example-java: Status==&quot;&apos; + TrackingCategory.StatusEnum.ACTIVE + &apos;&quot;
           x-example-php: Status==&quot;&apos; . \XeroAPI\XeroPHP\Models\Accounting\TrackingCategory::STATUS_ACTIVE . &apos;&quot;
           x-ruby-param: Status==#{XeroRuby::Accounting::TrackingCategory::ACTIVE}

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -8610,7 +8610,7 @@ paths:
           is_variable: true
           nonString: true
           key: dueDate
-          keyPascal: Date
+          keyPascal: DueDate
           keySnake: due_date
           default: dueDateValue
           python: due_date_value


### PR DESCRIPTION
## Description
Added properties to support NetStandard documentation and some minor bug fixes with x-examples.

## Release Notes
Added csharp specific properties to enums, date objects, types and variable names to support documentation.
Fixed issues with createTaxRates, createBankTransactions, updateTaxRates, updateBankTransactions examples.
Added is_money attributes to support converting to Decimal in csharp examples.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
