### PR TITLE
Add getJournalByNumber call

### DIFF
--- a/xero-app-store.yaml
+++ b/xero-app-store.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.21.0"
+  version: "2.22.0"
   title: Xero AppStore API
   description: These endpoints are for Xero Partners to interact with the App Store Billing platform
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.21.0"
+  version: "2.22.0"
   title: Xero Finance API
   description: The Finance API is a collection of endpoints which customers can use in the course of a loan application, which may assist lenders to gain the confidence they need to provide capital.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.21.0"
+  version: "2.22.0"
   title: Xero OAuth 2 Identity Service API
   description: These endpoints are related to managing authentication tokens and identity for Xero API
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.21.0'
+  version: '2.22.0'
   title: 'Xero Payroll AU API'
   description: 'This is the Xero Payroll API for orgs in Australia region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.21.0'
+  version: '2.22.0'
   title: 'Xero Payroll NZ'
   description: 'This is the Xero Payroll API for orgs in the NZ region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.21.0'
+  version: '2.22.0'
   title: 'Xero Payroll UK'
   description: 'This is the Xero Payroll API for orgs in the UK region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.21.0"
+  version: "2.22.0"
   title: Xero Projects API
   description: This is the Xero Projects API 
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -10242,6 +10242,70 @@ paths:
                             }
                           ]
                         }'
+  '/Journals/{JournalNumber}':
+    parameters:
+      - $ref: '#/components/parameters/requiredHeader'
+    get:
+      security:
+        - OAuth2: [accounting.journals.read]
+      tags:
+        - Accounting
+      operationId: getJournalByNumber
+      summary: Retrieves a specific journal using a unique journal number.
+      parameters:
+        - $ref: '#/components/parameters/JournalNumber'
+      responses:
+        '200':
+          description: Success - return response of type Journals array with specified Journal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Journals'
+              example: '{
+                          "Id": "39ab8367-eb14-420d-83a9-e01ddddd21f8",
+                          "Status": "OK",
+                          "ProviderName": "Provider Name Example",
+                          "DateTimeUTC": "\/Date(1552335613002)\/",
+                          "Journals": [
+                            {
+                              "JournalID": "1b31feeb-aa23-404c-8c19-24c827c53661",
+                              "JournalDate": "\/Date(1539993600000+0000)\/",
+                              "JournalNumber": 1,
+                              "CreatedDateUTC": "\/Date(1541176243467+0000)\/",
+                              "Reference": "Red Fish, Blue Fish",
+                              "JournalLines": [
+                                {
+                                  "JournalLineID": "81e6b1bf-d812-4f87-8dc4-698558ae043e",
+                                  "AccountID": "b94495d0-44ab-4199-a1d0-427a4877e100",
+                                  "AccountCode": "610",
+                                  "AccountType": "CURRENT",
+                                  "AccountName": "Accounts Receivable",
+                                  "Description": "",
+                                  "NetAmount": 40.00,
+                                  "GrossAmount": 40.00,
+                                  "TaxAmount": 0.00,
+                                  "TaxType": "",
+                                  "TaxName": "",
+                                  "TrackingCategories": []
+                                },
+                                {
+                                  "JournalLineID": "ad221a8c-ebee-4c1b-88ed-d574e27e8803",
+                                  "AccountID": "e0a5d892-9f9f-44f0-a153-5cb7db125170",
+                                  "AccountCode": "200",
+                                  "AccountType": "REVENUE",
+                                  "AccountName": "Sales",
+                                  "Description": "Acme Tires",
+                                  "NetAmount": -40.00,
+                                  "GrossAmount": -40.00,
+                                  "TaxAmount": 0.00,
+                                  "TaxType": "NONE",
+                                  "TaxName": "No GST",
+                                  "TrackingCategories": []
+                                }
+                              ]
+                            }
+                          ]
+                        }'
   /LinkedTransactions:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
@@ -22617,6 +22681,15 @@ components:
       schema:
         type: string
         format: uuid
+    JournalNumber:
+      required: true
+      in: path
+      name: JournalNumber
+      x-snake: journal_number
+      description: Number of a Journal
+      example: 1000
+      schema:
+        type: integer
     LinkedTransactionID:
       required: true
       in: path

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Xero Accounting API
-  version: "2.21.0"
+  version: "2.22.0"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:
     name: "Xero Platform Team"

--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.21.0"
+  version: "2.22.0"
   title: Xero Assets API
   description: The Assets API exposes fixed asset related functions of the Xero Accounting application and can be used for a variety of purposes such as creating assets, retrieving asset valuations etc.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.21.0"
+  version: "2.22.0"
   title: Xero Bank Feeds API
   description: The Bank Feeds API is a closed API that is only available to financial institutions that have an established financial services partnership with Xero.
                If you're an existing financial services partner that wants access, contact your local Partner Manager.

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -4,7 +4,7 @@ servers:
     url: https://api.xero.com/files.xro/1.0/
 info:
   title: Xero Files API
-  version: "2.21.0"
+  version: "2.22.0"
   description: "These endpoints are specific to Xero Files API"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:


### PR DESCRIPTION
Resolves XeroAPI/Xero-OpenAPI#484

This did at least successfully generate into java with the command:
```sh
docker run --rm -v $PWD:/local openapitools/openapi-generator-cli:v4.2.0 generate -i /local/xero_accounting.yaml -g java -o /local/out/java
```
it seems having multiple paths that differ only in their parameter types is accepted by the generator so long as they have different `operationId` fields?