### PR TITLE
Add missing report tax type codes

### DIFF
--- a/xero-app-store.yaml
+++ b/xero-app-store.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.28.1"
+  version: "2.29.0"
   title: Xero AppStore API
   description: These endpoints are for Xero Partners to interact with the App Store Billing platform
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.28.1"
+  version: "2.29.0"
   title: Xero Finance API
   description: The Finance API is a collection of endpoints which customers can use in the course of a loan application, which may assist lenders to gain the confidence they need to provide capital.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.28.1"
+  version: "2.29.0"
   title: Xero OAuth 2 Identity Service API
   description: These endpoints are related to managing authentication tokens and identity for Xero API
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.28.1'
+  version: '2.29.0'
   title: 'Xero Payroll AU API'
   description: 'This is the Xero Payroll API for orgs in Australia region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.28.1'
+  version: '2.29.0'
   title: 'Xero Payroll NZ'
   description: 'This is the Xero Payroll API for orgs in the NZ region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.28.1'
+  version: '2.29.0'
   title: 'Xero Payroll UK'
   description: 'This is the Xero Payroll API for orgs in the UK region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.28.1"
+  version: "2.29.0"
   title: Xero Projects API
   description: This is the Xero Projects API 
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Xero Accounting API
-  version: "2.28.1"
+  version: "2.29.0"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:
     name: "Xero Platform Team"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -28179,6 +28179,13 @@ components:
           - TXRCREINPUT
           - TXRCESSINPUT
           - TXRCTSINPUT
+          - CAPEXINPUT
+          - UNDEFINED
+          - CAPEXOUTPUT
+          - ZEROEXPOUTPUT
+          - GOODSIMPORT
+          - NONEINPUT
+          - NOTREPORTED
         CanApplyToAssets:
           description: Boolean to describe if tax rate can be used for asset accounts i.e.  true,false
           readOnly: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23640,8 +23640,7 @@ components:
           $ref: '#/components/schemas/CurrencyCode'
           type: string
         TaxType:
-          description: The tax type from TaxRates
-          $ref: '#/components/schemas/TaxType'
+          description: The tax type from taxRates
           type: string
         EnablePaymentsToAccount:
           description: Boolean – describes whether account can have payments applied to it
@@ -23949,7 +23948,6 @@ components:
           example: "00000000-0000-0000-0000-000000000000"
         TaxType:
           description: The tax type from TaxRates
-          $ref: '#/components/schemas/TaxType'
           type: string
         TaxAmount:
           description: The tax amount is auto calculated as a percentage of the line amount (see below) based on the tax rate. This value can be overriden if
@@ -25810,7 +25808,6 @@ components:
           type: string
         TaxType:
           description: The tax type from TaxRates
-          $ref: '#/components/schemas/TaxType'
           type: string
       type: object
     Journals:
@@ -25934,8 +25931,7 @@ components:
           readOnly: true
           example: 0.00
         TaxType:
-          description: The tax type from TaxRates
-          $ref: '#/components/schemas/TaxType'
+          description: The tax type from taxRates
           type: string
         TaxName:
           description: see TaxRates
@@ -26129,7 +26125,6 @@ components:
           example: Coded incorrectly Office Equipment should be Computer Equipment
         TaxType:
           description: The tax type from TaxRates
-          $ref: '#/components/schemas/TaxType'
           type: string
         Tracking:
           description: Optional Tracking Category – see Tracking. Any JournalLine can have a maximum of 2 <TrackingCategory> elements.
@@ -28078,7 +28073,6 @@ components:
           type: string
         TaxType:
           description: The tax type
-          $ref: '#/components/schemas/TaxType'
           type: string
         TaxComponents:
           description: See TaxComponents

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23558,6 +23558,7 @@ components:
           type: string
         TaxType:
           description: The tax type from TaxRates
+          $ref: '#/components/schemas/TaxType'
           type: string
         EnablePaymentsToAccount:
           description: Boolean – describes whether account can have payments applied to it
@@ -23865,6 +23866,7 @@ components:
           example: "00000000-0000-0000-0000-000000000000"
         TaxType:
           description: The tax type from TaxRates
+          $ref: '#/components/schemas/TaxType'
           type: string
         TaxAmount:
           description: The tax amount is auto calculated as a percentage of the line amount (see below) based on the tax rate. This value can be overriden if
@@ -25725,6 +25727,7 @@ components:
           type: string
         TaxType:
           description: The tax type from TaxRates
+          $ref: '#/components/schemas/TaxType'
           type: string
       type: object
     Journals:
@@ -25849,6 +25852,7 @@ components:
           example: 0.00
         TaxType:
           description: The tax type from TaxRates
+          $ref: '#/components/schemas/TaxType'
           type: string
         TaxName:
           description: see TaxRates
@@ -26042,6 +26046,7 @@ components:
           example: Coded incorrectly Office Equipment should be Computer Equipment
         TaxType:
           description: The tax type from TaxRates
+          $ref: '#/components/schemas/TaxType'
           type: string
         Tracking:
           description: Optional Tracking Category – see Tracking. Any JournalLine can have a maximum of 2 <TrackingCategory> elements.
@@ -27989,6 +27994,7 @@ components:
           type: string
         TaxType:
           description: The tax type
+          $ref: '#/components/schemas/TaxType'
           type: string
         TaxComponents:
           description: See TaxComponents

--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.28.1"
+  version: "2.29.0"
   title: Xero Assets API
   description: The Assets API exposes fixed asset related functions of the Xero Accounting application and can be used for a variety of purposes such as creating assets, retrieving asset valuations etc.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.28.1"
+  version: "2.29.0"
   title: Xero Bank Feeds API
   description: The Bank Feeds API is a closed API that is only available to financial institutions that have an established financial services partnership with Xero.
                If you're an existing financial services partner that wants access, contact your local Partner Manager.

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -4,7 +4,7 @@ servers:
     url: https://api.xero.com/files.xro/1.0/
 info:
   title: Xero Files API
-  version: "2.28.1"
+  version: "2.29.0"
   description: "These endpoints are specific to Xero Files API"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:


### PR DESCRIPTION
## Description
- added missing report tax types to the enum (CAPEXINPUT, UNDEFINED, CAPEXOUTPUT, ZEROEXPOUTPUT, GOODSIMPORT, NONEINPUT, NOTREPORTED)

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves [Issue 430](https://github.com/XeroAPI/Xero-NetStandard/issues/430)

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
