### PR TITLE
Ni category updates

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -352,8 +352,11 @@ paths:
                               "payrollCalendarID": null,
                               "updatedDateUTC": "2017-05-12T10:00:24",
                               "createdDateUTC": "2017-05-12T10:00:24",
-                              "niCategory": "A",
                               "niCategories": [
+                                {
+                                  "startDate": "2020-05-01T00:00:00",
+                                  "niCategory": "A"
+                                },
                                 {
                                   "startDate": null,
                                   "niCategory": "A",
@@ -362,6 +365,7 @@ paths:
                                   "workplacePostcode": "SW1A 1AA"
                                 }
                               ],
+                              "employeeNumber": "2",
                               "endDate": null
                           }
                         }'
@@ -6056,7 +6060,7 @@ components:
         - PayrollCalendarID
         - StartDate
         - EmployeeNumber
-        - NICategory
+        - NICategories
       properties:
         payrollCalendarID:
           description: Xero unique identifier for the payroll calendar of the employee

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -617,7 +617,15 @@ paths:
                           "employment": {
                             "payrollCalendarID": "216d80e6-af55-47b1-b718-9457c3f5d2fe",
                             "startDate": "2020-04-01T00:00:00",
-                            "niCategory": "A",
+                            "niCategories": [
+                              {
+                                "niCategory": "A",
+                                "startDate": "2020-05-01",
+                                "niCategoryID": 594,
+                                "dateFirstEmployedAsCivilian": null,
+                                "workplacePostcode": null
+                              }
+                            ],
                             "employeeNumber": "123ABC"
                           }
                         }'
@@ -636,8 +644,12 @@ paths:
             example: '{
                         "PayrollCalendarID": "216d80e6-af55-47b1-b718-9457c3f5d2fe",
                         "StartDate": "2020-04-01",
-                        "EmployeeNumber": "123ABC",
-                        "NICategory": "A"
+                        "NICategories": [
+                          {
+                            "NICategory": ""
+                          }
+                        ],
+                        "EmployeeNumber": "123ABC"
                       }'
   /Employees/{EmployeeID}/Tax:
     parameters:

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -5997,6 +5997,14 @@ components:
           type: string
           format: date-time
           x-is-datetime: true
+        niCategory:
+          $ref: '#/components/schemas/NICategoryLetter'
+          deprecated: true
+        niCategories:
+          description: The employee's NI categories
+          type: array
+          items:
+            $ref: '#/components/schemas/NICategory'
         nationalInsuranceNumber:
           description: National insurance number of the employee
           type: string

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -7864,3 +7864,49 @@ components:
           description: The Xero identifier for Timesheet tracking category.
           type: string
           format: uuid
