### PR TITLE
Set utc dates format to date

### DIFF
--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -801,11 +801,11 @@ components:
           example: 3615
         CreatedDateUtc:
           description: Created date in UTC
-          type: string
+          type: date
           example: '2020-12-03T19:04:58.6970000'
         UpdatedDateUtc:
           description: Updated date in UTC
-          type: string
+          type: date
           example: '2020-12-03T19:04:58.6970000'
         User:
           $ref: '#/components/schemas/User'

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -801,11 +801,13 @@ components:
           example: 3615
         CreatedDateUtc:
           description: Created date in UTC
-          type: date
+          type: string
+          format: date-time
           example: '2020-12-03T19:04:58.6970000'
         UpdatedDateUtc:
           description: Updated date in UTC
-          type: date
+          type: string
+          format: date-time
           example: '2020-12-03T19:04:58.6970000'
         User:
           $ref: '#/components/schemas/User'


### PR DESCRIPTION
## Files API
- Updated `CreatedDateUtc` and `UpdatedDateUtc` format from string to date, in `FileObject`

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Invalid data type for parameter, forcing users to manually parse to datetime 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
