### PR TITLE
fix: typo on required field name EarningsTemplates - case mismatch

### DIFF
--- a/xero-payroll-nz.yaml
+++ b/xero-payroll-nz.yaml
@@ -7008,7 +7008,7 @@ components:
     EmployeePayTemplate:
       type: object
       required:
-        - EarningTemplates
+        - earningTemplates
       properties:
         employeeID:
           description: Unique identifier for the employee

--- a/xero-payroll-uk.yaml
+++ b/xero-payroll-uk.yaml
@@ -6187,7 +6187,7 @@ components:
     EmployeePayTemplate:
       type: object
       required:
-        - EarningTemplates
+        - earningTemplates
       properties:
         employeeID:
           description: Unique identifier for the employee


### PR DESCRIPTION
## Description
Typo on required field name EarningsTemplates - case mismatch