### PR TITLE
Remove empty enum values from specs

### DIFF
--- a/xero-app-store.yaml
+++ b/xero-app-store.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "2.40.3"
   title: Xero AppStore API
   description: These endpoints are for Xero Partners to interact with the App Store Billing platform
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-app-store.yaml
+++ b/xero-app-store.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "3.0.0"
   title: Xero AppStore API
   description: These endpoints are for Xero Partners to interact with the App Store Billing platform
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-app-store.yaml
+++ b/xero-app-store.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "3.0.0"
+  version: "2.40.2"
   title: Xero AppStore API
   description: These endpoints are for Xero Partners to interact with the App Store Billing platform
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "2.40.3"
   title: Xero Finance API
   description: The Finance API is a collection of endpoints which customers can use in the course of a loan application, which may assist lenders to gain the confidence they need to provide capital.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "3.0.0"
+  version: "2.40.2"
   title: Xero Finance API
   description: The Finance API is a collection of endpoints which customers can use in the course of a loan application, which may assist lenders to gain the confidence they need to provide capital.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "3.0.0"
   title: Xero Finance API
   description: The Finance API is a collection of endpoints which customers can use in the course of a loan application, which may assist lenders to gain the confidence they need to provide capital.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "3.0.0"
   title: Xero OAuth 2 Identity Service API
   description: These endpoints are related to managing authentication tokens and identity for Xero API
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "3.0.0"
+  version: "2.40.2"
   title: Xero OAuth 2 Identity Service API
   description: These endpoints are related to managing authentication tokens and identity for Xero API
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "2.40.3"
   title: Xero OAuth 2 Identity Service API
   description: These endpoints are related to managing authentication tokens and identity for Xero API
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "3.0.0"
+  version: '2.40.2'
   title: 'Xero Payroll AU API'
   description: 'This is the Xero Payroll API for orgs in Australia region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.40.2'
+  version: "2.40.3"
   title: 'Xero Payroll AU API'
   description: 'This is the Xero Payroll API for orgs in Australia region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -5370,7 +5370,6 @@ components:
       - FIXEDAMOUNTEACHPERIOD
       - ENTERRATEINPAYTEMPLATE
       - BASEDONORDINARYEARNINGS
-      - ""
     SuperannuationContributionType: 
       type: string
       enum:
@@ -5431,7 +5430,7 @@ components:
       - EMPLOYEE  
       - CONTRACTOR
     CountryOfResidence:
-      description: Country of residence as a valid ISO 3166-1 alpha-2 country code e.g. "AU", "NZ", "CA" or an empty string ("") to unset a previously set value. Only applicable, and mandatory if income type is WORKINGHOLIDAYMAKER.
+      description: Country of residence as a valid ISO 3166-1 alpha-2 country code e.g. "AU", "NZ", "CA". Only applicable, and mandatory if income type is WORKINGHOLIDAYMAKER.
       type: string
       example: "AU"
       enum:
@@ -5685,7 +5684,6 @@ components:
       - CW
       - SX
       - SS
-      - ""
     IncomeType: 
       type: string
       enum:

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.40.2'
+  version: "3.0.0"
   title: 'Xero Payroll AU API'
   description: 'This is the Xero Payroll API for orgs in Australia region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "3.0.0"
+  version: '2.40.2'
   title: 'Xero Payroll NZ'
   description: 'This is the Xero Payroll API for orgs in the NZ region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.40.2'
+  version: "3.0.0"
   title: 'Xero Payroll NZ'
   description: 'This is the Xero Payroll API for orgs in the NZ region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.40.2'
+  version: "2.40.3"
   title: 'Xero Payroll NZ'
   description: 'This is the Xero Payroll API for orgs in the NZ region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.40.2'
+  version: "2.40.3"
   title: 'Xero Payroll UK'
   description: 'This is the Xero Payroll API for orgs in the UK region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: '2.40.2'
+  version: "3.0.0"
   title: 'Xero Payroll UK'
   description: 'This is the Xero Payroll API for orgs in the UK region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "3.0.0"
