### PR TITLE
removes nullable fields from finance spec and makes if-modified-since header consistent

### DIFF
--- a/xero-app-store.yaml
+++ b/xero-app-store.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.16.7"
+  version: "2.16.8"
   title: Xero AppStore API
   description: These endpoints are for Xero Partners to interact with the App Store Billing platform
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.16.7"
+  version: "2.16.8"
   title: Xero Finance API
   description: The Finance API is a collection of endpoints which customers can use in the course of a loan application, which may assist lenders to gain the confidence they need to provide capital.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -852,7 +852,6 @@ components:
         month:
           type: string
           description: The month this usage item contains data for
-          nullable: true
         accountId:
           type: string
           description: The account this usage item contains data for
@@ -860,55 +859,44 @@ components:
         currencyCode:
           type: string
           description: The currency code this usage item contains data for
-          nullable: true
         totalReceived:
           type: number
           description: Total received
           format: double
-          nullable: true
         countReceived:
           type: integer
           description: Count of received
           format: int32
-          nullable: true
         totalPaid:
           type: number
           description: Total paid
           format: double
-          nullable: true
         countPaid:
           type: integer
           description: Count of paid
           format: int32
-          nullable: true
         totalManualJournal:
           type: number
           description: Total value of manual journals
           format: double
-          nullable: true
         countManualJournal:
           type: integer
           description: Count of manual journals
           format: int32
-          nullable: true
         accountName:
           type: string
           description: The name of the account
-          nullable: true
         reportingCode:
           type: string
           description: Shown if set
-          nullable: true
         reportingCodeName:
           type: string
           description: Shown if set
-          nullable: true
         reportCodeUpdatedDateUtc:
           type: string
           description: Last modified date UTC format
           format: date-time
           x-is-datetime: true
-          nullable: true
       additionalProperties: false
     AccountUsageResponse:
       type: object
@@ -920,16 +908,13 @@ components:
         startMonth:
           type: string
           description: The start month of the report
-          nullable: true
         endMonth:
           type: string
           description: The end month of the report
-          nullable: true
         accountUsage:
           type: array
           items:
             $ref: "#/components/schemas/AccountUsage"
-          nullable: true
       additionalProperties: false
     HistoryRecordResponse:
       type: object
@@ -937,11 +922,9 @@ components:
         changes:
           type: string
           description: The type of change recorded against the document
-          nullable: true
         dateUTCString:
           type: string
           description: UTC date that the history record was created
-          nullable: true
         dateUTC:
           type: string
           description: UTC date that the history record was created
@@ -950,11 +933,9 @@ components:
         user:
           type: string
           description: The users first and last name
-          nullable: true
         details:
           type: string
           description: Description of the change event or transaction
-          nullable: true
       additionalProperties: false
     LockHistoryModel:
       type: object
@@ -963,18 +944,15 @@ components:
           type: string
           format: date
           description: Date the account hard lock was set
-          nullable: true
         softLockDate:
           type: string
           format: date
           description: Date the account soft lock was set
-          nullable: true
         updatedDateUtc:
           type: string
           format: date-time
           description: The system date time that the lock was updated
           x-is-datetime: true
-          nullable: true
       additionalProperties: false
     LockHistoryResponse:
       type: object
@@ -987,12 +965,10 @@ components:
           type: string
           format: date
           description: The end date of the report
-          nullable: true
         lockDates:
           type: array
           items:
             $ref: "#/components/schemas/LockHistoryModel"
-          nullable: true
       additionalProperties: false
     PracticeResponse:
       type: object
@@ -1004,11 +980,9 @@ components:
         tier:
           type: string
           description: Customer tier e.g. Silver
-          nullable: true
         location:
           type: string
           description: Country of location.
-          nullable: true
         organisationCount:
           type: integer
           description: Organisation count.
@@ -1024,13 +998,11 @@ components:
           $ref: "#/components/schemas/ProblemType"
         title:
           type: string
-          nullable: true
         status:
           type: integer
           format: int32
         detail:
           type: string
-          nullable: true
       additionalProperties: false
     ProblemType:
       enum:
@@ -1046,11 +1018,9 @@ components:
         reportName:
           type: string
           description: Report code or report title
-          nullable: true
         reportDateText:
           type: string
           description: The date or date range of the report
-          nullable: true
         publishedDateUtc:
           type: string
           description: The system date time that the report was published
@@ -1068,12 +1038,10 @@ components:
           type: string
           format: date
           description: The end date of the report
-          nullable: true
         reports:
           type: array
           items:
             $ref: "#/components/schemas/ReportHistoryModel"
-          nullable: true
       additionalProperties: false
     UserActivitiesResponse:
       type: object
@@ -1085,12 +1053,10 @@ components:
         dataMonth:
           type: string
           description: The month of the report
