### PR TITLE
fix: add BASICLITE to Organisation Class enum BREAKING CHANGE: added …

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -22912,6 +22912,7 @@ components:
             - GROW
             - COMPREHENSIVE
             - SIMPLE
+            - BASICLITE
         Edition:
           description: BUSINESS or PARTNER. Partner edition organisations are sold exclusively through accounting partners and have restricted functionality (e.g. no access to invoicing)
           type: string


### PR DESCRIPTION
The Xero API returns `BASICLITE` as an organisation class for organisations on the Basic Lite plan, but this value is missing from the `Class` enum in the OpenAPI spec (xero_accounting.yaml).

This causes SDK code generation to produce enums that do not include BASICLITE, resulting in deserialization failures for affected organisations.

Acceptance Criteria:
- `BASICLITE` is added to the Organisation `Class` enum in xero_accounting.yaml
- PR raised to XeroAPI/Xero-OpenAPI upstream