+  version: '2.40.2'
   title: 'Xero Payroll UK'
   description: 'This is the Xero Payroll API for orgs in the UK region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "3.0.0"
+  version: "2.40.2"
   title: Xero Projects API
   description: This is the Xero Projects API 
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1458,7 +1458,6 @@ components:
       - ZMW
       - ZMK
       - ZWD
-      - ""
     Error:
       externalDocs:
         url: 'https://developer.xero.com/documentation/projects/projects-response-codes'

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "2.40.3"
   title: Xero Projects API
   description: This is the Xero Projects API 
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "3.0.0"
   title: Xero Projects API
   description: This is the Xero Projects API 
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -25567,7 +25567,6 @@ components:
         - ZMW
         - ZMK
         - ZWD
-        - "" 
     Employees:
       type: object
       x-isObjectArray: true

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Xero Accounting API
-  version: "2.40.2"
+  version: "2.40.3"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:
     name: "Xero Platform Team"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Xero Accounting API
-  version: "2.40.2"
+  version: "3.0.0"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:
     name: "Xero Platform Team"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Xero Accounting API
-  version: "3.0.0"
+  version: "2.40.2"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:
     name: "Xero Platform Team"

--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "2.40.3"
   title: Xero Assets API
   description: The Assets API exposes fixed asset related functions of the Xero Accounting application and can be used for a variety of purposes such as creating assets, retrieving asset valuations etc.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "3.0.0"
+  version: "2.40.2"
   title: Xero Assets API
   description: The Assets API exposes fixed asset related functions of the Xero Accounting application and can be used for a variety of purposes such as creating assets, retrieving asset valuations etc.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "3.0.0"
   title: Xero Assets API
   description: The Assets API exposes fixed asset related functions of the Xero Accounting application and can be used for a variety of purposes such as creating assets, retrieving asset valuations etc.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -1023,7 +1023,6 @@ components:
       - ZMW
       - ZMK
       - ZWD
-      - ""
     CountryCode:
       type: string
       example: "GB"

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "2.40.3"
   title: Xero Bank Feeds API
   description: The Bank Feeds API is a closed API that is only available to financial institutions that have an established financial services partnership with Xero.
                If you're an existing financial services partner that wants access, contact your local Partner Manager.

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "3.0.0"
+  version: "2.40.2"
   title: Xero Bank Feeds API
   description: The Bank Feeds API is a closed API that is only available to financial institutions that have an established financial services partnership with Xero.
                If you're an existing financial services partner that wants access, contact your local Partner Manager.

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "2.40.2"
+  version: "3.0.0"
   title: Xero Bank Feeds API
   description: The Bank Feeds API is a closed API that is only available to financial institutions that have an established financial services partnership with Xero.
                If you're an existing financial services partner that wants access, contact your local Partner Manager.

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -4,7 +4,7 @@ servers:
     url: https://api.xero.com/files.xro/1.0/
 info:
   title: Xero Files API
-  version: "3.0.0"
+  version: "2.40.2"
   description: "These endpoints are specific to Xero Files API"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -4,7 +4,7 @@ servers:
     url: https://api.xero.com/files.xro/1.0/
 info:
   title: Xero Files API
-  version: "2.40.2"
+  version: "3.0.0"
   description: "These endpoints are specific to Xero Files API"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -4,7 +4,7 @@ servers:
     url: https://api.xero.com/files.xro/1.0/
 info:
   title: Xero Files API
-  version: "2.40.2"
+  version: "2.40.3"
   description: "These endpoints are specific to Xero Files API"
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
   contact:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change is to remove empty enum values from the specifications of Accounting, Bankfeeds, Payroll_AU, and Projects.

## Release Notes
The empty enum values use a reserved keyword name in PHP which causes errors while utilising the SDK. Issue reported at xero-php-oauth2 [#258](https://github.com/XeroAPI/xero-php-oauth2/issues/258)

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
