### PR TITLE
[LEND-3076] Remove Indirect Bank Feed

### DIFF
--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -77,15 +77,12 @@ paths:
                       totalAmount: 189
                       dataSource:
                         directBankFeed: 0
-                        indirectBankFeed: 0
                         fileUpload: 300
                         manual: -188
                         directBankFeedPos: 0
-                        indirectBankFeedPos: 0
                         fileUploadPos: 2223
                         manualPos: 0
                         directBankFeedNeg: 0
-                        indirectBankFeedNeg: 0
                         fileUploadNeg: -1890
                         manualNeg: -500
                         otherPos: 0
@@ -1551,7 +1548,7 @@ components:
           format: date-time
         importSourceType:
           type: string
-          description: Looking at the most recent bank statement, this field indicates the source of the data (direct bank feed, indirect bank feed, file upload, or manual keying).
+          description: Looking at the most recent bank statement, this field indicates the source of the data (direct bank feed, file upload, or manual keying).
       additionalProperties: false
     DataSourceResponse:
       type: object
@@ -1559,12 +1556,6 @@ components:
         directBankFeed:
           type: number
           description: Sum of the amounts of all statement lines where the source of the data was a direct bank feed in to Xero via an API integration.   This could be from a bank or aggregator.   This gives an indication on the certainty of correctness of the data.
-          format: double
-          x-is-money: true
-        indirectBankFeed:
-          type: number
-          deprecated: true
-          description: No longer in use.
           format: double
           x-is-money: true
         fileUpload:
@@ -1582,12 +1573,6 @@ components:
           description: Sum of the amounts of all statement lines where the source of the data was a direct bank feed in to Xero via an API integration.   This could be from a bank or aggregator.  This gives an indication on the certainty of correctness of the data.  Only positive transactions are included.
           format: double
           x-is-money: true
-        indirectBankFeedPos:
-          type: number
-          deprecated: true
-          description: No longer in use.
-          format: double
-          x-is-money: true
         fileUploadPos:
           type: number
           description: Sum of the amounts of all statement lines where the source of the data was a file manually uploaded in to Xero.   This gives an indication on the certainty of correctness of the data. Only positive transactions are included.
@@ -1601,12 +1586,6 @@ components:
         directBankFeedNeg:
           type: number
           description: Sum of the amounts of all statement lines where the source of the data was a direct bank feed in to Xero via an API integration.   This could be from a bank or aggregator.   This gives an indication on the certainty of correctness of the data.  Only negative transactions are included.
-          format: double
-          x-is-money: true
-        indirectBankFeedNeg:
-          type: number
-          deprecated: true
-          description: No longer in use.
           format: double
           x-is-money: true
         fileUploadNeg:


### PR DESCRIPTION
## Description
Following[ Cash Validation - fix bug for data source classification](https://xero.atlassian.net/jira/software/c/projects/LEND/boards/4170?selectedIssue=LEND-2862) implemented on June 20, 2024, this is the 2nd release to remove indirectBankFeed data point from the Cash Validation schema

We want to roll out this change at Feb 3, 2025

## Release Notes
Removing unused and deprecated fields from the Api response.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
