### PR TITLE
fix: reorder the OrganisationType enum

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -23023,25 +23023,25 @@ components:
           type: string
           enum:
             - ACCOUNTING_PRACTICE
-            - CCORPORATIONLLC
             - COMPANY
             - CHARITY
             - CLUB_OR_SOCIETY
             - INDIVIDUAL
-            - LLC
             - LOOK_THROUGH_COMPANY
             - NOT_FOR_PROFIT
-            - NOTLLC
             - PARTNERSHIP
-            - PARTNERSHIPLLC
-            - PERSONAL
             - S_CORPORATION
-            - SCORPORATIONLLC
             - SELF_MANAGED_SUPERANNUATION_FUND
-            - SINGLEMEMBERLLC
             - SOLE_TRADER
             - SUPERANNUATION_FUND
             - TRUST
+            - PERSONAL
+            - SINGLEMEMBERLLC
+            - CCORPORATIONLLC
+            - PARTNERSHIPLLC
+            - SCORPORATIONLLC
+            - LLC
+            - NOTLLC
             - UNSPECIFIED
         BaseCurrency:
           $ref: "#/components/schemas/CurrencyCode"
@@ -23129,25 +23129,25 @@ components:
           type: string
           enum:
             - ACCOUNTING_PRACTICE
-            - CCORPORATIONLLC
             - COMPANY
             - CHARITY
             - CLUB_OR_SOCIETY
             - INDIVIDUAL
-            - LLC
             - LOOK_THROUGH_COMPANY
             - NOT_FOR_PROFIT
-            - NOTLLC
             - PARTNERSHIP
-            - PARTNERSHIPLLC
-            - PERSONAL
             - S_CORPORATION
-            - SCORPORATIONLLC
             - SELF_MANAGED_SUPERANNUATION_FUND
-            - SINGLEMEMBERLLC
             - SOLE_TRADER
             - SUPERANNUATION_FUND
             - TRUST
+            - PERSONAL
+            - SINGLEMEMBERLLC
+            - CCORPORATIONLLC
+            - PARTNERSHIPLLC
+            - SCORPORATIONLLC
+            - LLC
+            - NOTLLC
             - UNSPECIFIED
         ShortCode:
           description: A unique identifier for the organisation. Potential uses.


### PR DESCRIPTION
## Description

Follow up to #805. This PR reorders the `OrganisationType` and `OrganisationEntityType` enums to keep the previous values in order and append new values rather than sort / alphabetise. This is to ensure that SDKs like the .Net standard version, do not reassign enum backing int values to different values. 

https://xero.atlassian.net/browse/PDSER-7782