### PR TITLE
Update xero_accounting.yaml

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -19110,7 +19110,7 @@ paths:
             type: string
             format: date
         - in: query
-          name: period
+          name: periods
           description: The number of periods to compare (integer between 1 and 12)
           example: 2
           schema:


### PR DESCRIPTION
corrected argument on budgetsummary report

## Description
Documentation shows the argument to be named periods (plural) this work in API Previewer correctly.
API Console (based on this OAS doesn't handle the argument, as it is missing the 's')