### PR TITLE
Update Bankfeeds spec to resolve issue 380

### DIFF
--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -127,13 +127,26 @@ paths:
                   ]
                 }
         '400':
-          description: 'invalid input, object invalid'
-        '409':
           description: failed to create new feed connection(s)response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/FeedConnections'
+              example:
+                {
+                    "items": [
+                        {
+                            "accountToken": "foobar71760",
+                            "status": "REJECTED",
+                            "error": {
+                                "type": "invalid-request",
+                                "title": "Invalid Request",
+                                "status": 400,
+                                "detail": "For the request field 'AccountNumber' exceeded the maximum length of 40."
+                            }
+                        }
+                    ]
+                }
   /FeedConnections/{id}:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'


### PR DESCRIPTION
Bankfeeds update to fix inaccuracy in error response for posting Feedconnections.

## Description
A development partner pointed out the error response and status code is incorrect for Feedconnections. The API will actually return an overall HTTP 400 but will include a sub-status per connection error in the response body. I removed the 409 from the expected responses, and updated the schema/example for the 400

## Release Notes
https://github.com/XeroAPI/Xero-OpenAPI/issues/380

## Screenshots (if appropriate):
<img width="460" alt="feedConnectionsError" src="https://user-images.githubusercontent.com/80783917/112220450-e3c75900-8beb-11eb-86e7-5d7471b45bef.PNG">

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