+    NICategoryLetter:
+      description: The employee's NI Category letter.
+      type: string
+      example: I
+      enum:
+      - A
+      - B
+      - C
+      - F
+      - H
+      - I
+      - J
+      - L
+      - M
+      - S
+      - V
+      - X
+      - Z
+    NICategory:
+      type: object
+      required:
+        - niCategory
+        - workplacePostcode
+      properties:
+        startDate:
+          description: The start date of the NI category (YYYY-MM-DD)
+          type: string
+          format: date
+          example: 2024-12-02  
+          x-is-date: true 
+        niCategory:
+          $ref: '#/components/schemas/NICategoryLetter'
+        niCategoryID:
+          description: Xero unique identifier for the NI category
+          type: number
+          example: 15
+        dateFirstEmployedAsCivilian:
+          description: The date in which the employee was first employed as a civilian (YYYY-MM-DD)
+          type: string
+          format: date
+          example: 2024-12-02
+          x-is-date: true 
+        workplacePostcode:
+          description: The workplace postcode
+          type: string
+          example: SW1A 1AA

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -359,7 +359,7 @@ paths:
                                 },
                                 {
                                   "startDate": null,
-                                  "niCategory": "A",
+                                  "niCategory": "F",
                                   "niCategoryID": 1,
                                   "dateFirstEmployedAsCivilian": null,
                                   "workplacePostcode": "SW1A 1AA"

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -580,7 +580,14 @@ paths:
           python: start_date
           ruby: start_date
           object: employment
-          is_last: true 
+          is_last: true
+        - niCategories:
+          key: niCategories
+          keyPascal: NICategories
+          keySnake: ni_categories
+          is_object: true
+          object: employment
+          default: A
       summary: Creates employment detail for a specific employee using a unique employee ID
       parameters:
         - $ref: '#/components/parameters/idempotencyKey'
@@ -6053,23 +6060,14 @@ components:
           type: string
           example: 007
         niCategory:
-          description: The NI Category of the employee
-          type: string
-          enum:
-          - A
-          - B
-          - C
-          - F
-          - H
-          - I
-          - J
-          - L
-          - M
-          - S
-          - V
-          - X
-          - Z
-          example: A
+          $ref: '#/components/schemas/NICategoryLetter'
+          deprecated: true
+        niCategories:
+          description: The employee's NI categories
+          type: array
+          items:
+            $ref: '#/components/schemas/NICategory'
+
     EmployeeTaxObject:
       type: object
       properties:

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -260,7 +260,7 @@ paths:
                                 "county":null,
                                 "countryName":null,
                                 "postCode": "MK9 1EB"
-                              }
+                              },
                               "payrollCalendarID":null,
                               "updatedDateUTC":"2020-03-25T03:12:10",
                               "createdDateUTC":"2020-03-25T03:12:10",

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -7888,12 +7888,16 @@ components:
       - A
       - B
       - C
+      - D
+      - E
       - F
       - H
       - I
       - J
+      - K
       - L
       - M
+      - N
       - S
       - V
       - X

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -352,6 +352,16 @@ paths:
                               "payrollCalendarID": null,
                               "updatedDateUTC": "2017-05-12T10:00:24",
                               "createdDateUTC": "2017-05-12T10:00:24",
+                              "niCategory": "A",
+                              "niCategories": [
+                                {
+                                  "startDate": null,
+                                  "niCategory": "A",
+                                  "niCategoryID": 1,
+                                  "dateFirstEmployedAsCivilian": null,
+                                  "workplacePostcode": "SW1A 1AA"
+                                }
+                              ],
                               "endDate": null
                           }
                         }'

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -7926,3 +7926,23 @@ components:
           description: The workplace postcode
           type: string
           example: SW1A 1AA
+      oneOf:
+        - required:
+          - workplacePostcode
+          properties:
+            niCategory:
+              enum: 
+                - F
+                - I
+                - L
+                - S
+                - N
+                - E
+                - D
+                - K
+        - required:
+          - dateFirstEmployedAsCivilian
+          properties:
+            niCategory:
+              enum:
+                - V

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -650,7 +650,8 @@ paths:
                         "StartDate": "2020-04-01",
                         "NICategories": [
                           {
-                            "NICategory": ""
+                            "NICategory": "A",
+                            "StartDate": "2020-05-01"
                           }
                         ],
                         "EmployeeNumber": "123ABC"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added entities for NICategoryLetter and NICategory.
- Freeport and Investment zone NI category letters added.
- Updated Employee entity. NICategoryLetter has been marked as deprecated and NICategories added as a new property.
- Validation added to NICategory entity. Validation added for `workplacePostcode` and `dateFirstEmployedAsCivilian`.
- Updated Employment POST. Added NI Categories and removed deprecated `niCategory` property.
- GET Employee 200 response example updated and NI Categories added.
- Added missing comma to Employee POST success response example.

## Release Notes
This change reflects the current functionality available in the public API and as shown in Xero documentation. 

[GET Employee](https://developer.xero.com/documentation/api/payrolluk/employees#get-employees)
[POST Employment](https://developer.xero.com/documentation/api/payrolluk/employment#post-employment)

## Screenshots (if appropriate):

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