-          nullable: true
         users:
           type: array
           items:
             $ref: "#/components/schemas/UserResponse"
-          nullable: true
       additionalProperties: false
     UserResponse:
       type: object
@@ -1104,13 +1070,11 @@ components:
           description: Timestamp of user creation.
           format: date-time
           x-is-datetime: true
-          nullable: true
         lastLoginDateUtc:
           type: string
           description: Timestamp of user last login
           format: date-time
           x-is-datetime: true
-          nullable: true
         isExternalPartner:
           type: boolean
           description: User is external partner.
@@ -1120,7 +1084,6 @@ components:
         monthPeriod:
           type: string
           description: Month period in format  yyyy-MM.
-          nullable: true
         numberOfLogins:
           type: integer
           description: Number of times the user has logged in.
@@ -1133,22 +1096,18 @@ components:
           type: number
           description: Net value of documents created.
           format: double
-          nullable: true
         absoluteValueDocumentsCreated:
           type: number
           description: Absolute value of documents created.
           format: double
-          nullable: true
         attachedPractices:
           type: array
           items:
             $ref: "#/components/schemas/PracticeResponse"
-          nullable: true
         historyRecords:
           type: array
           items:
             $ref: "#/components/schemas/HistoryRecordResponse"
-          nullable: true
       additionalProperties: false
     BankStatementResponse:
       type: object
@@ -1183,7 +1142,6 @@ components:
         balanceCurrency:
           type: string
           description: Currency which the cashAccount transactions relate to.
-          nullable: true
       additionalProperties: false
     CashValidationResponse:
       type: object
@@ -1199,7 +1157,6 @@ components:
           description: UTC Date when the last bank statement item was entered into
             Xero. This date is represented in ISO 8601 format.
           format: date
-          nullable: true
         bankStatement:
           $ref: "#/components/schemas/BankStatementResponse"
         cashAccount:
@@ -1214,14 +1171,12 @@ components:
             the first date which transactions on this statement pertain to. This date
             is represented in ISO 8601 format.
           format: date
-          nullable: true
         endDate:
           type: string
           description: Looking at the most recent bank statement, this field indicates
             the last date which transactions on this statement pertain to. This date
             is represented in ISO 8601 format.
           format: date
-          nullable: true
         startBalance:
           type: number
           description: Looking at the most recent bank statement, this field indicates
@@ -1241,13 +1196,11 @@ components:
             ISO 8601 format.
           format: date-time
           x-is-datetime: true
-          nullable: true
         importSourceType:
           type: string
           description: Looking at the most recent bank statement, this field indicates
             the source of the data (direct bank feed, indirect bank feed, file upload,
             or manual keying).
-          nullable: true
       additionalProperties: false
     DataSourceResponse:
       type: object
@@ -1367,7 +1320,6 @@ components:
           type: string
           description: The DEBIT or CREDIT status of the account. Cash accounts in
             credit have a negative balance.
-          nullable: true
       additionalProperties: false
     StatementLinesResponse:
       type: object
@@ -1409,14 +1361,12 @@ components:
             line for which the reconciled flag is set to FALSE.  This date is represented
             in ISO 8601 format.
           format: date
-          nullable: true
         latestUnreconciledTransaction:
           type: string
           description: UTC Date which is the latest transaction date of a statement
             line for which the reconciled flag is set to FALSE.  This date is represented
             in ISO 8601 format.
           format: date
-          nullable: true
         deletedAmount:
           type: number
           description: Sum of the amounts of all deleted statement lines.  Transactions
@@ -1435,14 +1385,12 @@ components:
             line for which the reconciled flag is set to TRUE.  This date is represented
             in ISO 8601 format.
           format: date
-          nullable: true
         latestReconciledTransaction:
           type: string
           description: UTC Date which is the latest transaction date of a statement
             line for which the reconciled flag is set to TRUE.  This date is represented
             in ISO 8601 format.
           format: date
-          nullable: true
         reconciledAmountPos:
           type: number
           description: Sum of the amounts of all statement lines where both the reconciled
@@ -1475,7 +1423,6 @@ components:
         code:
           type: string
           description: "Accounting code"
-          nullable: true
         accountID:
           type: string
           description: "ID of the account"
@@ -1483,11 +1430,9 @@ components:
         name:
           type: string
           description: "Account name"
-          nullable: true
         reportingCode:
           type: string
           description: "Reporting code"
-          nullable: true
         total:
           type: number
           description: "Total movement on this account"
@@ -1500,7 +1445,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BalanceSheetAccountType"
-          nullable: true
         total:
           type: number
           description: "Total value of all the accounts in this type"
@@ -1512,13 +1456,11 @@ components:
         accountType:
           type: string
           description: "The type of the account. See <a href='https://developer.xero.com/documentation/api/types#AccountTypes'>Account Types</a>"
