### PR TITLE
Reports consolidation & Budgets Endpoints

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3317,7 +3317,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Budget'
+                $ref: '#/components/schemas/Budgets'
               example: '{
                           "Id": "04e93d48-e72f-4775-b7dd-15a041fab972",
                           "Status": "OK",

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -19956,6 +19956,23 @@ paths:
                             }
                           ]
                         }'
+  '/Reports':
+    parameters:
+      - $ref: '#/components/parameters/requiredHeader'
+    get:
+      security:
+        - OAuth2: [accounting.reports.read]
+      tags:
+        - Accounting
+      operationId: getReportForGST
+      summary: Retrieves report for GST (only valid for NZ orgs)
+      responses:
+        '200':
+          description: Success - return response of type ReportWithRows
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportWithRows'
   '/Reports/ProfitAndLoss':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3343,6 +3343,19 @@ paths:
                               ]
                             }
                           }'                      
+  '/Budgets/{BudgetID}':
+    parameters:
+      - $ref: '#/components/parameters/requiredHeader'
+    get:
+      security:
+        - OAuth2: [accounting.budgets.read]
+      tags:
+        - Accounting
+      operationId: getBudget
+      summary: Retrieves a specific budgets, which includes budget lines
+      parameters:
+        - $ref: '#/components/parameters/BudgetID'
+      responses:
   '/Contacts':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -22419,6 +22432,16 @@ components:
       schema:
         type: string
         format: uuid
+    BudgetID:
+      required: true
+      in: path
+      name: BudgetID
+      x-snake: budget_id
+      description: Unique identifier for Budgets
+      example: "00000000-0000-0000-0000-000000000000"
+      schema:
+        type: string
+        format: uuid
     ContactID:
       required: true
       in: path
@@ -23663,6 +23686,14 @@ components:
           type: string
       type: object
     Budgets:
+      type: object
+      x-isObjectArray: true
+      properties:
+        Invoices:
+          type: array
+          items:
+            $ref: '#/components/schemas/Budget'
+    Budget:
       type: object
       externalDocs:
         url: 'http://developer.xero.com/documentation/api/budgets/'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3224,8 +3224,8 @@ paths:
               $ref: '#/components/schemas/PaymentService'
             example: '{  
                         "PaymentServiceID": "00000000-0000-0000-0000-000000000000",
-                        "PaymentServiceName": "ACME Payments",
-                        "PaymentServiceUrl": "https://www.payupnow.com/",
+                        "PaymentServiceName": "Payments Service",
+                        "PaymentServiceUrl": "https://www.paymentservice.com/",
                         "PayNowText": "Pay Now"
                       }'
   '/Budgets':
@@ -3274,75 +3274,31 @@ paths:
               schema:
                 $ref: '#/components/schemas/Budgets'
               example: '{
