### PR TITLE
Update xero_accounting.yaml to change signs for debit and credit

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -11095,7 +11095,7 @@ paths:
           key: lineAmount
           keyPascal: LineAmount
           keySnake: line_amount
-          default: 100.0
+          default: -100.0
           is_money: true
           object: credit
         - accountCode:
@@ -11126,7 +11126,7 @@ paths:
           key: lineAmount
           keyPascal: LineAmount
           keySnake: line_amount
-          default: -100.0
+          default: 100.0
           is_money: true
           object: debit
         - accountCode:
@@ -11329,7 +11329,7 @@ paths:
           key: lineAmount
           keyPascal: LineAmount
           keySnake: line_amount
-          default: 100.0
+          default: -100.0
           is_money: true
           object: credit
         - accountCode:
@@ -11360,7 +11360,7 @@ paths:
           key: lineAmount
           keyPascal: LineAmount
           keySnake: line_amount
-          default: -100.0
+          default: 100.0
           is_money: true
           object: debit
         - accountCode:
@@ -11638,7 +11638,7 @@ paths:
           key: lineAmount
           keyPascal: LineAmount
           keySnake: line_amount
-          default: 100.0
+          default: -100.0
           is_money: true
           object: credit
         - accountCode:
@@ -11669,7 +11669,7 @@ paths:
           key: lineAmount
           keyPascal: LineAmount
           keySnake: line_amount
-          default: -100.0
+          default: 100.0
           is_money: true
           object: debit
         - accountCode:


### PR DESCRIPTION
The debit lines should be positive and credits negative in the code examples for creating and updating journals

## Description
Changed the signs so that they are correct

## Release Notes
If the examples were followed exactly the journal would be the wrong way round

## Screenshots (if appropriate):
![ManualJournalAPIExplorer](https://github.com/XeroAPI/Xero-OpenAPI/assets/86235862/2db3afcb-86d5-47f0-8923-b08e5ec15062)


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
