### PR TITLE
Update LineItem to include the Item object

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23287,6 +23287,8 @@ components:
           type: number
           format: double
           x-is-money: true
+        Item:
+          $ref: '#/components/schemas/LineItemItem'
         LineAmount:
           description: If you wish to omit either of the <Quantity> or <UnitAmount> you can provide a LineAmount and Xero will calculate the missing amount for
             you. The line amount reflects the discounted price if a DiscountRate
@@ -23317,6 +23319,20 @@ components:
           type: string
           format: uuid
       type: object
+    LineItemItem:
+      properties:
+        Code:
+          description: User defined item code (max length = 30)
+          maxLength: 30
+          type: string
+        Name:
+          description: The name of the item (max length = 50)
+          maxLength: 50
+          type: string
+        ItemID:
+          description: The Xero identifier for an Item
+          type: string
+          format: uuid
     LineItemTracking:
       externalDocs:
         url: 'https://developer.xero.com/documentation/api/invoices#post'


### PR DESCRIPTION
Update LineItem to include the Item object that is returned in BankTransactions, Invoices, and CreditNotes

## Description
There is an [open issue](https://github.com/XeroAPI/Xero-Java/issues/305) in the Xero-Java SDK that pointed out our API returns the Item object when retrieving Invoices but the SDK does not serialize it.

## Release Notes
This enhancement was [added last year](https://developer.xero.com/documentation/api/accounting/releasenotes#9-july-2021) but is not included in our documentation or spec.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
