### PR TITLE
AUP-14336 Removing JobKeeper allowance type

### DIFF
--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -5327,7 +5327,6 @@ components:
       - MEALS
       - TRAVEL
       - OTHER
-      - JOBKEEPER
       - TOOLS
       - TASKS
       - QUALIFICATIONS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change is just to remove the `JOBKEEPER` value from our allowance type enum collection. This is because this item is now deprecated and should no longer be used by API consumers.

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
The JobKeeper allowance type was developed to be used within the period of time when the JobKeeper covid19 program was running. Now that the government program has ended, it is being removed from Xero. This change is to remove the allowance type from our API to prevent users of our API from using this now deprecated item.
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
