### PR TITLE
Fix incorrect openapi version in Xero Payroll NZ spec

### DIFF
--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.
+openapi: 3.0.0
 info:
   version: "3.0.3"
   title: 'Xero Payroll NZ'


### PR DESCRIPTION
## Description
The `openapi` version number in the Xero Payroll NZ spec is currently incorrect which can prevent code generation from succeeding. This change corrects the version.

## Release Notes
Ensures the Xero Payroll NZ `openapi` version is of a valid format.

## Screenshots (if appropriate):
N/A

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
