### PR TITLE
Add paid leave categorization support for AU payroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+
+# JetBrains generated files
+.idea

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -4821,6 +4821,23 @@ components:
           description: The type of units as specified by the LeaveType (see PayItems)
           type: string
           example: Hours
+    LeaveCategoryCode:
+      description: Code used to identify the Leave Category
+      type: string
+      enum:
+        - ANNUALLEAVE
+        - LONGSERVICELEAVE
+        - PERSONALCARERSLEAVE
+        - ROSTEREDDAYOFF
+        - TIMEOFFINLIEU
+        - COMPASSIONATEANDBEREAVEMENTLEAVE
+        - STUDYLEAVE
+        - FAMILYANDDOMESTICVIOLENCELEAVE
+        - SPECIALPAIDLEAVE
+        - COMMUNITYSERVICELEAVE
+        - JURYDUTYLEAVE
+        - DEFENCERESERVELEAVE
+      example: ANNUALLEAVE
     RateType:
       type: string
       enum:

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -3211,91 +3211,6 @@ paths:
                             ]
                         }
                       ]'
-  /TypesAndCodes/LeaveCategories:
-    parameters:
-      - $ref: '#/components/parameters/requiredHeader'
-    get:
-      security:
-        - OAuth2: [payroll.settings, payroll.settings.read]
-      tags:
-        - PayrollAu
-      operationId: getLeaveCategories
-      summary: Retrieves all active AU paid leave categories
-      responses:
-        '200':
-          description: List of leave category objects
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LeaveCategories'
-              example: '{
-                          "Id": "00000000-0000-0000-0000-000000000000",
-                          "Status": "OK",
-                          "ProviderName": "Payroll API Test Client",
-                          "DateTimeUTC": "/Date(1660514293596)/",
-                          "LeaveCategories": [
-                              {
-                                  "LeaveCategoryCode": "ANNUALLEAVE",
-                                  "CanBeSGCExempt": false,
-                                  "Name": "Annual Leave"
-                              },
-                              {
-                                  "LeaveCategoryCode": "LONGSERVICELEAVE",
-                                  "CanBeSGCExempt": false,
-                                  "Name": "Long Service Leave"
-                              },
-                              {
-                                  "LeaveCategoryCode": "PERSONALCARERSLEAVE",
-                                  "CanBeSGCExempt": false,
-                                  "Name": "Personal/Carer’s Leave"
-                              },
-                              {
-                                  "LeaveCategoryCode": "ROSTEREDDAYOFF",
-                                  "CanBeSGCExempt": false,
-                                  "Name": "Rostered Day Off"
-                              },
-                              {
-                                  "LeaveCategoryCode": "TIMEOFFINLIEU",
-                                  "CanBeSGCExempt": false,
-                                  "Name": "Time Off In Lieu"
-                              },
-                              {
-                                  "LeaveCategoryCode": "COMPASSIONATEANDBEREAVEMENTLEAVE",
-                                  "CanBeSGCExempt": false,
-                                  "Name": "Compassionate and Bereavement Leave"
-                              },
-                              {
-                                  "LeaveCategoryCode": "STUDYLEAVE",
-                                  "CanBeSGCExempt": false,
-                                  "Name": "Study Leave"
-                              },
-                              {
-                                  "LeaveCategoryCode": "FAMILYANDDOMESTICVIOLENCELEAVE",
-                                  "CanBeSGCExempt": false,
-                                  "Name": "Family and Domestic Violence Leave"
-                              },
-                              {
-                                  "LeaveCategoryCode": "SPECIALPAIDLEAVE",
-                                  "CanBeSGCExempt": false,
-                                  "Name": "Special Paid Leave"
-                              },
-                              {
-                                  "LeaveCategoryCode": "COMMUNITYSERVICELEAVE",
-                                  "CanBeSGCExempt": true,
-                                  "Name": "Community Service Leave"
-                              },
-                              {
-                                  "LeaveCategoryCode": "JURYDUTYLEAVE",
-                                  "CanBeSGCExempt": true,
-                                  "Name": "Jury Duty Leave"
-                              },
-                              {
-                                  "LeaveCategoryCode": "DEFENCERESERVELEAVE",
-                                  "CanBeSGCExempt": true,
-                                  "Name": "Defence Reserve Leave"
-                              }
-                          ]
-                      }'
 components:
   securitySchemes:
     OAuth2:
@@ -4912,27 +4827,6 @@ components:
           description: The type of units as specified by the LeaveType (see PayItems)
           type: string
           example: Hours
-    LeaveCategories:
-      type: object
-      x-isObjectArray: true
-      description: All active AU paid leave categories
-      properties:
-        LeaveCategories:
-          type: array
-          items:
-            $ref: '#/components/schemas/LeaveCategory'
-    LeaveCategory:
-      type: object
-      properties:
-        Name:
-          description: A descriptive name for the Leave Category
-          type: string
-        LeaveCategoryCode:
-          $ref: '#/components/schemas/LeaveCategoryCode'
-        CanBeSGCExempt:
-          description: Indicates whether the Leave Category supports superannuation guarantee contribution exemption
-          type: boolean
-          example: false
     LeaveCategoryCode:
       description: Code used to identify the Leave Category
       type: string

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -3292,7 +3292,7 @@ components:
           type: string
           example: developer@me.com
         Gender:
-          description: The employee’s gender. See Employee Gender
+          description: The employee’s gender. See Employee Gender
           type: string
           enum:
           - N

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -4821,6 +4821,15 @@ components:
           description: The type of units as specified by the LeaveType (see PayItems)
           type: string
           example: Hours
