### PR TITLE
Update xero_accounting.yaml

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -25009,6 +25009,7 @@ components:
         - CAD
         - CDF
         - CHF
+        - CLF
         - CLP
         - CNY
         - COP
@@ -25030,7 +25031,6 @@ components:
         - FKP
         - GBP
         - GEL
-        - GGP
         - GHS
         - GIP
         - GMD
@@ -25044,12 +25044,10 @@ components:
         - HUF
         - IDR
         - ILS
-        - IMP
         - INR
         - IQD
         - IRR
         - ISK
-        - JEP
         - JMD
         - JOD
         - JPY
@@ -25112,11 +25110,13 @@ components:
         - SEK
         - SGD
         - SHP
+        - SKK
+        - SLE
         - SLL
         - SOS
-        - SPL
         - SRD
         - STN
+        - STD
         - SVC
         - SYP
         - SZL
@@ -25127,7 +25127,6 @@ components:
         - TOP
         - TRY_LIRA
         - TTD
-        - TVD
         - TWD
         - TZS
         - UAH
@@ -25136,12 +25135,12 @@ components:
         - UYU
         - UZS
         - VEF
+        - VES
         - VND
         - VUV
         - WST
         - XAF
         - XCD
-        - XDR
         - XOF
         - XPF
         - YER
@@ -25180,6 +25179,7 @@ components:
         - CAD
         - CDF
         - CHF
+        - CLF
         - CLP
         - CNY
         - COP
@@ -25201,7 +25201,6 @@ components:
         - FKP
         - GBP
         - GEL
-        - GGP
         - GHS
         - GIP
         - GMD
@@ -25215,12 +25214,10 @@ components:
         - HUF
         - IDR
         - ILS
-        - IMP
         - INR
         - IQD
         - IRR
         - ISK
-        - JEP
         - JMD
         - JOD
         - JPY
@@ -25283,10 +25280,12 @@ components:
         - SEK
         - SGD
         - SHP
+        - SKK
+        - SLE
         - SLL
         - SOS
-        - SPL
         - SRD
+        - STD
         - STN
         - SVC
         - SYP
@@ -25298,7 +25297,6 @@ components:
         - TOP
         - TRY
         - TTD
-        - TVD
         - TWD
         - TZS
         - UAH
@@ -25307,12 +25305,12 @@ components:
         - UYU
         - UZS
         - VEF
+        - VES
         - VND
         - VUV
         - WST
         - XAF
         - XCD
-        - XDR
         - XOF
         - XPF
         - YER

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -25021,6 +25021,7 @@ components:
         - DKK
         - DOP
         - DZD
+        - EEK
         - EGP
         - ERN
         - ETB
@@ -25067,6 +25068,7 @@ components:
         - LRD
         - LSL
         - LTL
+        - LVL
         - LYD
         - MAD
         - MDL
@@ -25075,11 +25077,13 @@ components:
         - MMK
         - MNT
         - MOP
+        - MRO
         - MRU
         - MUR
         - MVR
         - MWK
         - MXN
+        - MXV
         - MYR
         - MZN
         - NAD
@@ -25188,6 +25192,7 @@ components:
         - DKK
         - DOP
         - DZD
+        - EEK
         - EGP
         - ERN
         - ETB
@@ -25234,6 +25239,7 @@ components:
         - LRD
         - LSL
         - LTL
+        - LVL
         - LYD
         - MAD
         - MDL
@@ -25242,11 +25248,13 @@ components:
         - MMK
         - MNT
         - MOP
+        - MRO
         - MRU
         - MUR
         - MVR
         - MWK
         - MXN
+        - MXV
         - MYR
         - MZN
         - NAD


### PR DESCRIPTION
Update xero_accounting.yaml to add in missing Estonian EEK currency code. 
## Description
Added all missing currency codes EEK, LVL, MRO, MXV to enum in xero_accounting.yaml

## Release Notes
Fixes issue raised in xero-ruby [#250](https://github.com/XeroAPI/xero-ruby/issues/250)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
