### PR TITLE
Add cashed out leave support for AU Payroll

### DIFF
--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -3490,11 +3490,7 @@ components:
           type: string
           example: My leave
         PayOutType:
-          description: How the requested leave will be paid out, e.g. cashed out.
-          type: string
-          enum:
-            - DEFAULT
-            - CASHED_OUT
+          $ref: '#/components/schemas/PayOutType'
         LeavePeriods:
           type: array
           items:
@@ -3510,6 +3506,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ValidationError'
+    PayOutType:
+      description: How the requested leave will be paid out, e.g. cashed out.
+      type: string
+      enum:
+        - DEFAULT
+        - CASHED_OUT
     LeavePeriod:
       type: object
       properties:
@@ -4116,11 +4118,7 @@ components:
           x-is-money: true
           example: 2.5
         PayOutType:
-          description: Indicates the type of payout the leave earnings line represents, e.g. whether it was cashed out.
-          type: string
-          enum:
-            - DEFAULT
-            - CASHED_OUT
+          $ref: '#/components/schemas/PayOutType'
     SettingsObject:
       type: object
       properties:

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -4083,6 +4083,12 @@ components:
           format: double
           x-is-money: true
           example: 2.5
+        PayOutType:
+          description: Indicates the type of payout the leave earnings line represents, e.g. whether it was cashed out.
+          type: string
+          enum:
+            - DEFAULT
+            - CASHED_OUT
     SettingsObject:
       type: object
       properties:

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -629,7 +629,26 @@ paths:
                               "Title": "vacation",
                               "StartDate": "/Date(1573516800000+0000)/",
                               "EndDate": "/Date(1573516800000+0000)/",
+                              "UpdatedDateUTC": "/Date(1573623008000+0000)/",
+                              "PayOutType": "DEFAULT"
+                            },
+                            {
+                              "LeaveApplicationID": "3b934902-1e16-4c02-a3d3-68fa7d63e01d",
+                              "EmployeeID": "cdfb8371-0b21-4b8a-8903-1024df6c391e",
+                              "LeaveTypeID": "184ea8f7-d143-46dd-bef3-0c60e1aa6fca",
+                              "LeavePeriods": [
+                                {
+                                  "PayPeriodStartDate": "/Date(1573171200000+0000)/",
+                                  "PayPeriodEndDate": "/Date(1573689600000+0000)/",
+                                  "LeavePeriodStatus": "SCHEDULED",
+                                  "NumberOfUnits": 8
+                                }
+                              ],
+                              "Title": "Cashed Out",
+                              "StartDate": "/Date(1573516800000+0000)/",
+                              "EndDate": "/Date(1573516800000+0000)/",
                               "UpdatedDateUTC": "/Date(1573623008000+0000)/"
+                              "PayOutType": " CASHED_OUT"
                             },
                             {
                               "LeaveApplicationID": "62b90465-66e9-4c3a-8151-de1e6335554d",
@@ -653,7 +672,8 @@ paths:
                               "Description": "My updated Description",
                               "StartDate": "/Date(1572559200000+0000)/",
                               "EndDate": "/Date(1572645600000+0000)/",
-                              "UpdatedDateUTC": "/Date(1573447344000+0000)/"
+                              "UpdatedDateUTC": "/Date(1573447344000+0000)/",
+                              "PayOutType": "DEFAULT"
                             },
                             {
                               "LeaveApplicationID": "e8bd9eeb-18c9-4475-9c81-b298f9aa26c0",
@@ -676,7 +696,8 @@ paths:
                               "Title": "Hello World",
                               "StartDate": "/Date(1572559200000+0000)/",
                               "EndDate": "/Date(1572645600000+0000)/",
-                              "UpdatedDateUTC": "/Date(1573447343000+0000)/"
+                              "UpdatedDateUTC": "/Date(1573447343000+0000)/",
+                              "PayOutType": "DEFAULT"
                             }
                           ]
                         }'
@@ -796,7 +817,8 @@ paths:
                               "Title": "Hello World",
                               "StartDate": "/Date(1572559200000+0000)/",
                               "EndDate": "/Date(1572645600000+0000)/",
-                              "UpdatedDateUTC": "/Date(1573679791897+0000)/"
+                              "UpdatedDateUTC": "/Date(1573679791897+0000)/",
+                              "PayOutType": "DEFAULT"
                             }
                           ]
                         }'
@@ -867,7 +889,8 @@ paths:
                               "Title": "vacation",
                               "StartDate": "/Date(1573516800000+0000)/",
                               "EndDate": "/Date(1573516800000+0000)/",
-                              "UpdatedDateUTC": "/Date(1573623008000+0000)/"
+                              "UpdatedDateUTC": "/Date(1573623008000+0000)/",
+                              "PayOutType": "DEFAULT"
                             }
                           ]
                         }'
@@ -991,7 +1014,8 @@ paths:
                             "Description": "My updated Description",
                             "StartDate": "/Date(1572559200000+0000)/",
                             "EndDate": "/Date(1572645600000+0000)/",
-                            "UpdatedDateUTC": "/Date(1573679792293+0000)/"
+                            "UpdatedDateUTC": "/Date(1573679792293+0000)/",
+                            "PayOutType": "DEFAULT"
                           }
                         ]
                       }'
@@ -2125,12 +2149,14 @@ paths:
                               {
                                 "EarningsRateID": "ab874dfb-ab09-4c91-954e-43acf6fc23b4",
                                 "RatePerUnit": 0,
-                                "NumberOfUnits": 0.6
+                                "NumberOfUnits": 0.6,
+                                "PayOutType": "DEFAULT"
                               },
                               {
                                 "EarningsRateID": "ab874dfb-ab09-4c91-954e-43acf6fc23b4",
-                                "RatePerUnit": 0,
-                                "NumberOfUnits": 0.6
+                                "RatePerUnit": 3,
+                                "NumberOfUnits": 0.6,
+                                "PayOutType": "CASHED_OUT"
                               }
                             ],
                             "TimesheetEarningsLines": [],

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -3463,6 +3463,12 @@ components:
           description: The Description of the Leave
           type: string
           example: My leave
+        PayOutType:
+          description: How the requested leave will be paid out, e.g. cashed out.
+          type: string
+          enum:
+            - DEFAULT
+            - CASHED_OUT
         LeavePeriods:
           type: array
           items:


### PR DESCRIPTION
Update the AU Payroll configuration to allow support for Cashed Out Leave.
This includes adding a new property to both the `LeaveApplication` object for leave requests, and `LeaveEarningsLine` object for pay slip identification.

## Description
Additions to `xero-payroll-au.yaml`:

Add new property `PayOutType` to the `LeaveApplication` object.
Add an equivalent property to the `LeaveEarningsLine` object.

## Release Notes
API users need to be able to create Cashed Out Leave applications, and also to be able to tell which lines on the employee payslip corresponds to cashed out leave.

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