-          nullable: true
         accounts:
           type: array
           items:
             $ref: "#/components/schemas/BalanceSheetAccountDetail"
           description: "A list of all accounts of this type. Refer to the Account section below for each account element detail."
-          nullable: true
         total:
           type: number
           description: "Total value of all the accounts in this type"
@@ -1531,7 +1473,6 @@ components:
           type: string
           format: date
           description: "Balance date of the report"
-          nullable: true
         asset:
           $ref: "#/components/schemas/BalanceSheetAccountGroup"
         liability:
@@ -1566,23 +1507,18 @@ components:
         accountType:
           type: string
           description: "The type of the account. See <a href='https://developer.xero.com/documentation/api/types#AccountTypes'>Account Types</a>"
-          nullable: true
         accountClass:
           type: string
           description: "The class of the account. See <a href='https://developer.xero.com/documentation/api/types#AccountClassTypes'>Account Class Types</a>"
-          nullable: true
         code:
           type: string
           description: "Account code"
-          nullable: true
         name:
           type: string
           description: "Account name"
-          nullable: true
         reportingCode:
           type: string
           description: "Reporting code used for cash flow classification"
-          nullable: true
         total:
           type: number
           description: "Total amount for the account"
@@ -1594,7 +1530,6 @@ components:
         name:
           type: string
           description: "Name of the cashflow activity type. It will be either Operating Activities, Investing Activities or Financing Activities"
-          nullable: true
         total:
           type: number
           description: "Total value of the activity type"
@@ -1603,7 +1538,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CashflowType"
-          nullable: true
       additionalProperties: false
     CashflowResponse:
       type: object
@@ -1623,7 +1557,6 @@ components:
           items:
             $ref: "#/components/schemas/CashflowActivity"
           description: "Break down of cash and cash equivalents for the period"
-          nullable: true
       additionalProperties: false
     CashflowType:
       type: object
@@ -1631,7 +1564,6 @@ components:
         name:
           type: string
           description: "Name of the activity"
-          nullable: true
         total:
           type: number
           description: "Total value of the activity"
@@ -1641,7 +1573,6 @@ components:
           items:
             $ref: "#/components/schemas/CashflowAccount"
           description: "List of the accounts in this activity"
-          nullable: true
       additionalProperties: false
     PnlAccount:
       type: object
@@ -1653,19 +1584,15 @@ components:
         accountType:
           type: string
           description: "The type of the account. See <a href='https://developer.xero.com/documentation/api/types#AccountTypes'>Account Types</a>"
-          nullable: true
         code:
           type: string
           description: "Account code"
-          nullable: true
         name:
           type: string
           description: "Account name"
-          nullable: true
         reportingCode:
           type: string
           description: "Reporting code (Shown if set)"
-          nullable: true
         total:
           type: number
           description: "Total movement on this account"
@@ -1683,7 +1610,6 @@ components:
           items:
             $ref: "#/components/schemas/PnlAccountType"
           description: "Contains trading income and other income for revenue section / operating expenses and direct cost for expense section if the data is available for each section. Refer to the account type element below"
-          nullable: true
       additionalProperties: false
     PnlAccountType:
       type: object
@@ -1695,13 +1621,11 @@ components:
         title:
           type: string
           description: "Name of this account type, it will be either Trading Income or Other Income for Revenue section / Direct Cost or Operating Expenses for Expense section"
-          nullable: true
         accounts:
           type: array
           items:
             $ref: "#/components/schemas/PnlAccount"
           description: "A list of the movement on each account detail during the query period. Refer to the account detail element below"
-          nullable: true
       additionalProperties: false
     ProfitAndLossResponse:
       type: object
@@ -1733,27 +1657,21 @@ components:
         accountType:
           type: string
           description: "The type of the account. See <a href='https://developer.xero.com/documentation/api/types#AccountTypes'>Account Types</a>"
-          nullable: true
         accountCode:
           type: string
           description: "Customer defined alpha numeric account code e.g 200 or SALES"
-          nullable: true
         accountClass:
           type: string
           description: "The class of the account. See <a href='https://developer.xero.com/documentation/api/types#AccountClassTypes'>Account Class Types</a>"
-          nullable: true
         status:
           type: string
           description: "Accounts with a status of ACTIVE can be updated to ARCHIVED. See <a href='https://developer.xero.com/documentation/api/types#AccountStatusCodes'>Account Status Codes</a>"
-          nullable: true
         reportingCode:
           type: string
           description: "Reporting code (Shown if set)"
-          nullable: true
         accountName:
           type: string
           description: "Name of the account"
-          nullable: true
         balance:
           $ref: "#/components/schemas/TrialBalanceEntry"
         signedBalance:
