### PR TITLE
Added Hourly option to SalaryAndWage paymentType

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -5759,6 +5759,7 @@ components:
           type: string
           enum:
             - Salary
+            - Hourly
     PayRuns:
       type: object
       properties:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently we are unable to access the salary and wage information on our Xero tenant (UK) as some of our staff are on an Hourly contract instead of a Salary contract. I believe this may be a simple oversight so I have prepared a change that adds the enumeration value.

## Release Notes
Adds the Hourly  Payment Type enum value for the UK Payroll API ensuring that salary and wage data.

## Screenshots (if appropriate):
N/A 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
