### PR TITLE
Single enum add for uk payroll earnings type

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -6749,6 +6749,7 @@ components:
             - StatutorySickPayNonPensionable
             - Tips(Direct)
             - Tips(Non-Direct)
+            - TerminationPay
         rateType:
           description: Indicates the type of the earning rate
           type: string


### PR DESCRIPTION
From a thread here: https://github.com/XeroAPI/xero-ruby/issues/175#issuecomment-861928921

Tracked down an earnings type that had not been reported for UK payroll yet. 
