### PR TITLE
Add directors fees to earnings types for AU Payroll SDK

### DIFF
--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -4800,6 +4800,7 @@ components:
       - LUMPSUMB
       - BONUSESANDCOMMISSIONS
       - LUMPSUME
+      - DIRECTORSFEES
     EmploymentTerminationPaymentType: 
       type: string
       enum:


### PR DESCRIPTION
Add directors fees earnings type to the payroll AU SDK in preparation for the implementation in the API itself.

## Description
Add EarningsRate enum value ```DIRECTORSFEES``` to the Payroll AU SDK spec

## Release Notes
This is required so app partners can prepare for integration before release of the changes to the API

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
