### PR TITLE
XBFIL-5368: Update query params for GET /files endpoint

### DIFF
--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -49,7 +49,16 @@ paths:
             - Name
             - Size
             - CreatedDateUTC
-            example: "CreatedDateUTC DESC"
+            example: "CreatedDateUTC"
+        - in: query
+          name: direction
+          description: sort direction
+          schema:
+            type: string
+            enum: 
+            - ASC
+            - DESC
+            example: "ASC"
       responses:
         '200':
           description: search results matching criteria


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
It appears that the `GET /files` endpoint has had incorrect query param details in the OpenAPI spec for quite some time (as raised in a help files thread [here](https://xero.slack.com/archives/C6HHK280L/p1744363800251299)). The example for the `sort` parameter is incorrect, and it was missing the `direction` parameter entirely. I have simply removed `DESC` from the `sort` example, and added a `direction` param with correct values and example.

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is required so that the OpenAPI Spec/API Explorer properly reflects the actual endpoint, as can be seen raised in this slack help-files request: https://xero.slack.com/archives/C6HHK280L/p1744363800251299

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
