### PR TITLE
Missing ENUM for Time entry status

### DIFF
--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1531,6 +1531,7 @@ components:
           enum:
             - ACTIVE
             - LOCKED
+            - INVOICED
           description: "Status of the time entry. By default a time entry is created with status of `ACTIVE`. A `LOCKED` state indicates that the time entry is currently changing state (for example being invoiced). Updates are not allowed when in this state. It will have a status of INVOICED once it is invoiced."
     TimeEntryCreateOrUpdate:
       externalDocs:


### PR DESCRIPTION
Causing issues in the SDKs when the status returned isn't expected