### PR TITLE
[APIB-4282] OpenAPI spec has paging info for Associations/objectid

### DIFF
--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -506,6 +506,29 @@ paths:
             type: string
             format: uuid
             example: 4ff1e5cc-9835-40d5-bb18-09fdb118db9c
+        - in: query
+          name: pagesize
+          description: pass an optional page size value
+          schema:
+            type: integer
+            maximum: 100
+            example: 50
+        - in: query
+          name: page
+          description: number of records to skip for pagination
+          schema:
+            type: integer
+            minimum: 1
+            example: 2
+        - in: query
+          name: sort
+          description: values to sort by
+          schema:
+            type: string
+            enum:
+              - Name
+              - CreatedDateUTC
+            example: "CreatedDateUTC DESC"
       responses:
         '200':
           description: search results matching criteria

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -528,7 +528,16 @@ paths:
             enum:
               - Name
               - CreatedDateUTC
-            example: "CreatedDateUTC DESC"
+            example: "Associations/{ObjectId}?sort=CreatedDateUtc"
+        - in: query
+          name: direction
+          description: direction to sort by
+          schema:
+            type: string
+            enum:
+              - ASC
+              - DESC
+            example: "Associations/{ObjectId}?sort=CreatedDateUtc&direction=DESC"
       responses:
         '200':
           description: search results matching criteria


### PR DESCRIPTION
OpenAPI spec has paging info for Associations/objectid

## Description
Paging information has been added to the OpenAPI spec on the associations/{objectid} endpoint

## Release Notes
The endpoint was updated and the Open API spec needs to be updated to reflect the new functionality
https://xero.atlassian.net/browse/APIB-4282

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
