### PR TITLE
Add AccountID on Bank transactions line items

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1487,6 +1487,7 @@ paths:
                                   "Tracking": [],
                                   "Quantity": 1.0000,
                                   "LineItemID": "d2a06879-da49-4d6c-83b5-72a93a523ec6",
+                                  "AccountID": "ebd06280-af70-4bed-97c6-7451a454ad85",
                                   "ValidationErrors": []
                                 }
                               ],
@@ -1756,6 +1757,7 @@ paths:
                                   "Tracking": [],
                                   "Quantity": 1.0000,
                                   "LineItemID": "d2a06879-da49-4d6c-83b5-72a93a523ec6",
+                                  "AccountID": "ebd06280-af70-4bed-97c6-7451a454ad85",
                                   "ValidationErrors": []
                                 }
                               ],
@@ -1930,6 +1932,7 @@ paths:
                                   "Tracking": [],
                                   "Quantity": 1.0000,
                                   "LineItemID": "40bec527-a744-4149-96c5-0ab643b51158",
+                                  "AccountID": "ebd06280-af70-4bed-97c6-7451a454ad85",
                                   "ValidationErrors": []
                                 }
                               ],
@@ -2190,6 +2193,7 @@ paths:
                                   "Tracking": [],
                                   "Quantity": 1.0000,
                                   "LineItemID": "d2a06879-da49-4d6c-83b5-72a93a523ec6",
+                                  "AccountID": "ebd06280-af70-4bed-97c6-7451a454ad85",
                                   "ValidationErrors": []
                                 }
                               ],
@@ -23058,6 +23062,11 @@ components:
         AccountCode:
           description: See Accounts
           type: string
+        AccountID:
+          description: The associated account ID related to this line item
+          type: string
+          format: uuid
+          example: "00000000-0000-0000-0000-000000000000"
         TaxType:
           description: The tax type from TaxRates
           type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This change is adding the field AccountID on the line items for GET bank transactions endpoint.
<!--- Describe your changes in detail -->

We are exposing the AccountID for the chart of account associated on the line item. It is not available for GET and not supported for PUT and POST just yet.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
