### PR TITLE
fix: xero-finance.yaml responses numeric to string

### DIFF
--- a/validator/scripts/validate-all.sh
+++ b/validator/scripts/validate-all.sh
@@ -10,6 +10,7 @@ ruleset="./validator/spectral.yaml"
 
 # Array of all YAML files
 files=(
+    "xero-finance.yaml"
     "xero-identity.yaml"
     "xero-projects.yaml"
     "xero-app-store.yaml"

--- a/xero-app-store.yaml
+++ b/xero-app-store.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 9.1.0
+  version: 9.1.1
   title: Xero AppStore API
   description: These endpoints are for Xero Partners to interact with the App Store Billing platform
   termsOfService: https://developer.xero.com/xero-developer-platform-terms-conditions/

--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -389,7 +389,7 @@ paths:
             type: string
           example: "2020-06-30"
       responses:
-        200:
+        "200":
           description: Success
           content:
             application/json:
@@ -453,7 +453,7 @@ paths:
                           total: 14.81
                       total: 14.81
                   total: 14.81
-        400:
+        "400":
           description: Bad Request
           content:
             application/json:
@@ -464,7 +464,7 @@ paths:
                 title: InvalidRequest
                 status: 400
                 detail: Organisation xxx does not exist
-        503:
+        "503":
           description: Server Error
           content:
             application/json:
@@ -503,7 +503,7 @@ paths:
             type: string
           example: "2021-09-15"
       responses:
-        200:
+        "200":
           description: Success
           content:
             application/json:
@@ -607,7 +607,7 @@ paths:
                             name: Loan - Shellcoll Distribution 2019
                             reportingCode: LIA.CUR.LOA
                             total: -15000.5
-        400:
+        "400":
           description: Bad Request
           content:
             application/json:
@@ -618,7 +618,7 @@ paths:
                 title: InvalidRequest
                 status: 400
                 detail: Organisation xxx does not exist
-        503:
+        "503":
           description: Server Error
           content:
             application/json:
@@ -657,7 +657,7 @@ paths:
             type: string
           example: "2021-09-15"
       responses:
-        200:
+        "200":
           description: Success
           content:
             application/json:
@@ -709,7 +709,7 @@ paths:
                           name: Office Expenses
                           reportingCode: EXP
                           total: 144.47
-        400:
+        "400":
           description: Bad Request
           content:
             application/json:
@@ -741,7 +741,7 @@ paths:
             type: string
           example: "2021-09-15"
       responses:
-        200:
+        "200":
           description: Success
           content:
             application/json:
@@ -769,7 +769,7 @@ paths:
                         value: 123
                         entryType: CREDIT
                       signedMovement: 0
-        400:
+        "400":
           description: Bad Request
           content:
             application/json:

--- a/xero-finance.yaml
+++ b/xero-finance.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 9.1.0
+  version: 9.1.1
   title: Xero Finance API
   description: The Finance API is a collection of endpoints which customers can use in the course of a loan application, which may assist lenders to gain the confidence they need to provide capital.
   termsOfService: https://developer.xero.com/xero-developer-platform-terms-conditions/
@@ -1116,7 +1116,7 @@ paths:
                                   reportingCode: REV.OTH
                                   lineAmount: 15.0
                                   accountType: REVENUE
-                          - paymentId: f94dad64-658c-491f-b901-05d38e9e8702
+                          - paymentId: f94dad64-658c-491f-b9.1.15d38e9e8702
                             date: "2021-01-01"
                             amount: 5.0
                             bankAmount: 5.0

--- a/xero-identity.yaml
+++ b/xero-identity.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 9.1.0
+  version: 9.1.1
   title: Xero OAuth 2 Identity Service API
   description: These endpoints are related to managing authentication tokens and identity for Xero API
   termsOfService: https://developer.xero.com/xero-developer-platform-terms-conditions/

--- a/xero-payroll-au.yaml
+++ b/xero-payroll-au.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 9.1.0
+  version: 9.1.1
   title: Xero Payroll AU API
   description: This is the Xero Payroll API for orgs in Australia region.
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"
@@ -467,7 +467,7 @@ paths:
               example:
                 Id: 00000000-0000-0000-0000-000000000000
                 Status: OK
-                ProviderName: 3f93110a-df13-49c7-b82f-a069813df188
+                ProviderName: 3f9.1.1a-df13-49c7-b82f-a069813df188
                 DateTimeUTC: /Date(1573621524786)/
                 Employees:
                   - EmployeeID: cdfb8371-0b21-4b8a-8903-1024df6c391e
@@ -583,7 +583,7 @@ paths:
                     EmployeeID: b34e89ff-770d-4099-b7e5-f968767118bc
                     LeaveTypeID: 184ea8f7-d143-46dd-bef3-0c60e1aa6fca
                     LeavePeriods:
-                      - PayPeriodStartDate: /Date(1571961600000+0000)/
+                      - PayPeriodStartDate: /Date(15719.1.10000+0000)/
                         PayPeriodEndDate: /Date(1572480000000+0000)/
                         LeavePeriodStatus: SCHEDULED
                         NumberOfUnits: 0
@@ -601,7 +601,7 @@ paths:
                     EmployeeID: b34e89ff-770d-4099-b7e5-f968767118bc
                     LeaveTypeID: 184ea8f7-d143-46dd-bef3-0c60e1aa6fca
                     LeavePeriods:
-                      - PayPeriodStartDate: /Date(1571961600000+0000)/
+                      - PayPeriodStartDate: /Date(15719.1.10000+0000)/
                         PayPeriodEndDate: /Date(1572480000000+0000)/
                         LeavePeriodStatus: SCHEDULED
                         NumberOfUnits: 0
@@ -823,7 +823,7 @@ paths:
                     EmployeeID: b34e89ff-770d-4099-b7e5-f968767118bc
                     LeaveTypeID: 184ea8f7-d143-46dd-bef3-0c60e1aa6fca
                     LeavePeriods:
-                      - PayPeriodStartDate: /Date(1571961600000+0000)/
+                      - PayPeriodStartDate: /Date(15719.1.10000+0000)/
                         PayPeriodEndDate: /Date(1572480000000+0000)/
                         LeavePeriodStatus: SCHEDULED
                         NumberOfUnits: 8
@@ -841,7 +841,7 @@ paths:
                     EmployeeID: b34e89ff-770d-4099-b7e5-f968767118bc
                     LeaveTypeID: 184ea8f7-d143-46dd-bef3-0c60e1aa6fca
                     LeavePeriods:
-                      - PayPeriodStartDate: /Date(1571961600000+0000)/
+                      - PayPeriodStartDate: /Date(15719.1.10000+0000)/
                         PayPeriodEndDate: /Date(1572480000000+0000)/
                         LeavePeriodStatus: PROCESSED
                         NumberOfUnits: 8
@@ -854,7 +854,7 @@ paths:
                     EndDate: /Date(1572645600000+0000)/
                     UpdatedDateUTC: /Date(1573447343000+0000)/
                     PayOutType: DEFAULT
-                  - LeaveApplicationID: 3f93110a-df13-49c7-b82f-a069813df188
+                  - LeaveApplicationID: 3f9.1.1a-df13-49c7-b82f-a069813df188
                     EmployeeID: cdfb8371-0b21-4b8a-8903-1024df6c391e
                     LeaveTypeID: 184ea8f7-d143-46dd-bef3-0c60e1aa6fca
                     LeavePeriods:
@@ -1024,7 +1024,7 @@ paths:
               example:
                 Id: 00000000-0000-0000-0000-000000000000
                 Status: OK
-                ProviderName: 3f93110a-df13-49c7-b82f-a069813df188
+                ProviderName: 3f9.1.1a-df13-49c7-b82f-a069813df188
                 DateTimeUTC: /Date(1573679792293)/
                 LeaveApplications:
                   - LeaveApplicationID: 1d4cd583-0107-4386-936b-672eb3d1f624
@@ -3127,7 +3127,7 @@ paths:
               example:
                 Id: 00000000-0000-0000-0000-000000000000
                 Status: OK
-                ProviderName: 3f93110a-df13-49c7-b82f-a069813df188
+                ProviderName: 3f9.1.1a-df13-49c7-b82f-a069813df188
                 DateTimeUTC: /Date(1573516185258)/
                 Timesheets:
                   - TimesheetID: a7eb0a79-8511-4ee7-b473-3a25f28abcb9

--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 9.1.0
+  version: 9.1.1
   title: 'Xero Payroll NZ'
   description: 'This is the Xero Payroll API for orgs in the NZ region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 9.1.0
+  version: 9.1.1
   title: 'Xero Payroll UK'
   description: 'This is the Xero Payroll API for orgs in the UK region.'
   termsOfService: "https://developer.xero.com/xero-developer-platform-terms-conditions/"

--- a/xero-projects.yaml
+++ b/xero-projects.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "9.1.0"
+  version: "9.1.1"
   title: Xero Projects API
   description: This is the Xero Projects API
   termsOfService: https://developer.xero.com/xero-developer-platform-terms-conditions/

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Xero Accounting API
-  version: 9.1.0
+  version: 9.1.1
   termsOfService: https://developer.xero.com/xero-developer-platform-terms-conditions/
   contact:
     name: Xero Platform Team
@@ -981,7 +981,7 @@ paths:
                       CurrencyCode: NZD
                     BatchPaymentID: b649632e-2782-4c74-95a5-d994d7140ed9
                     DateString: 2022-08-01T00:00:00
-                    Date: /Date(1659312000000+0000)/
+                    Date: /Date(1659.1.100000+0000)/
                     Payments: []
                     Type: PAYBATCH
                     Status: DELETED
@@ -1108,7 +1108,7 @@ paths:
                       CurrencyCode: NZD
                     BatchPaymentID: b649632e-2782-4c74-95a5-d994d7140ed9
                     DateString: 2022-08-01T00:00:00
-                    Date: /Date(1659312000000+0000)/
+                    Date: /Date(1659.1.100000+0000)/
                     Payments: []
                     Type: PAYBATCH
                     Status: DELETED
@@ -1523,7 +1523,7 @@ paths:
                 ProviderName: Xero API Partner
                 DateTimeUTC: /Date(1551213568047)/
                 BankTransactions:
-                  - BankTransactionID: 1289c190-e46d-434b-9628-463ffdb52f00
+                  - BankTransactionID: 1289.1.1-e46d-434b-9628-463ffdb52f00
                     BankAccount:
                       AccountID: 6f7594f2-f059-4d56-9e67-47ac9733bfe9
                       Code: "088"
@@ -1780,7 +1780,7 @@ paths:
                 ProviderName: Xero API Partner
                 DateTimeUTC: /Date(1551213568047)/
                 BankTransactions:
-                  - BankTransactionID: 1289c190-e46d-434b-9628-463ffdb52f00
+                  - BankTransactionID: 1289.1.1-e46d-434b-9628-463ffdb52f00
                     BankAccount:
                       AccountID: 6f7594f2-f059-4d56-9e67-47ac9733bfe9
                       Code: "088"
@@ -2155,7 +2155,7 @@ paths:
                 ProviderName: Xero API Partner
                 DateTimeUTC: /Date(1551213568875)/
                 BankTransactions:
-                  - BankTransactionID: 1289c190-e46d-434b-9628-463ffdb52f00
+                  - BankTransactionID: 1289.1.1-e46d-434b-9628-463ffdb52f00
                     BankAccount:
                       AccountID: 6f7594f2-f059-4d56-9e67-47ac9733bfe9
                       Code: "088"
@@ -7562,7 +7562,7 @@ paths:
                     SubTotal: 40.00
                     TotalTax: 0.00
                     Total: 40.00
-                    UpdatedDateUTC: /Date(1541176290160+0000)/
+                    UpdatedDateUTC: /Date(154117629.1.1+0000)/
                     CurrencyCode: NZD
                   - Type: ACCREC
                     InvoiceID: 046d8a6d-1ae1-4b4d-9340-5601bdf41b87
@@ -9754,7 +9754,7 @@ paths:
                     TargetLineItemID: d5128ff1-0f39-4d2a-a6d5-46dfaf5f075c
                     Status: ONDRAFT
                     Type: BILLABLEEXPENSE
-                    UpdatedDateUTC: /Date(1552347991000+0000)/
+                    UpdatedDateUTC: /Date(15523479.1.10+0000)/
                     SourceTransactionTypeCode: ACCPAY
     put:
       security:
@@ -9858,7 +9858,7 @@ paths:
                     TargetLineItemID: d5128ff1-0f39-4d2a-a6d5-46dfaf5f075c
                     Status: ONDRAFT
                     Type: BILLABLEEXPENSE
-                    UpdatedDateUTC: /Date(1552347991000+0000)/
+                    UpdatedDateUTC: /Date(15523479.1.10+0000)/
                     SourceTransactionTypeCode: ACCPAY
     post:
       security:
@@ -14372,7 +14372,7 @@ paths:
                             Option: Eastside
                     Date: /Date(1571875200000)/
                     DateString: 2019-10-24T00:00:00
-                    ExpiryDate: /Date(1571961600000)/
+                    ExpiryDate: /Date(15719.1.10000)/
                     ExpiryDateString: 2019-10-25T00:00:00
                     Status: ACCEPTED
                     CurrencyRate: 0.937053

--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 9.1.0
+  version: 9.1.1
   title: Xero Assets API
   description: The Assets API exposes fixed asset related functions of the Xero Accounting application and can be used for a variety of purposes such as creating assets, retrieving asset valuations etc.
   termsOfService: https://developer.xero.com/xero-developer-platform-terms-conditions/

--- a/xero_bankfeeds.yaml
+++ b/xero_bankfeeds.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 9.1.0
+  version: 9.1.1
   title: Xero Bank Feeds API
   description: The Bank Feeds API is a closed API that is only available to financial institutions that have an established financial services partnership with Xero. If you're an existing financial services partner that wants access, contact your local Partner Manager. If you're a financial institution who wants to provide bank feeds to your business customers, contact us to become a financial services partner.
   termsOfService: https://developer.xero.com/xero-developer-platform-terms-conditions/

--- a/xero_files.yaml
+++ b/xero_files.yaml
@@ -4,7 +4,7 @@ servers:
     url: https://api.xero.com/files.xro/1.0/
 info:
   title: Xero Files API
-  version: 9.1.0
+  version: 9.1.1
   description: These endpoints are specific to Xero Files API
   termsOfService: https://developer.xero.com/xero-developer-platform-terms-conditions/
   contact:


### PR DESCRIPTION
Fix a failing validation on Open API Specification for the `xero-finance.yaml` file.
Issue: https://github.com/XeroAPI/Xero-OpenAPI/issues/741

## Description
Response codes should be `string` not `numeric`.

## Release Notes
N/A

## Screenshots (if appropriate):

## Types of Changes
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
