### PR TITLE
Update xero_accounting.yaml

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -15396,7 +15396,7 @@ paths:
         - OAuth2: [accounting.attachments, accounting.attachments.read]
       tags:
         - Accounting
-      operationId: getPurchaseOrder≠AttachmentByFileName
+      operationId: getPurchaseOrderAttachmentByFileName
       summary: Retrieves a specific attachment for a specific purchase order by filename
       parameters:
         - $ref: '#/components/parameters/PurchaseOrderID'


### PR DESCRIPTION
## Description
`getPurchaseOrderAttachmentByFileName` contained an odd character (`≠`) in the name.
Probably a typo, so this PR just removes this character.

## Release Notes
Some code generators (e.g. [NSwag](https://github.com/RicoSuter/NSwag)) use the tag to create a name for the method.
This character causes compile errors.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
