### PR TITLE
UKPAY-3302: Update docs to support the new NI Category letters for FY2022-2023. (F, I, S, L, V)

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -5922,11 +5922,16 @@ components:
           - A
           - B
           - C
+          - F
           - H
+          - I
           - J
+          - L
           - M
-          - Z
+          - S
+          - V
           - X
+          - Z
           example: A
     EmployeeTaxObject:
       type: object


### PR DESCRIPTION
## Description
As part of the NI initiative for 2022-2023, five new codes (F, I, S, L, V) have been introduced in MVC.
This PR updates the docs - particulary niCategory object to now accepts the newly introduced codes. 

## Release Notes
Open API doc needed to be aligned with new codes that have now been introduced in MVC

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
