### PR TITLE
[UKPAY-11962] feat: Adding NeonatalCare enum to EmployeeStatutoryLeaveBalance and EmployeeStatutoryLeaveSummary for UK

### DIFF
--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -6327,6 +6327,7 @@ components:
           - Paternity
           - Sharedparental
           - Bereavement
+          - NeonatalCare
         balanceRemaining:
           description: The balance remaining for the corresponding leave type as of specified date.
           type: number
@@ -6368,6 +6369,7 @@ components:
             - Paternity
             - Sharedparental
             - Bereavement
+            - NeonatalCare
         startDate:
           description: The date when the leave starts  
           type: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add new leave type to the EmployeeStatutoryLeaveBalance and EmployeeStatutoryLeaveSummary responses for UK.


## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- We introduced Neonatal Care Leave recently and these endpoints will in the future (in the case of balance) and have (in the case of summary) support for neonatal care

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
