### PR TITLE
Fix GetBudget filtering and missing UK payroll earningsrates

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -6775,6 +6775,8 @@ components:
             - StatutorySickPayNonPensionable
             - Tips(Direct)
             - Tips(Non-Direct)
+            - TipsNonDirect
+            - TipsDirect
             - TerminationPay
         rateType:
           description: Indicates the type of the earning rate

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -6773,8 +6773,6 @@ components:
             - StatutorySharedParentalPayNonPensionable
             - StatutorySickPay
             - StatutorySickPayNonPensionable
-            - Tips(Direct)
-            - Tips(Non-Direct)
             - TipsNonDirect
             - TipsDirect
             - TerminationPay

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3314,9 +3314,21 @@ paths:
       tags:
         - Accounting
       operationId: getBudget
-      summary: Retrieves a specific budgets, which includes budget lines
+      summary: Retrieves a specific budget, which includes budget lines
       parameters:
         - $ref: '#/components/parameters/BudgetID'
+        - in: query
+          name: DateTo
+          description: Filter by start date
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: DateFrom
+          description: Filter by end date
+          schema:
+            type: string
+            format: date
       responses:
         '200':
           description: Success - return response of type Invoices array with specified Invoices

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23771,7 +23771,9 @@ components:
             x-is-msdate: true
           Amount:
             description: LineItem Quantity
-            type: integer
+            type: number
+            format: double
+            x-is-money: true
           UnitAmount:
             description: Budgeted amount
             type: number


### PR DESCRIPTION
## Description
Filtering is available when retrieving a single budget, this adds support for it
Added missing EarningsRates for tips in UK Payroll 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
