### PR TITLE
Fix UK Payroll GET filters

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -27,17 +27,11 @@ paths:
       summary: Retrieves employees
       parameters:
         - in: query
-          name: firstName
-          description: Filter by first name
+          name: filter
+          description: Filter by first name and/or lastname
           schema:
             type: string
-          example: John
-        - in: query
-          name: lastName
-          description: Filter by last name
-          schema:
-            type: string
-          example: Johnson
+          example: firstName==John,lastName==Smith
         - in: query
           name: page
           description: Page number which specifies the set of records to retrieve. By default the number of the records per set is 100.
@@ -2775,17 +2769,11 @@ paths:
           schema:
             type: integer
         - in: query
-          name: employeeId
-          description: By default get Timesheets will return the timesheets for all employees in an organization. You can add GET https://…/timesheets?filter=employeeId=={EmployeeID} to get only the timesheets of a particular employee.
+          name: filter
+          description: Filter by first name and/or lastname
           schema:
             type: string
-            format: uuid
-        - in: query
-          name: payrollCalendarId
-          description: By default get Timesheets will return all the timesheets for an organization. You can add GET https://…/timesheets?filter=payrollCalendarId=={PayrollCalendarID} to filter the timesheets by payroll calendar id
-          schema:
-            type: string
-            format: uuid
+          example: employeeId==00000000-0000-0000-0000-000000000000,payrollCalendarId==00000000-0000-0000-0000-000000000000
       responses:
         '200':
           description: search results matching criteria


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Get methods for Employees and Timesheets incorrectly defined params to be passed by name for querying the API.  Instead it needs to be a single param called "filter" that has named params and values passed together.

## Description
<!--- Describe your changes in detail -->

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
