### PR TITLE
Remove readonly property from manulajournalline TaxAmount

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -25075,7 +25075,6 @@ components:
             $ref: '#/components/schemas/TrackingCategory'
         TaxAmount:
           description: The calculated tax amount based on the TaxType and LineAmount
-          readOnly: true
           type: number
           format: double
           x-is-money: true


### PR DESCRIPTION
## Description
Field incorrectly set as read-only

## Release Notes
Brings OAuth 2.0 SDK in line with the OA1 behaviour