### PR TITLE
update createbrandingthemepaymentservices method and bump version

### DIFF
--- a/xero-app-store.yaml
+++ b/xero-app-store.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.32.0"
+  version: "2.33.0"
   title: Xero AppStore API
   description: These endpoints are for Xero Partners to interact with the App Store Billing platform
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.32.0"
+  version: "2.33.0"
   title: Xero Finance API
   description: The Finance API is a collection of endpoints which customers can use in the course of a loan application, which may assist lenders to gain the confidence they need to provide capital.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.32.0"
+  version: "2.33.0"
   title: Xero OAuth 2 Identity Service API
   description: These endpoints are related to managing authentication tokens and identity for Xero API
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.32.0'
+  version: '2.33.0'
   title: 'Xero Payroll AU API'
   description: 'This is the Xero Payroll API for orgs in Australia region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.32.0'
+  version: '2.33.0'
   title: 'Xero Payroll NZ'
   description: 'This is the Xero Payroll API for orgs in the NZ region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.32.0'
+  version: '2.33.0'
   title: 'Xero Payroll UK'
   description: 'This is the Xero Payroll API for orgs in the UK region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.32.0"
+  version: "2.33.0"
   title: Xero Projects API
   description: This is the Xero Projects API 
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Xero Accounting API
-  version: "2.32.0"
+  version: "2.33.0"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:
     name: "Xero Platform Team"
@@ -3441,17 +3441,20 @@ paths:
           $ref: '#/components/responses/400Error'
       requestBody:
         required: true
-        description: PaymentService object in body of request
+        description: PaymentServices array with PaymentService object in body of request
         content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PaymentService'
-            example: '{  
-                        "PaymentServiceID": "00000000-0000-0000-0000-000000000000",
-                        "PaymentServiceName": "Payments Service",
-                        "PaymentServiceUrl": "https://www.paymentservice.com/",
-                        "PayNowText": "Pay Now"
-                      }'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentServices'
+              example: '{
+                          "PaymentServices": [
+                            {
+                              "PaymentServiceName": "PayUpNow",
+                              "PaymentServiceUrl": "https://www.payupnow.com/",
+                              "PayNowText": "Time To Pay"
+                            }
+                          ]
+                        }'
   '/Budgets':
     parameters:
       - $ref: '#/components/parameters/requiredHeader'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3461,8 +3461,10 @@ paths:
               example: '{
                           "PaymentServices": [
                             {
+                              "PaymentServiceID": "54b3b4f6-0443-4fba-bcd1-61ec0c35ca55",
                               "PaymentServiceName": "PayUpNow",
                               "PaymentServiceUrl": "https://www.payupnow.com/",
+                              "PaymentServiceType": "Custom",
                               "PayNowText": "Time To Pay"
                             }
                           ]

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -3413,6 +3413,18 @@ paths:
           keySnake: pay_now_text
           default: Pay Now
           object: paymentService
+        - paymentServices:
+          is_object: true
+          key: paymentServices
+          keyPascal: PaymentServices
+        - add_paymentService:
+          is_last: true
+          is_array_add: true
+          key: paymentServices
+          keyPascal: PaymentServices
+          java: PaymentServices
+          csharp: PaymentService
+          object: paymentService
       parameters:
         - $ref: '#/components/parameters/BrandingThemeID'
       responses:

--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.32.0"
+  version: "2.33.0"
   title: Xero Assets API
   description: The Assets API exposes fixed asset related functions of the Xero Accounting application and can be used for a variety of purposes such as creating assets, retrieving asset valuations etc.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.32.0"
+  version: "2.33.0"
   title: Xero Bank Feeds API
   description: The Bank Feeds API is a closed API that is only available to financial institutions that have an established financial services partnership with Xero.
                If you're an existing financial services partner that wants access, contact your local Partner Manager.

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -4,7 +4,7 @@ servers:
     url: https://api.xero.com/files.xro/1.0/
 info:
   title: Xero Files API
-  version: "2.32.0"
+  version: "2.33.0"
   description: "These endpoints are specific to Xero Files API"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates `CreateBrandingThemePaymentServices` method to accept an array of `PaymentService` objects instead of just one `PaymentService` object to match API functionality

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves [Xero-Node #605](https://github.com/XeroAPI/xero-node/issues/605)

This will result in a small breaking change where any projects currently using this method will need to wrap their `PaymentService` object in a `PaymentServices` object like so:

`
{
                          "PaymentServices": [
                            {
                              "PaymentServiceID": "54b3b4f6-0443-4fba-bcd1-61ec0c35ca55",
                              "PaymentServiceName": "PayUpNow",
                              "PaymentServiceUrl": "https://www.payupnow.com/",
                              "PaymentServiceType": "Custom",
                              "PayNowText": "Time To Pay"
                            }
                          ]
                        }
`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
