### PR TITLE
XBFIL-4328- Fix formatting and add 3 new fields

### DIFF
--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -595,7 +595,7 @@ paths:
                           "19d4fc59-e799-410f-912b-03d4ab294d73": 2,
                           "82195976-5175-45d4-926e-807ff10892e7": 1,
                           "a8547af2-2900-4879-98b8-f1a780c78feb": 0}'
-/Folders:
+  /Folders:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -685,7 +685,7 @@ paths:
             example: '{
                         "Name": "My Docs"
                       }'  
-/Folders/{FolderId}:
+  /Folders/{FolderId}:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -793,7 +793,7 @@ paths:
         '204':
           description: Successful deletion - return response 204 no content
           x-isEmpty: true
-/Inbox:
+  /Inbox:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -987,7 +987,7 @@ components:
       type: object
       properties:
         SendWithObject:
-          description:  Boolean flag to determines whether the file is sent with the document it is attached to on client facing communications. Note- The SendWithObject element is only returned when using /Associations/{ObjectId} endpoint. 
+          description: Boolean flag to determines whether the file is sent with the document it is attached to on client facing communications. Note- The SendWithObject element is only returned when using /Associations/{ObjectId} endpoint. 
           type: boolean
           example: true
         Name:

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -553,6 +553,9 @@ paths:
                   $ref: '#/components/schemas/Association'
               example: '[
                           {
+                              "SendWithObject":false,
+                              "Name":"testfile.pdf",
+                              "Size":12357,
                               "FileId":"6beccb4a-0d7d-4518-93f3-e0cd1dccb254",
                               "ObjectId":"1270bf7c-5d18-473a-9231-1e36c4bd33ed",
                               "ObjectType":"Business",
@@ -591,9 +594,8 @@ paths:
                 example: '{
                           "19d4fc59-e799-410f-912b-03d4ab294d73": 2,
                           "82195976-5175-45d4-926e-807ff10892e7": 1,
-                          "a8547af2-2900-4879-98b8-f1a780c78feb": 0
-                }'                        
-  /Folders:
+                          "a8547af2-2900-4879-98b8-f1a780c78feb": 0}'
+/Folders:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -683,7 +685,7 @@ paths:
             example: '{
                         "Name": "My Docs"
                       }'  
-  /Folders/{FolderId}:
+/Folders/{FolderId}:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -791,7 +793,7 @@ paths:
         '204':
           description: Successful deletion - return response 204 no content
           x-isEmpty: true
-  /Inbox:
+/Inbox:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
@@ -984,6 +986,18 @@ components:
     Association:
       type: object
       properties:
+        SendWithObject:
+          description: Boolean flag to know if a file is associated to a document. This is only relevant for object association endpoint- /Associations/{ObjectId}. 
+          type: boolean
+          example: true
+        Name:
+          description: The name of the associated file. This is only relevant for object association endpoint- /Associations/{ObjectId}. 
+          type: string
+          example: Test.pdf
+        Size:
+          description: The size of the associated file in bytes. This is only relevant for object association endpoint- /Associations/{ObjectId}. 
+          type: integer
+          example: 12357
         FileId:
           description: The unique identifier of the file  
           type: string

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -987,15 +987,15 @@ components:
       type: object
       properties:
         SendWithObject:
-          description: Boolean flag to know if a file is associated to a document. This is only relevant for object association endpoint- /Associations/{ObjectId}. 
+          description:  Boolean flag to determines whether the file is sent with the document it is attached to on client facing communications. Note- The SendWithObject element is only returned when using /Associations/{ObjectId} endpoint. 
           type: boolean
           example: true
         Name:
-          description: The name of the associated file. This is only relevant for object association endpoint- /Associations/{ObjectId}. 
+          description: The name of the associated file. Note- The Name element is only returned when using /Associations/{ObjectId} endpoint. 
           type: string
           example: Test.pdf
         Size:
-          description: The size of the associated file in bytes. This is only relevant for object association endpoint- /Associations/{ObjectId}. 
+          description: The size of the associated file in bytes. Note- The Size element is only returned when using /Associations/{ObjectId} endpoint. 
           type: integer
           example: 12357
         FileId:


### PR DESCRIPTION
Added 'Name', 'Size', 'SendWithObject' to object association endpoint

Adding these 3 new properties to response of an existing /associations/{objectId} endpoint
https://xero.atlassian.net/browse/XBFIL-4328

## Description
<!--- Describe your changes in detail -->

## Release Notes

Adding these 3 new properties to response of an existing /associations/{objectId} endpoint as requested by another internal team.
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