+    LeaveCategories:
+      type: object
+      x-isObjectArray: true
+      description: All active AU paid leave categories
+      properties:
+        LeaveCategories:
+          type: array
+          items:
+            $ref: '#/components/schemas/LeaveCategory'
     LeaveCategory:
       type: object
       properties:

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -3296,12 +3296,6 @@ paths:
                               }
                           ]
                       }'
-        '400':
-          description: validation error for a bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIException'
 components:
   securitySchemes:
     OAuth2:

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -4392,6 +4392,12 @@ components:
           description: Is the current record
           type: boolean
           example: true
+        LeaveCategoryCode:
+          $ref: '#/components/schemas/LeaveCategoryCode'
+        SGCExempt:
+          description: Set this to indicate that the leave type is exempt from superannuation guarantee contribution
+          type: boolean
+          example: true
     ReimbursementType:
       type: object
       properties:

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -4821,6 +4821,18 @@ components:
           description: The type of units as specified by the LeaveType (see PayItems)
           type: string
           example: Hours
+    LeaveCategory:
+      type: object
+      properties:
+        Name:
+          description: A descriptive name for the Leave Category
+          type: string
+        LeaveCategoryCode:
+          $ref: '#/components/schemas/LeaveCategoryCode'
+        CanBeSGCExempt:
+          description: Indicates whether the Leave Category supports superannuation guarantee contribution exemption
+          type: boolean
+          example: false
     LeaveCategoryCode:
       description: Code used to identify the Leave Category
       type: string

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -3211,6 +3211,97 @@ paths:
                             ]
                         }
                       ]'
+  /TypesAndCodes/LeaveCategories:
+    parameters:
+      - $ref: '#/components/parameters/requiredHeader'
+    get:
+      security:
+        - OAuth2: [payroll.settings, payroll.settings.read]
+      tags:
+        - PayrollAu
+      operationId: getLeaveCategories
+      summary: Retrieves all active AU paid leave categories
+      responses:
+        '200':
+          description: List of leave category objects
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LeaveCategories'
+              example: '{
+                          "Id": "00000000-0000-0000-0000-000000000000",
+                          "Status": "OK",
+                          "ProviderName": "Payroll API Test Client",
+                          "DateTimeUTC": "/Date(1660514293596)/",
+                          "LeaveCategories": [
+                              {
+                                  "LeaveCategoryCode": "ANNUALLEAVE",
+                                  "CanBeSGCExempt": false,
+                                  "Name": "Annual Leave"
+                              },
+                              {
+                                  "LeaveCategoryCode": "LONGSERVICELEAVE",
+                                  "CanBeSGCExempt": false,
+                                  "Name": "Long Service Leave"
+                              },
+                              {
+                                  "LeaveCategoryCode": "PERSONALCARERSLEAVE",
+                                  "CanBeSGCExempt": false,
+                                  "Name": "Personal/Carer’s Leave"
+                              },
+                              {
+                                  "LeaveCategoryCode": "ROSTEREDDAYOFF",
+                                  "CanBeSGCExempt": false,
+                                  "Name": "Rostered Day Off"
+                              },
+                              {
+                                  "LeaveCategoryCode": "TIMEOFFINLIEU",
+                                  "CanBeSGCExempt": false,
+                                  "Name": "Time Off In Lieu"
+                              },
+                              {
+                                  "LeaveCategoryCode": "COMPASSIONATEANDBEREAVEMENTLEAVE",
+                                  "CanBeSGCExempt": false,
+                                  "Name": "Compassionate and Bereavement Leave"
+                              },
+                              {
+                                  "LeaveCategoryCode": "STUDYLEAVE",
+                                  "CanBeSGCExempt": false,
+                                  "Name": "Study Leave"
+                              },
+                              {
+                                  "LeaveCategoryCode": "FAMILYANDDOMESTICVIOLENCELEAVE",
+                                  "CanBeSGCExempt": false,
+                                  "Name": "Family and Domestic Violence Leave"
+                              },
+                              {
+                                  "LeaveCategoryCode": "SPECIALPAIDLEAVE",
+                                  "CanBeSGCExempt": false,
+                                  "Name": "Special Paid Leave"
+                              },
+                              {
+                                  "LeaveCategoryCode": "COMMUNITYSERVICELEAVE",
+                                  "CanBeSGCExempt": true,
+                                  "Name": "Community Service Leave"
+                              },
+                              {
+                                  "LeaveCategoryCode": "JURYDUTYLEAVE",
+                                  "CanBeSGCExempt": true,
+                                  "Name": "Jury Duty Leave"
+                              },
+                              {
+                                  "LeaveCategoryCode": "DEFENCERESERVELEAVE",
+                                  "CanBeSGCExempt": true,
+                                  "Name": "Defence Reserve Leave"
+                              }
+                          ]
+                      }'
+        '400':
+          description: validation error for a bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIException'
 components:
   securitySchemes:
     OAuth2:


### PR DESCRIPTION
Update the AU payroll config to allow support for paid leave categorization. This includes adding two new properties to the `LeaveType` object.

_Abbreviations_

- STP: Single Touch Payroll
- SGC: Superannuation Guarantee Contribution

## Description

Additions to `xero-payroll-au.yaml`:

- Add new properties to the `LeaveType` object: `LeaveCategoryCode` and `SGCExempt` (See [docs](https://developer.xero.com/documentation/api/payrollau/payitems#get-payitems--elements-for-leavetypes))
- Add new schema definitions:
  - `LeaveCategoryCode` enum 

## Release Notes
- API consumers will need to categorize all leave pay items as part of STP phase 2. The leave category code will be used to determine which category a new leave pay item will be filed as.
- There are different rules for pay items created with these leave categories, some cannot be SGC exempt

## Screenshots (if appropriate):

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
