### PR TITLE
[INVINP-10104] LineAmount wording change

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23958,10 +23958,8 @@ components:
         Item:
           $ref: '#/components/schemas/LineItemItem'
         LineAmount:
-          description: If you wish to omit either of the <Quantity> or <UnitAmount> you can provide a LineAmount and Xero will calculate the missing amount for
-            you. The line amount reflects the discounted price if a DiscountRate
-            has been used . i.e LineAmount = Quantity * Unit Amount * ((100 –
-            DiscountRate)/100)
+          description: If you wish to omit either the Quantity or UnitAmount you can provide a LineAmount and Xero will calculate the missing amount for
+            you. The line amount reflects the discounted price if either a DiscountRate or DiscountAmount has been used i.e. LineAmount = Quantity * Unit Amount * ((100 - DiscountRate)/100) or LineAmount = (Quantity * UnitAmount) - DiscountAmount
           type: number
           format: double
           x-is-money: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Slight change in wording on `LineItem` is needed to cater for `DiscountRate` as well as `DiscountAmount`. 
Goes with [this ](https://github.com/XeroAPI/Xero-OpenAPI/pull/518)PR, previously approved and merged
This change needs to be released on the **31st October**

## Release Notes
https://xero.atlassian.net/browse/INVINP-10104

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/93885337/198399635-c9b2a77a-0073-46f0-92b7-2216bfa6ede3.png)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
