### PR TITLE
Adding SIMPLE product enum

### DIFF
--- a/xero-app-store.yaml
+++ b/xero-app-store.yaml
@@ -469,11 +469,13 @@ components:
             * FIXED: Customers are charged a fixed amount for each billing period
             * PER_SEAT: Customers are charged based on the number of units they purchase
             * METERED: Customers are charged per use of this product
+            * SIMPLE: Customers are charged on a fixed amount for each billing period with an optional add-on feature
           type: string
           enum:
           - FIXED
           - PER_SEAT
           - METERED
+          - SIMPLE
         usageUnit:
           description: The unit of the usage product. e.g. "user", "minutes", "SMS", etc
           type: string


### PR DESCRIPTION
SIMPLE subscription product enum was missing, thus the yaml file has been updated to add it into the product.cs file.

## Description
A small update on the xero-app-store.yaml file to add "SIMPLE" product enum value for GetSubscription response.

## Release Notes
Check above description

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
