### PR TITLE
UKPAY-2355 Add isOffPayrollWorker property to docs

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -28,10 +28,10 @@ paths:
       parameters:
         - in: query
           name: filter
-          description: Filter by first name and/or lastname
+          description: Filter by first name, lastname, and/or whether they are an off-payroll worker
           schema:
             type: string
-          example: firstName==John,lastName==Smith
+          example: firstName==John,lastName==Smith,isOffPayrollWorker==false
         - in: query
           name: page
           description: Page number which specifies the set of records to retrieve. By default the number of the records per set is 100.
@@ -78,7 +78,8 @@ paths:
                                 "payrollCalendarID":"216d80e6-af55-47b1-b718-9457c3f5d2fe",
                                 "updatedDateUTC":"2020-02-13T16:23:31",
                                 "createdDateUTC":"2020-02-10T10:00:24",
-                                "endDate":null
+                                "endDate":null,
+                                "isOffPayrollWorker":false
                               },
                               {
                                 "employeeID":"67e545d4-e8a6-4f98-9f63-85c2383dfe12",
@@ -100,7 +101,8 @@ paths:
                                 "payrollCalendarID":"5e813d9e-949c-461f-8a89-e9ee8955a254",
                                 "updatedDateUTC":"2020-02-13T16:48:51",
                                 "createdDateUTC":"2020-02-13T16:32:12",
-                                "endDate":null
+                                "endDate":null,
+                                "isOffPayrollWorker":false
                               },
                               {
                                 "employeeID":"eb4a0c3b-b0d6-440d-bccc-348b7dc92321",
@@ -122,7 +124,8 @@ paths:
                                 "payrollCalendarID":"d45bc68f-59d6-4000-929d-1058dcfa79e1",
                                 "updatedDateUTC":"2020-02-13T16:53:12",
                                 "createdDateUTC":"2020-02-13T16:46:41",
-                                "endDate":null
+                                "endDate":null,
+                                "isOffPayrollWorker":false
                               }
                           ]
                         }'
@@ -247,14 +250,15 @@ paths:
                               "phoneNumber":null,
                               "startDate":null,
                               "nationalInsuranceNumber":null,
-                              "address":{
-                                "addressLine1":"101 Green St",
+                              "isOffPayrollWorker": false,
+                              "address": {
+                                "addressLine1": "171 Midsummer",
                                 "addressLine2":null,
-                                "city":"San Francisco",
+                                "city": "Milton Keyness",
                                 "county":null,
                                 "countryName":null,
-                                "postCode":"6TGR4F"
-                              },
+                                "postCode": "MK9 1EB"
+                              }
                               "payrollCalendarID":null,
                               "updatedDateUTC":"2020-03-25T03:12:10",
                               "createdDateUTC":"2020-03-25T03:12:10",
@@ -279,15 +283,15 @@ paths:
                         "title":"Mr",
                         "firstName":"Mike",
                         "lastName":"Fancy",
-                        "dateOfBirth":"1999-01-01",
-                        "address":{
-                            "addressLine1":"101 Green St",
-                            "city":"San Francisco",
-                            "postCode":"6TGR4F",
-                            "country":"UK"
-                        },
+                        "dateOfBirth":"1999-01-01T00:00:00",
+                        "gender":"M",
                         "email":"mike@starkindustries.com",
-                        "gender":"M"
+                        "isOffPayrollWorker": false,
+                        "address": {
+                          "addressLine1": "171 Midsummer",
+                          "city": "Milton Keyness",
+                          "postCode": "MK9 1EB"
+                        }
                       }'
   /Employees/{EmployeeID}:
     parameters:
@@ -317,37 +321,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/EmployeeObject'
               example: '{
