### PR TITLE
Add Paid Parental Leave and Workers Compensation to earnings types

### DIFF
--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -4838,6 +4838,8 @@ components:
       - LUMPSUME
       - LUMPSUMW
       - DIRECTORSFEES
+      - PAIDPARENTALLEAVE
+      - WORKERSCOMPENSATION
     EmploymentTerminationPaymentType: 
       type: string
       enum:


### PR DESCRIPTION
Add `Paid Parental Leave` and `Workers Compensation` earnings types to the payroll AU SDK in preparation for the implementation in the API itself.

## Description
Add EarningsType enum value `PAIDPARENTALLEAVE` and `WORKERSCOMPENSATION` to the Payroll AU SDK spec

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