@@ -1773,7 +1691,6 @@ components:
         entryType:
           type: string
           description: "Sign (Debit/Credit) of the movement of balance in the account"
-          nullable: true
       additionalProperties: false
     TrialBalanceMovement:
       type: object
@@ -1800,16 +1717,13 @@ components:
           type: string
           format: date
           description: "Start date of the report"
-          nullable: true
         endDate:
           type: string
           format: date
           description: "End date of the report"
-          nullable: true
         accounts:
           type: array
           items:
             $ref: "#/components/schemas/TrialBalanceAccount"
           description: "Refer to the accounts section below"
-          nullable: true
       additionalProperties: false

--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.16.7"
+  version: "2.16.8"
   title: Xero OAuth 2 Identity Service API
   description: These endpoints are related to managing authentication tokens and identity for Xero API
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.16.7'
+  version: '2.16.8'
   title: 'Xero Payroll AU API'
   description: 'This is the Xero Payroll API for orgs in Australia region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -32,6 +32,7 @@ paths:
         - in: header
           name: If-Modified-Since
           description: Only records created or modified since this timestamp will be returned
+          example: "2020-02-06T12:17:43.202-08:00"
           schema:
             type: string
             format: date-time
@@ -573,8 +574,10 @@ paths:
         - in: header
           name: If-Modified-Since
           description: Only records created or modified since this timestamp will be returned
+          example: "2020-02-06T12:17:43.202-08:00"
           schema:
             type: string
+            format: date-time
         - in: query
           name: where
           description: Filter by an any element
@@ -1017,8 +1020,10 @@ paths:
         - in: header
           name: If-Modified-Since
           description: Only records created or modified since this timestamp will be returned
+          example: "2020-02-06T12:17:43.202-08:00"
           schema:
             type: string
+            format: date-time
         - in: query
           name: where
           description: Filter by an any element
@@ -1523,8 +1528,10 @@ paths:
         - in: header
           name: If-Modified-Since
           description: Only records created or modified since this timestamp will be returned
+          example: "2020-02-06T12:17:43.202-08:00"
           schema:
             type: string
+            format: date-time
         - in: query
           name: where
           description: Filter by an any element
@@ -1786,8 +1793,10 @@ paths:
         - in: header
           name: If-Modified-Since
           description: Only records created or modified since this timestamp will be returned
+          example: "2020-02-06T12:17:43.202-08:00"
           schema:
             type: string
+            format: date-time
         - in: query
           name: where
           description: Filter by an any element
@@ -2391,8 +2400,10 @@ paths:
         - in: header
           name: If-Modified-Since
           description: Only records created or modified since this timestamp will be returned
+          example: "2020-02-06T12:17:43.202-08:00"
           schema:
             type: string
+            format: date-time
         - in: query
           name: where
           description: Filter by an any element
@@ -2713,8 +2724,10 @@ paths:
         - in: header
           name: If-Modified-Since
           description: Only records created or modified since this timestamp will be returned
+          example: "2020-02-06T12:17:43.202-08:00"
           schema:
             type: string
+            format: date-time
         - in: query
           name: where
           description: Filter by an any element

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.16.7'
+  version: '2.16.8'
   title: 'Xero Payroll NZ'
   description: 'This is the Xero Payroll API for orgs in the NZ region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.16.7'
+  version: '2.16.8'
   title: 'Xero Payroll UK'
   description: 'This is the Xero Payroll API for orgs in the UK region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.16.7"
+  version: "2.16.8"
   title: Xero Projects API
   description: This is the Xero Projects API 
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Xero Accounting API
-  version: "2.16.7"
+  version: "2.16.8"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:
     name: "Xero Platform Team"

--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.16.7"
+  version: "2.16.8"
   title: Xero Assets API
   description: The Assets API exposes fixed asset related functions of the Xero Accounting application and can be used for a variety of purposes such as creating assets, retrieving asset valuations etc.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.16.7"
+  version: "2.16.8"
   title: Xero Bank Feeds API
   description: The Bank Feeds API is a closed API that is only available to financial institutions that have an established financial services partnership with Xero.
                If you're an existing financial services partner that wants access, contact your local Partner Manager.

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -4,7 +4,7 @@ servers:
     url: https://api.xero.com/files.xro/1.0/
 info:
   title: Xero Files API
-  version: "2.16.7"
+  version: "2.16.8"
   description: "These endpoints are specific to Xero Files API"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
-removes `nullable: true` fields from Finance API spec
-makes `if-modified-since` header consistent to reflect `type: string` and `format: date-time`

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
-`nullable: true` was a leftover artifact from the internal API spec and was breaking the .NET SDK build
-`if-modified-since` header now matches format in the API docs `example: "2020-02-06T12:17:43.202-08:00"`

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