-                          "id":"a8ef46c6-8191-43f6-a3c9-f42c7ca884b5",
-                          "providerName":"provider-name",
-                          "dateTimeUTC":"2020-03-25T03:28:45.5524202",
-                          "httpStatusCode":"OK",
-                          "pagination":null,
-                          "problem":null,
-                          "employee":{
-                              "employeeID":"aad6b292-7b94-408b-93f6-e489867e3fb0",
-                              "title":"Mr.",
-                              "firstName":"Jack",
-                              "lastName":"Allan",
-                              "dateOfBirth":"1987-12-23T00:00:00",
-                              "gender":"M",
-                              "email":null,
-                              "phoneNumber":null,
-                              "startDate":"2020-02-03T00:00:00",
-                              "nationalInsuranceNumber":"AB123456C",
-                              "address":{
-                                "addressLine1":"171 Midsummer Boulevard",
-                                "addressLine2":null,
-                                "city":"Milton Keynes",
-                                "county":null,
-                                "countryName":"UNITED KINGDOM",
-                                "postCode":"MK9 1EB"
+                          "id": "9414291b-a8c6-08fa-b165-9b30b1e6aab5",
+                          "providerName": "!YLT5Y",
+                          "dateTimeUTC": "2018-04-09T05:15:18.1011141",
+                          "httpStatusCode": "OK",
+                          "pagination": null,
+                          "problem": null,
+                          "employee": {
+                              "employeeID": "d17e008e-3381-45c0-b50c-2fab7757e503",
+                              "title": "Mr.",
+                              "firstName": "Edgar",
+                              "lastName": "Allan Po",
+                              "dateOfBirth": "1985-03-24T00:00:00",
+                              "gender": "M",
+                              "email": "tester1@gmail.com",
+                              "phoneNumber": "0400123456",
+                              "nationalInsuranceNumber": null,
+                              "isOffPayrollWorker": false,
+                              "address": {
+                                  "addressLine1": "171 Midsummer",
+                                  "addressLine2": null,
+                                  "city": "Milton Keyness",
+                                  "county": null,
+                                  "countryName": null,
+                                  "postCode": "MK9 1EB"
                               },
-                              "payrollCalendarID":"216d80e6-af55-47b1-b718-9457c3f5d2fe",
-                              "updatedDateUTC":"2020-02-13T16:23:31",
-                              "createdDateUTC":"2020-02-10T10:00:24",
-                              "niCategory":"A",
-                              "employeeNumber":"01",
-                              "endDate":null
+                              "payrollCalendarID": null,
+                              "updatedDateUTC": "2017-05-12T10:00:24",
+                              "createdDateUTC": "2017-05-12T10:00:24",
+                              "endDate": null
                           }
                         }'
     put:
@@ -457,39 +459,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/EmployeeObject'
               example: '{
-                        "id": "eebef848-5fa2-42c2-a10f-4dc47a9cf82a",
-                        "providerName": "provider-name",
-                        "dateTimeUTC": "2020-03-25T17:03:50.710258",
-                        "httpStatusCode": "OK",
-                        "pagination": null,
-                        "problem": null,
-                        "employee": {
-                          "employeeID": "aad6b292-7b94-408b-93f6-e489867e3fb0",
-                          "title": "Mr",
-                          "firstName": "Mike",
-                          "lastName": "Johnllsbkrhwopson",
-                          "dateOfBirth": "1999-01-01T00:00:00",
-                          "gender": "M",
-                          "email": "84044@starkindustries.com",
-                          "phoneNumber": null,
-                          "startDate": "2020-02-03T00:00:00",
-                          "nationalInsuranceNumber": null,
-                          "address": {
-                            "addressLine1": "101 Green St",
-                            "addressLine2": null,
-                            "city": "San Francisco",
-                            "county": null,
-                            "countryName": null,
-                            "postCode": "6TGR4F"
-                          },
-                          "payrollCalendarID": "216d80e6-af55-47b1-b718-9457c3f5d2fe",
-                          "updatedDateUTC": "2020-03-25T17:03:50",
-                          "createdDateUTC": "2020-02-10T10:00:24",
-                          "niCategory": null,
-                          "employeeNumber": null,
-                          "endDate": null
-                        }
-                      }'
+                          "id": "9414291b-a8c6-08fa-b165-9b30b1e6aab5",
+                          "providerName": "!YLT5Y",
+                          "dateTimeUTC": "2018-04-09T05:10:51.3504472",
+                          "httpStatusCode": "OK",
+                          "pagination": null,
+                          "problem": null,
+                          "employee": {
+                              "employeeID": "07f0f9fc-cc95-46ac-9a8a-aa03779f2bde",
+                              "title": "Mr.",
+                              "firstName": "TestDataUK",
+                              "lastName": "Tester",
+                              "dateOfBirth": "1992-11-22T00:00:00",
+                              "gender": "M",
+                              "email": "tester@gmail.com",
+                              "phoneNumber": "0400123456",
+                              "startDate": null,
+                              "nationalInsuranceNumber": null,
+                              "isOffPayrollWorker": false,
+                              "address": {
+                                "addressLine1": "171 Midsummer",
+                                "addressLine2":null,
+                                "city": "Milton Keyness",
+                                "county":null,
+                                "countryName":null,
+                                "postCode": "MK9 1EB"
+                              }
+                              "payrollCalendarID": null,
+                              "updatedDateUTC": "2017-06-27T04:56:03",
+                              "createdDateUTC": "2017-05-12T10:00:24",
+                              "endDate": null
+                          }
+                        }'
         '400':
           description: validation error for a bad request
           content:
@@ -503,18 +504,19 @@ paths:
             schema:
               $ref: '#/components/schemas/Employee'
             example: '{
-                        "title":"Mr",
-                        "firstName":"Mike",
-                        "lastName":"Johnllsbkrhwopson",
-                        "dateOfBirth":"1999-01-01",
-                        "address":{
-                            "addressLine1":"101 Green St",
-                            "city":"San Francisco",
-                            "postCode":"6TGR4F",
-                            "country":"UK"
-                        },
-                        "email":"84044@starkindustries.com",
-                        "gender":"M"
+                        "title": "Mr.",
+                        "firstName": "TestDataUK",
+                        "lastName": "Tester",
+                        "dateOfBirth": "1992-11-22T00:00:00",
+                        "gender": "M",
+                        "email": "tester@gmail.com",
+                        "phoneNumber": "0400123456",
+                        "isOffPayrollWorker": false,
+                        "address": {
+                          "addressLine1": "171 Midsummer",
+                          "city": "Milton Keyness",
+                          "postCode": "MK9 1EB"
+                        }
                       }'
   /Employees/{EmployeeID}/Employment:
     parameters:
@@ -5880,6 +5882,9 @@ components:
           description: National insurance number of the employee
           type: string
           example: AB123456C
+        isOffPayrollWorker:
+          description: Whether the employee is an off payroll worker
+          type: boolean
     EmploymentObject:
       type: object
       properties:


### PR DESCRIPTION
## Description
Add the `isOffPayrollWorker` property to the Employee schema as well as to the affected example requests and responses.

## Release Notes
- Allow creation and management of off-payroll workers

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
