### PR TITLE
Undone alphabetised ordering and added missing category letters.

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -7907,20 +7907,20 @@ components:
       - A
       - B
       - C
-      - D
-      - E
       - F
       - H
       - I
       - J
-      - K
       - L
       - M
-      - N
       - S
       - V
       - X
       - Z
+      - D
+      - E
+      - K
+      - N
     NICategory:
       type: object
       required:


### PR DESCRIPTION
## Description
Undone the alphabetised ordering on NICategoryLetter as this affects the outputted enum SDK code. The original order has been added, and any missing category letters have been added at the end.

## Release Notes
Fixes a potential issue with the outputted enum SDK code. Reverts back to original ordering while also adding missing letters.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
