### PR TITLE
add x-is-datetime tag so Java SDK will use LocalDatetime

### DIFF
--- a/xero-app-store.yaml
+++ b/xero-app-store.yaml
@@ -287,10 +287,12 @@ components:
             End of the current period that the subscription has been invoiced for.
           format: date-time
           type: string
+          x-is-datetime: true
         endDate:
           description: If the subscription has been canceled, this is the date when the subscription ends. If null, the subscription is active and has not been cancelled
           format: date-time
           type: string
+          x-is-datetime: true
         id:
           description: The unique identifier of the subscription
           format: uuid
@@ -308,6 +310,7 @@ components:
           description: Date when the subscription was first created.
           format: date-time
           type: string
+          x-is-datetime: true
         status:
           description: Status of the subscription. Available statuses are ACTIVE, CANCELED, and PAST_DUE.
           type: string
@@ -399,6 +402,7 @@ components:
           description: Date when the subscription to this product will end
           format: date-time
           type: string
+          x-is-datetime: true
         id:
           description: The unique identifier of the subscription item.
           format: uuid
@@ -418,6 +422,7 @@ components:
             the future for downgrades or reduced number of seats that haven't taken effect yet.
           format: date-time
           type: string
+          x-is-datetime: true
         status:
           description: |
             Status of the subscription item. Available statuses are ACTIVE, CANCELED, and
@@ -483,6 +488,7 @@ components:
           description: The time when this usage was recorded in UTC
           format: date-time
           type: string
+          x-is-datetime: true
         usageRecordId:
           description: The unique identifier of the usageRecord.
           format: guid
@@ -528,6 +534,7 @@ components:
           description: DateTime in UTC of when the the product was consumed/used
           format: date-time
           type: string
+          x-is-datetime: true
       required:
         - quantity
         - timestamp


### PR DESCRIPTION
Add new vendor tag so Java SDK will properly parse date format
## Description
Xero-Java SDK is currently defaulting the date-time fields to DateTimeOffset. The App Store API actually returns dates in UTC with no offset. This vendor tag will change these fields to the correct type, LocalDateTime.

## Release Notes
This fixes a serialization issue in the Xero-Java SDK 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
