### PR TITLE
Move the summary only param for getInvoices to the last parameter position

### DIFF
--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.13.1"
+  version: "2.13.2"
   title: Xero OAuth 2 Identity Service API
   description: These endpoints are related to managing authentication tokens and identity for Xero API
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.13.1'
+  version: '2.13.2'
   title: 'Xero Payroll AU API'
   description: 'This is the Xero Payroll API for orgs in Australia region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.13.1'
+  version: '2.13.2'
   title: 'Xero Payroll NZ'
   description: 'This is the Xero Payroll API for orgs in the NZ region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.13.1'
+  version: '2.13.2'
   title: 'Xero Payroll UK'
   description: 'This is the Xero Payroll API for orgs in the UK region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.13.1"
+  version: "2.13.2"
   title: Xero Projects API
   description: This is the Xero Projects API 
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Xero Accounting API
-  version: "2.13.1"
+  version: "2.13.2"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:
     name: "Xero Platform Team"
@@ -7875,8 +7875,8 @@ paths:
           example: false
           schema:
             type: boolean
-        - $ref: '#/components/parameters/summaryOnly'
         - $ref: '#/components/parameters/unitdp'
+        - $ref: '#/components/parameters/summaryOnly'
       responses:
         '200':
           description: Success - return response of type Invoices array with all Invoices

--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.13.1"
+  version: "2.13.2"
   title: Xero Assets API
   description: The Assets API exposes fixed asset related functions of the Xero Accounting application and can be used for a variety of purposes such as creating assets, retrieving asset valuations etc.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.13.1"
+  version: "2.13.2"
   title: Xero Bank Feeds API
   description: The Bank Feeds API is a closed API that is only available to financial institutions that have an established financial services partnership with Xero.
                If you're an existing financial services partner that wants access, contact your local Partner Manager.

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -4,7 +4,7 @@ servers:
     url: https://api.xero.com/files.xro/1.0/
 info:
   title: Xero Files API
-  version: "2.13.1"
+  version: "2.13.2"
   description: "These endpoints are specific to Xero Files API"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:


### PR DESCRIPTION
Make it a little easier for devs to grok where to add in data for the additional parameter.

## Description
Most sdks used named objects for params, but some like node, use a position pattern for function params. This tweaks the recent addition to be appended to the end of the getInvoices fn to make the breaking change a little more palatable.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
