### PR TITLE
fix: typo in getReportsList summary

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -18094,7 +18094,7 @@ paths:
       tags:
         - Accounting
       operationId: getReportsList
-      summary: Retrieves a list of the organistaions unique reports that require a uuid to fetch
+      summary: Retrieves a list of the organisations unique reports that require a uuid to fetch
       responses:
         "200":
           description: Success - return response of type ReportWithRows


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Corrected a spelling error in `xero_accounting.yaml`, changing "organistaions" to "organisations" in the summary for the `getReportsList` operation.

## Release Notes
This PR fixes a minor typo in the API specification.  

## Screenshots (if appropriate):
N/A

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
