### PR TITLE
[ZAV-192] Adds new TaxTypes and ReportTaxTypes supporting South Africa  rate change 2025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 # JetBrains generated files
 .idea
+
+.vscode/

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -28575,6 +28575,24 @@ components:
       - BLINPUT3
       - BLINPUT3Y23
       - BLINPUT3Y24
+      - SROUTPUT25
+      - CAPOUTPUT25
+      - ACC28PLUS25
+      - ACCUPTO2825
+      - CIUOUTPUT25
+      - SHOUTPUT25
+      - CAPINPUT25
+      - SRINPUT25
+      - CIUINPUT25
+      - BADDEBT25
+      - ACC28PLUS
+      - ACCUPTO28
+      - SHOUTPUT
+      - OTHEROUTPUT
+      - IMINPUT
+      - BADDEBT
+      - OTHERINPUT
+      - ZRINPUT
     Setup:
       externalDocs:
         url: 'https://developer.xero.com/documentation/api-guides/conversions'
@@ -28818,6 +28836,16 @@ components:
           - BADDEBTRECOVERY
           - USSALESTAX
           - BLINPUT3
+          - SROUTPUT25
+          - CAPOUTPUT25
+          - ACC28PLUS25
+          - ACCUPTO2825
+          - CIUOUTPUT25
+          - SHOUTPUT25
+          - CAPINPUT25
+          - SRINPUT25
+          - CIUINPUT25
+          - BADDEBT25
         CanApplyToAssets:
           description: Boolean to describe if tax rate can be used for asset accounts i.e.  true,false
           readOnly: true


### PR DESCRIPTION
JIRA: https://xero.atlassian.net/browse/ZAV-192
Epic: https://xero.atlassian.net/browse/ZAV-180

## Description
As part of the South Africa VAT rate changes 2025, we need to create some new SystemGSTCodes. These codes are:
```
SROUTPUT25
CAPOUTPUT25
ACC28PLUS25
ACCUPTO2825
CIUOUTPUT25
SHOUTPUT25
CAPINPUT25
SRINPUT25
CIUINPUT25
BADDEBT25
```

These codes have been added to the `ReportTaxType` enum in the open API spec.

These codes have also been added to the `TaxType` enum but I've noticed there are some pre-existing SystemGSTCodes for ZA VAT that are not included in this enum. So I have added these too:

```
ACC28PLUS
ACCUPTO28
SHOUTPUT
OTHEROUTPUT
IMINPUT
BADDEBT
OTHERINPUT
ZRINPUT
```

I've been using [this guide](https://xero.atlassian.net/wiki/spaces/SGTAX/pages/269564543161/How+To+Create+New+Tax+Rates) for a similar change for Singapore tax rates and this appears to be what was done in [this PR](https://github.com/XeroAPI/Xero-OpenAPI/commit/574e5724a71b2e5e577810da65df94ea035fb863).

I believe adding values to these enums creates a breaking change.

BTW - the `TaxType` enum does not appear to be referenced by any other entity in the spec, so I'm unsure how this gets used.

## Release Notes
Compliance change South Africa VAT rate change May 2025

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
