### PR TITLE
Add missing OrganisationRole REMOVED

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -29004,6 +29004,7 @@ components:
           - MANAGEDCLIENT
           - CASHBOOKCLIENT
           - UNKNOWN
+          - REMOVED
       type: object
     Error:
       externalDocs:


### PR DESCRIPTION
Adding support for a previously unseen OrganisationRole on the Users and ExpenseClaim endpoints.

## Description
ExpenseClaims and Users endpoints return a previously unseen role. Adding the new role so that server response can be handled by our SDKs

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
