### PR TITLE
remove invalid `type: string` from Contact property in Quote schema

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -24128,7 +24128,6 @@ components:
           type: string
         Contact:
           $ref: '#/components/schemas/Contact'
-          type: string
         LineItems:
           description: See LineItems
           type: array


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed an incorrect `type: string` declaration from the `Contact` property in the `Quote` schema. The `Contact` property already uses `$ref` to reference the `Contact` schema, so having an additional `type: string` declaration is invalid OpenAPI syntax.

This can cause code generation tools to incorrectly interpret the `Contact` property. For example, the current version of `openapi-generator-cli` generates the `Contact` property of `Quote` as a string.

## Release Notes
This change fixes a mistake in the `Quote` schema where the `Contact` property had both a `$ref` and a `type: string` sibling. The change ensures compliance with the OpenAPI specification and prevents issues with code generators.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
