### PR TITLE
Mark Accounting API Employee endpoints as deprecated

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -6535,6 +6535,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
+      deprecated: true
       security:
         - OAuth2:
             - accounting.settings
@@ -6543,6 +6544,7 @@ paths:
         - Accounting
       operationId: getEmployees
       summary: Retrieves employees used in Xero payrun
+      description: This endpoint is deprecated and will be removed April 28, 2026
       parameters:
         - $ref: '#/components/parameters/ifModifiedSince'
         - in: query
@@ -6599,6 +6601,7 @@ paths:
                       Description: Go to external link
                     UpdatedDateUTC: /Date(1552324737990+0000)/
     put:
+      deprecated: true
       security:
         - OAuth2:
             - accounting.settings
@@ -6606,6 +6609,7 @@ paths:
         - Accounting
       operationId: createEmployees
       summary: Creates new employees used in Xero payrun
+      description: This endpoint is deprecated and will be removed April 28, 2026
       x-hasAccountingValidationError: true
       x-example:
         - employee:
@@ -6677,6 +6681,7 @@ paths:
                   ExternalLink:
                     Url: http://twitter.com/#!/search/Nick+Fury
     post:
+      deprecated: true
       security:
         - OAuth2:
             - accounting.settings
@@ -6684,6 +6689,7 @@ paths:
         - Accounting
       operationId: updateOrCreateEmployees
       summary: Creates a single new employees used in Xero payrun
+      description: This endpoint is deprecated and will be removed April 28, 2026
       x-hasAccountingValidationError: true
       x-example:
         - employee:
@@ -6758,6 +6764,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/requiredHeader'
     get:
+      deprecated: true
       security:
         - OAuth2:
             - accounting.settings
@@ -6766,6 +6773,7 @@ paths:
         - Accounting
       operationId: getEmployee
       summary: Retrieves a specific employee used in Xero payrun using a unique employee Id
+      description: This endpoint is deprecated and will be removed April 28, 2026
       parameters:
         - $ref: '#/components/parameters/EmployeeID'
       responses:


### PR DESCRIPTION
## Description
- Mark Accounting API Employee endpoints as deprecated
   - Mark endpoints as deprecated
   - Add description to indicate date when removal of endpoints will occur

## Release Notes
The Accounting API Employee endpoints will be removed on April 28, 2026.

These endpoints are related to Employees used for the Pay Run feature, which is being retired. See [Xero Central article](https://central.xero.com/s/article/About-the-retirement-of-pay-run) for more information.
- Users making use of the Pay Run feature have already been notified
- Developers making use of these endpoints have been identified and will be notified in the coming days.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
