### PR TITLE
NZP-4591 Add new fields and deprecations for NZ Holidays Act

### DIFF
--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -6838,12 +6838,23 @@ components:
           type: number
           format: double
           x-is-money: true
+        numberOfUnitsTaken:
+          description: The number of units taken for the leave
+          type: number
+          format: double
+        typeOfUnits:
+          description: The type of units paid for the leave
+          type: string
+        typeOfUnitsTaken:
+          description: The type of units taken for the leave
+          type: string
         periodStatus:
-          description: Period Status
+          description: Status of leave
           type: string
           enum:
             - Approved
             - Completed
+            - Estimated
     EmployeeLeaveBalances:
       type: object
       properties:
@@ -7108,13 +7119,25 @@ components:
           x-is-money: true
           example: 10.0
         sickLeaveHoursToAccrueAnnually:
-          description: Number of hours accrued annually for sick leave. Multiply the number of days they're entitled to by the hours worked per day
+          description: Deprecated use SickLeaveToAccrueAnnually
           type: number
           format: double
           x-is-money: true
           example: 100.5
         sickLeaveMaximumHoursToAccrue:
-          description: Maximum number of hours accrued annually for sick leave. Multiply the maximum days they can accrue by the hours worked per day
+          description: Deprecated use SickLeaveMaximumToAccrue
+          type: number
+          format: double
+          x-is-money: true
+          example: 200.5
+        SickLeaveToAccrueAnnually:
+          description: Number of units accrued annually for sick leave. The type of units is determined by the property "TypeOfUnitsToAccrue" on the "Sick Leave" leave type
+          type: number
+          format: double
+          x-is-money: true
+          example: 100.5
+        SickLeaveMaximumToAccrue:
+          description: Maximum number of units accrued annually for sick leave. The type of units is determined by the property "TypeOfUnitsToAccrue" on the "Sick Leave" leave type
           type: number
           format: double
           x-is-money: true
@@ -7130,7 +7153,13 @@ components:
           type: string
           example: OnAnniversaryDate
         SickLeaveAnniversaryDate:
-          description: If Sick Leave Schedule of Accrual is "OnAnniversaryDate", this is the date when entitled to Sick Leave
+          description: If Sick Leave Schedule of Accrual is "OnAnniversaryDate", this is the date when entitled to Sick Leave. When null the Employee's start date is used as the anniversary date
+          type: string
+          format: date
+          example: 2020-01-19
+          x-is-date: true
+        AnnualLeaveAnniversaryDate:
+          description: The first date the employee will accrue Annual Leave. When null the Employee's start date is used as the anniversary date
           type: string
           format: date
           example: 2020-01-19
@@ -7160,20 +7189,31 @@ components:
             - PercentageOfGrossEarnings
             - NoAccruals
         hoursAccruedAnnually:
-          description: The number of hours accrued for the leave annually. This is 0 when the scheduleOfAccrual chosen is "OnHourWorked"
+          description: Deprecated use UnitsAccruedAnnually
           type: number
           format: double
           x-is-money: true
+        UnitsAccruedAnnually:
+          description: The number of units accrued for the leave annually. This is 0 when the ScheduleOfAccrual chosen is "NoAccruals"
+          type: number
+          format: double
+          x-is-money: true
+        typeOfUnitsToAccrue:
+          description: The type of units accrued for the leave annually
+          type: string
         maximumToAccrue:
-          description: The maximum number of hours that can be accrued for the leave
+          description: The maximum number of units that can be accrued for the leave
           type: number
           format: double
           x-is-money: true
         openingBalance:
-          description: The initial number of hours assigned when the leave was added to the employee
+          description: The initial number of units assigned when the leave was added to the employee
           type: number
           format: double
           x-is-money: true
+        openingBalanceTypeOfUnits:
+          description: The type of units for the opening balance
+          type: string
         rateAccruedHourly:
           description: The number of hours added to the leave balance for every hour worked by the employee. This is normally 0, unless the scheduleOfAccrual chosen is "OnHourWorked"
           type: number
@@ -7642,6 +7682,12 @@ components:
         isActive:
           description: Shows whether the leave type is active or not
           type: boolean
+        typeOfUnits:
+          description: The type of units to be paid for the leave type
+          type: string
+        typeOfUnitsToAccrue:
+          description: The type of units to be accrued for the leave type
+          type: string
     Reimbursements:
       type: object
       properties:


### PR DESCRIPTION
## Description
Based on this notice [Payroll NZ Holiday Act (2003) Update]( https://developer.xero.com/documentation/api/changelog/payrollnz-holiday-act), Add the following fields to the following objects:

- Period / Employees Leave Periods - https://developer.xero.com/documentation/api/payrollnz/employeeleaveperiods
  - NumberOfUnitsTaken (GET)
  - TypeOfUnits (GET)
  - TypeOfUnitsTaken (GET)
  - PeriodStatus will now always return “Estimated”
- Employees Leave Setup - https://developer.xero.com/documentation/api/payrollnz/employeeleavesetup
  - Deprecated
    - SickLeaveHoursToAccrueAnnually (POST)
    - SickLeaveMaximumHoursToAccrue (POST)
  - New
    - SickLeaveToAccrueAnnually (POST)
      - replaces SickLeaveHoursToAccrueAnnually
    - SickLeaveMaximumToAccrue (POST)
      - replaces SickLeaveMaximumHoursToAccrue
    - SickLeaveScheduleOfAccrual (POST)
    - SickLeaveAnniversaryDate (POST)
    - AnnualLeaveAnniversaryDate (POST)
- Employees Leave Types - https://developer.xero.com/documentation/api/payrollnz/employeeleavetypes
  - Deprecated
    - HoursAccruedAnnually (GET | POST)
  - New
    - UnitsAccruedAnnually  (GET | POST)
      - replaces HoursAccruedAnnually
    - TypeOfUnitsToAccrue  (GET)
    - OpeningBalanceTypeOfUnits (GET)
- Leave Types - https://developer.xero.com/documentation/api/payrollnz/leavetypes
  - TypeOfUnits (GET) 
  - TypeOfUnitsToAccrue (GET) 

## Release Notes
Feature -
 - add NZ Holiday Act fields
## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
