### PR TITLE
[XBAP-22591] - Updated Date field decsription for Payment and Batchpayment endpoint

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -20902,10 +20902,10 @@ components:
           type: string
           format: uuid
         DateString:
-          description: Date the payment is being made (YYYY-MM-DD) e.g. 2009-09-06
+          description: Date the payment is being made, provided as an ISO 8601 datetime string in the format YYYY-MM-DDTHH:mm:ss e.g. 2018-10-03T00:00:00
           type: string
         Date:
-          description: Date the payment is being made (YYYY-MM-DD) e.g. 2009-09-06
+          description: Date the payment is being made, provided as a Unix timestamp in milliseconds with an optional UTC offset e.g. \/Date(1721347200000+0000)\/
           type: string
           x-is-msdate: true
         Amount:
@@ -23728,7 +23728,7 @@ components:
           description: Code of account you are using to make the payment e.g. 001 (note- not all accounts have a code value)
           type: string
         Date:
-          description: Date the payment is being made (YYYY-MM-DD) e.g. 2009-09-06
+          description: Date the payment is being made, provided as a Unix timestamp in milliseconds with an optional UTC offset e.g. \/Date(1721347200000+0000)\/
           type: string
           x-is-msdate: true
         CurrencyRate:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- The **Date** field of the payment is returned as "\/Date(1721347200000+0000)\/" from API but [document ](https://developer.xero.com/documentation/api/accounting/payments#get-payments) says it is 2024-07-19 
- This PR is to update description of Date field for Payment and BatchPayment endpoint

## Release Notes
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- This is a bug fix aimed at preventing customer confusion. It allows them to perform necessary data conversions beforehand if their receiving system expects a different date format (e.g., SQL expecting a standard date string).

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
