### PR TITLE
Added missing EASTERISLANDSTANDARDTIME timezone

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -25926,6 +25926,7 @@ components:
       - HAWAIIANSTANDARDTIME
       - UTC11
       - DATELINESTANDARDTIME
+      - EASTERISLANDSTANDARDTIME
     PaymentTerm:
       externalDocs:
         url: 'http://developer.xero.com/documentation/api/organisation/'


### PR DESCRIPTION
Customer reported that this time zone was missing from the Ruby SDK

## Description
Added missing ENUM