### PR TITLE
Update GET TaxRates spec

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23662,6 +23662,14 @@ components:
       schema:
         type: string
         format: uuid
+    TaxType:
+      required: true
+      in: path
+      name: TaxType
+      description: A valid TaxType code
+      example: "INPUT2"
+      schema:
+        type: string
   responses:
     400Error:
       description: A failed request due to validation error

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22753,7 +22753,7 @@ paths:
         - OAuth2: [accounting.settings, accounting.settings.read]
       tags:
         - Accounting
-      operationId: getTaxRates
+      operationId: getTaxRateByTaxType
       summary: Retrieves a specific tax rate according to given TaxType code
       parameters:
         - $ref: "#/components/parameters/TaxType"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22745,6 +22745,54 @@ paths:
                           }
                         ]
                       }'
+  "/TaxRates/{TaxType}":
+    parameters:
+      - $ref: "#/components/parameters/requiredHeader"
+    get:
+      security:
+        - OAuth2: [accounting.settings, accounting.settings.read]
+      tags:
+        - Accounting
+      operationId: getTaxRates
+      summary: Retrieves a single tax rate by using a unique TaxType code
+      parameters:
+        - $ref: "#/components/parameters/TaxType"
+      responses:
+        "200":
+          description: Success - return response of type TaxRates array with one TaxRate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaxRates"
+              example: '{
+                "Id": "455d494d-9706-465b-b584-7086ca406b27",
+                "Status": "OK",
+                "ProviderName": "Xero API Partner",
+                "DateTimeUTC": "\/Date(1550797359081)\/",
+                "TaxRates": [
+                {
+                "Name": "15% GST on Expenses",
+                "TaxType": "INPUT2",
+                "ReportTaxType": "INPUT",
+                "CanApplyToAssets": true,
+                "CanApplyToEquity": true,
+                "CanApplyToExpenses": true,
+                "CanApplyToLiabilities": true,
+                "CanApplyToRevenue": false,
+                "DisplayTaxRate": 15.0000,
+                "EffectiveRate": 15.0000,
+                "Status": "ACTIVE",
+                "TaxComponents": [
+                {
+                "Name": "GST",
+                "Rate": 15.0000,
+                "IsCompound": false,
+                "IsNonRecoverable": false
+                }
+                ]
+                }
+                ]
+                }'
   /TrackingCategories:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22354,13 +22354,6 @@ paths:
           example: "Name ASC"
           schema:
             type: string
-        - in: query
-          name: TaxType
-          x-snake: tax_type
-          description: Filter by tax type
-          example: "INPUT"
-          schema:
-            type: string
       responses:
         '200':
           description: Success - return response of type TaxRates array with TaxRates

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22765,34 +22765,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/TaxRates"
               example: '{
-                "Id": "455d494d-9706-465b-b584-7086ca406b27",
-                "Status": "OK",
-                "ProviderName": "Xero API Partner",
-                "DateTimeUTC": "\/Date(1550797359081)\/",
-                "TaxRates": [
-                {
-                "Name": "15% GST on Expenses",
-                "TaxType": "INPUT2",
-                "ReportTaxType": "INPUT",
-                "CanApplyToAssets": true,
-                "CanApplyToEquity": true,
-                "CanApplyToExpenses": true,
-                "CanApplyToLiabilities": true,
-                "CanApplyToRevenue": false,
-                "DisplayTaxRate": 15.0000,
-                "EffectiveRate": 15.0000,
-                "Status": "ACTIVE",
-                "TaxComponents": [
-                {
-                "Name": "GST",
-                "Rate": 15.0000,
-                "IsCompound": false,
-                "IsNonRecoverable": false
-                }
-                ]
-                }
-                ]
-                }'
+                          "Id": "455d494d-9706-465b-b584-7086ca406b27",
+                          "Status": "OK",
+                          "ProviderName": "Xero API Partner",
+                          "DateTimeUTC": "\/Date(1550797359081)\/",
+                          "TaxRates": [
+                            {
+                              "Name": "15% GST on Expenses",
+                              "TaxType": "INPUT2",
+                              "ReportTaxType": "INPUT",
+                              "CanApplyToAssets": true,
+                              "CanApplyToEquity": true,
+                              "CanApplyToExpenses": true,
+                              "CanApplyToLiabilities": true,
+                              "CanApplyToRevenue": false,
+                              "DisplayTaxRate": 15.0000,
+                              "EffectiveRate": 15.0000,
+                              "Status": "ACTIVE",
+                              "TaxComponents": [
+                                {
+                                  "Name": "GST",
+                                  "Rate": 15.0000,
+                                  "IsCompound": false,
+                                  "IsNonRecoverable": false
+                                }
+                              ]
+                            }
+                          ]
+                        }'
   /TrackingCategories:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22754,7 +22754,7 @@ paths:
       tags:
         - Accounting
       operationId: getTaxRates
-      summary: Retrieves a single tax rate by using a unique TaxType code
+      summary: Retrieves a specific tax rate according to given TaxType code
       parameters:
         - $ref: "#/components/parameters/TaxType"
       responses:


### PR DESCRIPTION
It's reported by users (see CX0014522641 CX ticket) that the TaxType query param is not working. This query param is not supported by the Accounting API. What is supported is record filtering which allows users to append the `TaxType` in the endpoint's URL to filter for TaxRate with specific TaxType.

Does not work -> `/TaxRates?TaxType={TaxType}`
Works -> `/TaxRates/{TaxType}`

## Description
* Remove the declaration of `TaxType` query param in GET TaxRates
* Add a new spec for `TaxRates/{TaxTypes}`

## Release Notes
We need to make this change to avoid confusing users since I few have used `TaxType` as query param.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
