### PR TITLE
AUP-8815: Update AU Payroll SDK allowance booleans

### DIFF
--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -1075,6 +1075,8 @@ paths:
                                 "IsExemptFromTax": true,
                                 "IsExemptFromSuper": true,
                                 "IsReportableAsW1": true,
+                                "AllowanceContributesToAnnualLeaveRate": false,
+                                "AllowanceContributesToOvertimeRate": false,
                                 "UpdatedDateUTC": "/Date(1573620821000+0000)/",
                                 "CurrentRecord": true
                               },
@@ -1088,6 +1090,8 @@ paths:
                                 "IsExemptFromTax": false,
                                 "IsExemptFromSuper": true,
                                 "IsReportableAsW1": false,
+                                "AllowanceContributesToAnnualLeaveRate": false,
+                                "AllowanceContributesToOvertimeRate": false,
                                 "UpdatedDateUTC": "/Date(1547500330000+0000)/",
                                 "CurrentRecord": true
                               },
@@ -1100,6 +1104,8 @@ paths:
                                 "IsExemptFromTax": true,
                                 "IsExemptFromSuper": true,
                                 "IsReportableAsW1": true,
+                                "AllowanceContributesToAnnualLeaveRate": false,
+                                "AllowanceContributesToOvertimeRate": false,
                                 "UpdatedDateUTC": "/Date(1547500330000+0000)/",
                                 "CurrentRecord": true
                               },
@@ -1113,6 +1119,8 @@ paths:
                                 "IsExemptFromTax": false,
                                 "IsExemptFromSuper": true,
                                 "IsReportableAsW1": true,
+                                "AllowanceContributesToAnnualLeaveRate": false,
+                                "AllowanceContributesToOvertimeRate": false,
                                 "UpdatedDateUTC": "/Date(1573620791000+0000)/",
                                 "EmploymentTerminationPaymentType": "O",
                                 "CurrentRecord": true
@@ -1464,6 +1472,8 @@ paths:
                                 "IsExemptFromSuper": true,
                                 "AccrueLeave": false,
                                 "IsReportableAsW1": false,
+                                "AllowanceContributesToAnnualLeaveRate": false,
+                                "AllowanceContributesToOvertimeRate": false,
                                 "UpdatedDateUTC": "/Date(1593448963210+0000)/",
                                 "CurrentRecord": true
                               },
@@ -1476,6 +1486,8 @@ paths:
                                 "IsExemptFromTax": true,
                                 "IsExemptFromSuper": true,
                                 "IsReportableAsW1": true,
+                                "AllowanceContributesToAnnualLeaveRate": false,
+                                "AllowanceContributesToOvertimeRate": false,
                                 "UpdatedDateUTC": "/Date(1476729649000+0000)/",
                                 "CurrentRecord": true
                               },
@@ -1489,6 +1501,8 @@ paths:
                                 "IsExemptFromTax": false,
                                 "IsExemptFromSuper": true,
                                 "IsReportableAsW1": true,
+                                "AllowanceContributesToAnnualLeaveRate": false,
+                                "AllowanceContributesToOvertimeRate": false,
                                 "UpdatedDateUTC": "/Date(1520900705000+0000)/",
                                 "EmploymentTerminationPaymentType": "O",
                                 "CurrentRecord": true
@@ -1513,6 +1527,8 @@ paths:
                             "IsExemptFromTax": true,
                             "IsExemptFromSuper": true,
                             "IsReportableAsW1": false,
+                            "AllowanceContributesToAnnualLeaveRate": false,
+                            "AllowanceContributesToOvertimeRate": false,
                             "EarningsType": "ORDINARYTIMEEARNINGS",
                             "EarningsRateID": "1fa4e226-b711-46ba-a8a7-4344c9c5fb87",
                             "RateType": "MULTIPLE",
@@ -4272,6 +4288,14 @@ components:
           example: false
         IsReportableAsW1:
           description: Boolean to determine if the earnings rate is reportable or exempt from W1
+          type: boolean
+          example: false
+        AllowanceContributesToAnnualLeaveRate:
+          description: Boolean to determine if the allowance earnings rate contributes towards annual leave rate. Only applicable if EarningsType is ALLOWANCE and RateType is RATEPERUNIT
+          type: boolean
+          example: false
+        AllowanceContributesToOvertimeRate:
+          description: Boolean to determine if the allowance earnings rate contributes towards overtime allowance rate. Only applicable if EarningsType is ALLOWANCE and RateType is RATEPERUNIT
           type: boolean
           example: false
         EarningsType:


### PR DESCRIPTION
Adding AllowanceContributesToAnnualLeaveRate, AllowanceContributesToOvertimeRate booleans for pay items

As part of STP2, two new checkboxes were added for allowance pay items - https://xero.atlassian.net/browse/AUP-8603.

## Description
- Jira: https://xero.atlassian.net/browse/AUP-8815
- Adding AllowanceContributesToAnnualLeaveRate and AllowanceContributesToOvertimeRate booleans to the Payroll AU SDK spec

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
