### PR TITLE
feat: Adding Bereavement enum to EmployeeStatutoryLeaveBalance and EmployeeStatutoryLeaveSummary for UK

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -6326,6 +6326,7 @@ components:
           - Maternity
           - Paternity
           - Sharedparental
+          - Bereavement
         balanceRemaining:
           description: The balance remaining for the corresponding leave type as of specified date.
           type: number
@@ -6366,6 +6367,7 @@ components:
             - Maternity
             - Paternity
             - Sharedparental
+            - Bereavement
         startDate:
           description: The date when the leave starts  
           type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add missing leave type to the EmployeeStatutoryLeaveBalance and EmployeeStatutoryLeaveSummary responses for UK. 

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- This leave type has been supported by these endpoints for the last two years, but they were not added when the work was done.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
