### PR TITLE
Add BASICLITE to Organisation Class enum in xero_accounting.yaml

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22912,6 +22912,7 @@ components:
             - GROW
             - COMPREHENSIVE
             - SIMPLE
+            - BASICLITE
         Edition:
           description: BUSINESS or PARTNER. Partner edition organisations are sold exclusively through accounting partners and have restricted functionality (e.g. no access to invoicing)
           type: string


### PR DESCRIPTION
## Description
Add BASICLITE to Organisation Class enum

The BASICLITE organisation class is being returned by the Xero API but is missing from the Class enum in the OpenAPI spec. This causes SDK code generation to fail with an unknown enum value, breaking integrations for organisations on the Basic Lite plan.

Change

Added BASICLITE to the Class enum in the Organisation schema in [xero_accounting.yaml](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Impact

Fixes SDK breakage for organisations with Class: BASICLITE
No breaking changes — additive enum value only