-                            "Id": "04e93d48-e72f-4775-b7dd-15a041fab972",
-                            "Status": "OK",
-                            "ProviderName": "Xero API Partner",
-                            "DateTimeUTC": "\/Date(1551399323399)\/",
-                            "Budgets": {
-                              "BudgetID": "c1d195d4-92aa-4abd-867a-7ac2f9d60500",
+                          "Id": "04e93d48-e72f-4775-b7dd-15a041fab972",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "\/Date(1551399323399)\/",
+                          "Budgets": [
+                            {
+                              "BudgetID": "847da917-9565-466c-a9cd-3ecf7eb9d094",
+                              "Status": "APPROVED",
+                              "Description": "FY2021 budget",
                               "Type": "TRACKING",
-                              "Description": "Daniels Northern Budget",
-                              "UpdatedDateUTC": "2017-08-14T01:18:26.74",
-                              "Tracking": [
-                                {
-                                    "TrackingCategoryID": "e94ba240-3edf-4ef3-8317-10147b968f94",
-                                    "Name": "Region",
-                                    "TrackingOptionID": "e94ba240-3edf-4ef3-8317-10147b968f94",
-                                    "Option": "North"
-                                },
-                                {
-                                    "TrackingCategoryID": "d8580491-4167-4a81-9624-ad3bdd8e46ce",
-                                    "Name": "Salesperson",
-                                    "TrackingOptionID": "9c24de87-a2b7-439d-a216-35d1af7bdec3",
-                                    "Option": "Daniel"
-                                }
-                              ],
-                              "BudgetLines": [
-                                {
-                                    "AccountID": "9c24de87-a2b7-439d-a216-35d1af7bdec3",
-                                    "AccountCode": "200",
-                                    "BudgetBalances": [
-                                      {
-                                          "Period": "2019-08",
-                                          "Amount": "1000",
-                                          "Notes": "Sample note"
-                                      },
-                                      {
-                                          "Period": "2019-09",
-                                          "Amount": "1050",
-                                          "Notes": ""
-                                      },
-                                      {
-                                          "Period": "2019-10",
-                                          "Amount": "1102",
-                                          "Notes": ""
-                                      }
-                                    ]
-                                },
-                                {
-                                    "AccountID": "385f90ae-e798-4990-9b1c-db8eb8b735c2",
-                                    "AccountCode": "420",
-                                    "BudgetBalances": [
-                                      {
-                                          "Period": "2019-08",
-                                          "Amount": "500",
-                                          "Notes": ""
-                                      },
-                                      {
-                                          "Period": "2019-09",
-                                          "Amount": "505",
-                                          "Notes": "Special Month"
-                                      },
-                                      {
-                                          "Period": "2019-10",
-                                          "Amount": "510",
-                                          "Notes": ""
-                                      }
-                                    ]
-                                }
-                              ]
+                              "UpdatedDateUTC": "\/Date(1622138002077+0000)\/",
+                              "BudgetLines": [],
+                              "Tracking": []
+                            },
+                            {
+                              "BudgetID": "93a4bab1-0021-4320-a2ec-c250528b4bc5",
+                              "Status": "APPROVED",
+                              "Description": "Overall Budget",
+                              "Type": "OVERALL",
+                              "UpdatedDateUTC": "\/Date(1622137786913+0000)\/",
+                              "BudgetLines": [],
+                              "Tracking": []
                             }
-                          }'                      
+                          ]
+                        }'                      
   '/Budgets/{BudgetID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -3356,6 +3312,83 @@ paths:
       parameters:
         - $ref: '#/components/parameters/BudgetID'
       responses:
