### PR TITLE
Added additional ReportTaxType - USSALESTAX

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -28564,6 +28564,7 @@ components:
           - IMN33
           - IMRE
           - BADDEBTRECOVERY
+          - USSALESTAX
         CanApplyToAssets:
           description: Boolean to describe if tax rate can be used for asset accounts i.e.  true,false
           readOnly: true


### PR DESCRIPTION
## Description
Added additional ReportTaxType used within the new Auto Sales Tax feature in the US edition of Xero

## Release Notes
New sales tax functionality for US Xero organisations has resulted in a new ReportTaxType to be used. 

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ x ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)