### PR TITLE
Remove trailing slash on base url for app store

### DIFF
--- a/xero-app-store.yml
+++ b/xero-app-store.yml
@@ -13,7 +13,7 @@ info:
     url: "https://github.com/XeroAPI/Xero-OpenAPI/blob/master/LICENSE"
 servers:
   - description: Xero App Store API
-    url: "https://api.xero.com/appstore/2.0/"
+    url: "https://api.xero.com/appstore/2.0"
 paths:
   "/subscriptions/{subscriptionId}":
     get:


### PR DESCRIPTION
Quick fix to remove a trailing slash on the base API url for new app store endpoints