+        '200':
+          description: Success - return response of type Invoices array with specified Invoices
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Budget'
+              example: '{
+                          "Id": "04e93d48-e72f-4775-b7dd-15a041fab972",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "\/Date(1551399323399)\/",
+                          "Budgets": {
+                            "BudgetID": "c1d195d4-92aa-4abd-867a-7ac2f9d60500",
+                            "Type": "TRACKING",
+                            "Description": "Daniels Northern Budget",
+                            "UpdatedDateUTC": "2017-08-14T01:18:26.74",
+                            "Tracking": [
+                              {
+                                "TrackingCategoryID": "e94ba240-3edf-4ef3-8317-10147b968f94",
+                                "Name": "Region",
+                                "TrackingOptionID": "e94ba240-3edf-4ef3-8317-10147b968f94",
+                                "Option": "North"
+                              },
+                              {
+                                "TrackingCategoryID": "d8580491-4167-4a81-9624-ad3bdd8e46ce",
+                                "Name": "Salesperson",
+                                "TrackingOptionID": "9c24de87-a2b7-439d-a216-35d1af7bdec3",
+                                "Option": "Daniel"
+                              }
+                            ],
+                            "BudgetLines": [
+                              {
+                                "AccountID": "9c24de87-a2b7-439d-a216-35d1af7bdec3",
+                                "AccountCode": "200",
+                                "BudgetBalances": [
+                                  {
+                                    "Period": "2019-08",
+                                    "Amount": "1000",
+                                    "Notes": "Sample note"
+                                  },
+                                  {
+                                    "Period": "2019-09",
+                                    "Amount": "1050",
+                                    "Notes": ""
+                                  },
+                                  {
+                                    "Period": "2019-10",
+                                    "Amount": "1102",
+                                    "Notes": ""
+                                  }
+                                ]
+                              },
+                              {
+                                "AccountID": "385f90ae-e798-4990-9b1c-db8eb8b735c2",
+                                "AccountCode": "420",
+                                "BudgetBalances": [
+                                  {
+                                    "Period": "2019-08",
+                                    "Amount": "500",
+                                    "Notes": ""
+                                  },
+                                  {
+                                    "Period": "2019-09",
+                                    "Amount": "505",
+                                    "Notes": "Special Month"
+                                  },
+                                  {
+                                    "Period": "2019-10",
+                                    "Amount": "510",
+                                    "Notes": ""
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        }'
+
   '/Contacts':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23722,7 +23722,7 @@ components:
       type: object
       x-isObjectArray: true
       properties:
-        Invoices:
+        Budgets:
           type: array
           items:
             $ref: '#/components/schemas/Budget'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -19215,8 +19215,8 @@ paths:
         - OAuth2: [accounting.reports.read]
       tags:
         - Accounting
-      operationId: getReportBASorGST
-      summary: Retrieves a specific report for BAS using a unique report Id (only valid for AU orgs)
+      operationId: getReportFromId
+      summary: Retrieves a specific report using a unique ReportID
       parameters:
         - in: path
           required: true
@@ -19987,8 +19987,8 @@ paths:
         - OAuth2: [accounting.reports.read]
       tags:
         - Accounting
-      operationId: getOtherReportsList
-      summary: Retrieves a list of org dynamic reports that require `/Reports/{uuid}`
+      operationId: getReportsList
+      summary: Retrieves a list of the organistaions unique reports that require a uuid to fetch
       responses:
         '200':
           description: Success - return response of type ReportWithRows

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Xero Accounting API
-  version: "2.12.0"
+  version: "2.13.0"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:
     name: "Xero Platform Team"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -19941,7 +19941,7 @@ paths:
         - OAuth2: [accounting.reports.read]
       tags:
         - Accounting
-      operationId: getReportForGST
+      operationId: getOtherReportsList
       summary: Retrieves report for GST (only valid for NZ orgs)
       responses:
         '200':

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -19942,7 +19942,7 @@ paths:
       tags:
         - Accounting
       operationId: getOtherReportsList
-      summary: Retrieves report for GST (only valid for NZ orgs)
+      summary: Retrieves a list of org dynamic reports that require `/Reports/{uuid}`
       responses:
         '200':
           description: Success - return response of type ReportWithRows

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -24796,8 +24796,7 @@ components:
           format: double
           x-is-money: true
         FullyPaidOnDate:
-          description: The date the invoice was fully paid. Only returned on fully paid
-            invoices
+          description: The date the invoice was fully paid. Only returned on fully paid invoices
           readOnly: true
           type: string
           x-is-msdate: true
@@ -26097,8 +26096,7 @@ components:
           type: string
           x-is-msdate: true
         CurrencyRate:
-          description: Exchange rate when payment is received. Only used for non base
-            currency invoices and credit notes e.g. 0.7500
+          description: Exchange rate when payment is received. Only used for non base currency invoices and credit notes e.g. 0.7500
           type: number
           format: double
           x-is-money: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3228,7 +3228,122 @@ paths:
                         "PaymentServiceUrl": "https://www.payupnow.com/",
                         "PayNowText": "Pay Now"
                       }'
-  /Contacts:
+  '/Budgets':
+    parameters:
+      - $ref: '#/components/parameters/requiredHeader'
+    get:
+      security:
+        - OAuth2: [accounting.budgets.read]
+      tags:
+        - Accounting
+      operationId: getBudgets
+      summary: 'Retrieve a list of budgets'
+      parameters:
+        - in: query
+          name: IDs
+          x-snake: ids
+          description: Filter by BudgetID. Allows you to retrieve a specific individual budget.
+          style: form
+          explode: false
+          example: '&quot;00000000-0000-0000-0000-000000000000&quot;'
+          x-example-java: UUID.fromString("00000000-0000-0000-0000-000000000000")
+          x-example-php: '&quot;00000000-0000-0000-0000-000000000000&quot;'
+          x-example-csharp: Guid.Parse("00000000-0000-0000-0000-000000000000");
+          schema:
+            type: string
+            items:
+              type: string
+              format: uuid
+        - in: query
+          name: DateTo
+          description: Filter by start date
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: DateFrom
+          description: Filter by end date
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Success - return response of type Budgets array with 0 to N Budgets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Budgets'
+              example: '{
+                            "Id": "04e93d48-e72f-4775-b7dd-15a041fab972",
+                            "Status": "OK",
+                            "ProviderName": "Xero API Partner",
+                            "DateTimeUTC": "\/Date(1551399323399)\/",
+                            "Budgets": {
+                              "BudgetID": "c1d195d4-92aa-4abd-867a-7ac2f9d60500",
+                              "Type": "TRACKING",
+                              "Description": "Daniels Northern Budget",
+                              "UpdatedDateUTC": "2017-08-14T01:18:26.74",
+                              "Tracking": [
+                                {
+                                    "TrackingCategoryID": "e94ba240-3edf-4ef3-8317-10147b968f94",
+                                    "Name": "Region",
+                                    "TrackingOptionID": "e94ba240-3edf-4ef3-8317-10147b968f94",
+                                    "Option": "North"
+                                },
+                                {
+                                    "TrackingCategoryID": "d8580491-4167-4a81-9624-ad3bdd8e46ce",
+                                    "Name": "Salesperson",
+                                    "TrackingOptionID": "9c24de87-a2b7-439d-a216-35d1af7bdec3",
+                                    "Option": "Daniel"
+                                }
+                              ],
+                              "BudgetLines": [
+                                {
+                                    "AccountID": "9c24de87-a2b7-439d-a216-35d1af7bdec3",
+                                    "AccountCode": "200",
+                                    "BudgetBalances": [
+                                      {
+                                          "Period": "2019-08",
+                                          "Amount": "1000",
+                                          "Notes": "Sample note"
+                                      },
+                                      {
+                                          "Period": "2019-09",
+                                          "Amount": "1050",
+                                          "Notes": ""
+                                      },
+                                      {
+                                          "Period": "2019-10",
+                                          "Amount": "1102",
+                                          "Notes": ""
+                                      }
+                                    ]
+                                },
+                                {
+                                    "AccountID": "385f90ae-e798-4990-9b1c-db8eb8b735c2",
+                                    "AccountCode": "420",
+                                    "BudgetBalances": [
+                                      {
+                                          "Period": "2019-08",
+                                          "Amount": "500",
+                                          "Notes": ""
+                                      },
+                                      {
+                                          "Period": "2019-09",
+                                          "Amount": "505",
+                                          "Notes": "Special Month"
+                                      },
+                                      {
+                                          "Period": "2019-10",
+                                          "Amount": "510",
+                                          "Notes": ""
+                                      }
+                                    ]
+                                }
+                              ]
+                            }
+                          }'                      
+  '/Contacts':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -23554,6 +23669,54 @@ components:
           description: Status of object
           type: string
       type: object
+    Budgets:
+      type: object
+      externalDocs:
+        url: 'http://developer.xero.com/documentation/api/budgets/'
+      properties:
+        BudgetID:
+          description: Xero identifier
+          type: string
+          format: uuid
+        Type:
+          description: Type of Budget. OVERALL or TRACKING
+          type: string
+          enum:
+          - OVERALL
+          - TRACKING
+        Description:
+          description: The Budget description
+          maxLength: 255
+          type: string
+        UpdatedDateUTC:
+          description: UTC timestamp of last update to budget
+          type: string
+          x-is-msdate-time: true
+          example: "/Date(1573755038314)/"
+          readOnly: true
+        BudgetLines:
+          $ref: '#/components/schemas/BudgetLines'
+        Tracking:
+          $ref: '#/components/schemas/TrackingCategory'
+    BudgetLines:
+      type: object
+      externalDocs:
+        url: 'http://developer.xero.com/documentation/api/budgets/'
+      properties:
+        Period:
+          description: Period the amount applies to (e.g. “2019-08”)
+          type: string
+          x-is-msdate: true
+        Amount:
+          description: LineItem Quantity
+          type: integer
+        UnitAmount:
+          description: Budgeted amount	
+          type: integer
+        Notes:
+          description: Any footnotes associated with this balance
+          maxLength: 255
+          type: string
     Balances:
       type: object
       description:  The raw AccountsReceivable(sales invoices) and

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -17660,7 +17660,6 @@ paths:
                           "DateTimeUTC": "\/Date(1555971088085)\/",
                           "Reports": [
                             {
-                              "ReportID": "AgedPayablesByContact",
                               "ReportName": "Aged Payables By Contact",
                               "ReportType": "AgedPayablesByContact",
                               "ReportTitles": [
@@ -17930,7 +17929,6 @@ paths:
                           "DateTimeUTC": "\/Date(1556032862815)\/",
                           "Reports": [
                             {
-                              "ReportID": "AgedReceivablesByContact",
                               "ReportName": "Aged Receivables By Contact",
                               "ReportType": "AgedReceivablesByContact",
                               "ReportTitles": [
@@ -18312,7 +18310,6 @@ paths:
                         "DateTimeUTC": "\/Date(1555099412778)\/",
                         "Reports": [
                           {
-                            "ReportID": "BalanceSheet",
                             "ReportName": "Balance Sheet",
                             "ReportType": "BalanceSheet",
                             "ReportTitles": [
@@ -19065,7 +19062,6 @@ paths:
                           "DateTimeUTC": "\/Date(1556035526223)\/",
                           "Reports": [
                             {
-                              "ReportID": "BankSummary",
                               "ReportName": "Bank Summary",
                               "ReportType": "BankSummary",
                               "ReportTitles": [
@@ -19165,23 +19161,6 @@ paths:
                             }
                           ]
                         }'
-  '/Reports':
-    parameters:
-      - $ref: '#/components/parameters/requiredHeader'
-    get:
-      security:
-        - OAuth2: [accounting.reports.read]
-      tags:
-        - Accounting
-      operationId: getReportBASorGSTList
-      summary: Retrieves report for BAS (only valid for AU orgs)
-      responses:
-        '200':
-          description: Success - return response of type ReportWithRows
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ReportWithRows'
   '/Reports/{ReportID}':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -19253,7 +19232,6 @@ paths:
                           "DateTimeUTC": "\/Date(1573755037865)\/",
                           "Reports": [
                             {
-                              "ReportID": "BudgetSummary",
                               "ReportName": "Budget Summary",
                               "ReportType": "BudgetSummary",
                               "ReportTitles": [
@@ -19496,7 +19474,6 @@ paths:
                           "DateTimeUTC": "/Date(1573755038314)/",
                           "Reports": [
                             {
-                              "ReportID": "ExecutiveSummary",
                               "ReportName": "Executive Summary",
                               "ReportType": "ExecutiveSummary",
                               "ReportTitles": [
@@ -20091,7 +20068,6 @@ paths:
                           "DateTimeUTC": "\/Date(1556129558740)\/",
                           "Reports": [
                             {
-                              "ReportID": "TrialBalance",
                               "ReportName": "Trial Balance",
                               "ReportType": "TrialBalance",
                               "ReportTitles": [
@@ -26709,7 +26685,7 @@ components:
         url: 'http://developer.xero.com/documentation/api/reports/'
       properties:
         ReportID:
-          description: Report id
+          description: ID of the Report
           type: string
         ReportName:
           description: Name of the report
@@ -26813,9 +26789,6 @@ components:
       externalDocs:
         url: 'http://developer.xero.com/documentation/api/reports/'
       properties:
-        ReportID:
-          description: See Prepayment Types
-          type: string
         ReportName:
           description: See Prepayment Types
           type: string


### PR DESCRIPTION
## Description
Added missing endpoints:
- /Budgets
- /Budgets/{BudgetID}

* breaking change for those using previous GST BAS reports endpoints - renamed routes to support no breaking changes to future state of adding org unique reports.
```
getReportsList
getReportFromId
```

## Release Notes
Solves the problem of some endpoints missing in the Open API Spec but present in the site documentation
Specifically impacting GST or BAS for AUS and NZ orgs

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
