### PR TITLE
Updated Budgeted amount type 

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23773,8 +23773,10 @@ components:
             description: LineItem Quantity
             type: integer
           UnitAmount:
-            description: Budgeted amount  
-            type: integer
+            description: Budgeted amount
+            type: number
+            format: double
+            x-is-money: true
           Notes:
             description: Any footnotes associated with this balance
             maxLength: 255

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23771,7 +23771,9 @@ components:
             x-is-msdate: true
           Amount:
             description: LineItem Quantity
-            type: integer
+            type: number
+            format: double
+            x-is-money: true
           UnitAmount:
             description: Budgeted amount
             type: number


### PR DESCRIPTION
## Description
Was set as integer which is incorrect as a decimal is typically returned.

## Release Notes
API returns decimals, this causes some SDKs to throw an error as they were expecting an integer.

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Should fix https://github.com/XeroAPI/Xero-NetStandard/issues/377