### PR TITLE
UKPAY-9238 Add scheduleOfAccrualDate to EmployeeLeaveType

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -1836,7 +1836,8 @@ paths:
                               "hoursAccruedAnnually": 200,
                               "maximumToAccrue": 0,
                               "openingBalance": 72,
-                              "rateAccruedHourly": 0
+                              "rateAccruedHourly": 0,
+                              "scheduleOfAccrualDate": null
                             }
                           ]
                         }'
@@ -1886,7 +1887,14 @@ paths:
           nonString: true 
           default: 5.25
           object: employeeLeaveType
-          is_last: true
+        - scheduleOfAccrualDate:
+          is_variable: true
+          nonString: true
+          key: scheduleOfAccrualDate
+          keyPascal: ScheduleOfAccrualDate
+          keySnake: schedule_of_accrual_date
+          object: employeeLeaveType
+          is_last: true 
       summary: Creates employee leave type records
       parameters:
         - $ref: '#/components/parameters/idempotencyKey'
@@ -6500,6 +6508,12 @@ components:
           description: The number of hours added to the leave balance for every hour worked by the employee. This is normally 0, unless the scheduleOfAccrual chosen is "OnHourWorked"
           type: number
           format: double
+        scheduleOfAccrualDate:
+          description: The date when an employee becomes entitled to their accrual. Only applicable when scheduleOfAccrual is "OnAnniversaryDate"
+          type: string
+          format: date
+          example: 2024-04-01
+          x-is-date: true
     EmployeePayTemplateObject:
       type: object
       properties:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a new optional property to the EmployeeLeaveType DTO for scheduleOfAccrualDate.

## Description
<!--- Describe your changes in detail -->
This affects the GET and the POST endpoints for employee leave types, but is fully backwards compatible. The developer documentation has already been updated.

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This property is already available via the web interface, and is being enabled for the API shortly.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
