### PR TITLE
feat(accounting): add UpdatedDateUTC field

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -5299,6 +5299,7 @@ paths:
                     TotalTax: 4.50
                     Total: 34.50
                     UpdatedDateUTC: /Date(1551812346157+0000)/
+                    UpdatedDateUTCString: 2019-03-05T18:59:06Z
                     CurrencyCode: NZD
                   - CreditNoteID: f8021bd2-9a6a-4c19-8477-163da0b9290f
                     CreditNoteNumber: ""
@@ -5327,6 +5328,7 @@ paths:
                     TotalTax: 6.00
                     Total: 46.00
                     UpdatedDateUTC: /Date(1551812506153+0000)/
+                    UpdatedDateUTCString: 2019-03-05T19:01:46Z
                     CurrencyCode: NZD
     put:
       security:
@@ -5558,6 +5560,7 @@ paths:
                     TotalTax: 6.00
                     Total: 46.00
                     UpdatedDateUTC: /Date(1551812702650+0000)/
+                    UpdatedDateUTCString: 2019-03-05T19:05:02Z
                     CurrencyCode: NZD
                     StatusAttributeString: OK
                     ValidationErrors:
@@ -5813,6 +5816,7 @@ paths:
                     TotalTax: 6.00
                     Total: 46.00
                     UpdatedDateUTC: /Date(1551812702650+0000)/
+                    UpdatedDateUTCString: 2019-03-05T19:05:02Z
                     CurrencyCode: NZD
                     StatusAttributeString: OK
                     ValidationErrors:
@@ -5950,6 +5954,7 @@ paths:
                     TotalTax: 4.50
                     Total: 34.50
                     UpdatedDateUTC: /Date(1551812346157+0000)/
+                    UpdatedDateUTCString: 2019-03-05T18:59:06Z
                     CurrencyCode: NZD
     post:
       security:
@@ -6198,6 +6203,7 @@ paths:
                     TotalTax: 6.00
                     Total: 46.00
                     UpdatedDateUTC: /Date(1551812704223+0000)/
+                    UpdatedDateUTCString: 2019-03-05T19:05:04Z
                     CurrencyCode: NZD
         "400":
           $ref: "#/components/responses/400Error"
@@ -7493,6 +7499,7 @@ paths:
                     TotalTax: 0.00
                     Total: 40.00
                     UpdatedDateUTC: /Date(1541176290160+0000)/
+                    UpdatedDateUTCString: 2018-11-02T16:31:30Z
                     CurrencyCode: NZD
                   - Type: ACCREC
                     InvoiceID: 046d8a6d-1ae1-4b4d-9340-5601bdf41b87
@@ -7535,6 +7542,7 @@ paths:
                     TotalTax: 6.00
                     Total: 46.00
                     UpdatedDateUTC: /Date(1541176592690+0000)/
+                    UpdatedDateUTCString: 2018-11-02T16:36:32Z
                     CurrencyCode: NZD
                     FullyPaidOnDate: /Date(1543449600000+0000)/
                   - Type: ACCREC
@@ -7571,6 +7579,7 @@ paths:
                     TotalTax: 15.00
                     Total: 115.00
                     UpdatedDateUTC: /Date(1541176648927+0000)/
+                    UpdatedDateUTCString: 2018-11-02T16:37:28Z
                     CurrencyCode: NZD
     put:
       security:
@@ -7898,6 +7907,7 @@ paths:
                     TotalTax: 0.00
                     Total: 40.00
                     UpdatedDateUTC: /Date(1552327126117+0000)/
+                    UpdatedDateUTCString: 2019-03-11T17:58:46Z
                     CurrencyCode: NZD
                     StatusAttributeString: OK
         "400":
@@ -8210,6 +8220,7 @@ paths:
                     TotalTax: 0.00
                     Total: 40.00
                     UpdatedDateUTC: /Date(1552327126117+0000)/
+                    UpdatedDateUTCString: 2019-03-11T17:58:46Z
                     CurrencyCode: NZD
                     StatusAttributeString: OK
         "400":
@@ -8368,6 +8379,7 @@ paths:
                     TotalTax: 0.00
                     Total: 148062.76
                     UpdatedDateUTC: /Date(1551981568133+0000)/
+                    UpdatedDateUTCString: 2019-03-07T17:59:28Z
                     CurrencyCode: NZD
                     FullyPaidOnDate: /Date(1552953600000+0000)/
                     StatusAttributeString: ERROR
@@ -8498,6 +8510,7 @@ paths:
                     TotalTax: 75.00
                     Total: 575.00
                     UpdatedDateUTC: /Date(1552329728987+0000)/
+                    UpdatedDateUTCString: 2019-03-11T18:42:08Z
                     CurrencyCode: NZD
         "400":
           $ref: "#/components/responses/400Error"
@@ -11112,6 +11125,7 @@ paths:
                     TotalTax: 0.00
                     Total: 500.00
                     UpdatedDateUTC: /Date(1552428535123+0000)/
+                    UpdatedDateUTCString: 2019-03-12T22:08:55Z
                     CurrencyCode: NZD
                   - OverpaymentID: 2a8bda49-8908-473b-8bcf-1f90990460eb
                     ID: 2a8bda49-8908-473b-8bcf-1f90990460eb
@@ -11138,6 +11152,7 @@ paths:
                     TotalTax: 0.00
                     Total: 20.00
                     UpdatedDateUTC: /Date(1552428568250+0000)/
+                    UpdatedDateUTCString: 2019-03-12T22:09:28Z
                     CurrencyCode: NZD
                   - OverpaymentID: ed7f6041-c915-4667-bd1d-54c48e92161e
                     ID: ed7f6041-c915-4667-bd1d-54c48e92161e
@@ -11164,6 +11179,7 @@ paths:
                     TotalTax: 0.00
                     Total: 3000.00
                     UpdatedDateUTC: /Date(1552428781527+0000)/
+                    UpdatedDateUTCString: 2019-03-12T22:13:01Z
                     CurrencyCode: NZD
                   - OverpaymentID: 0859adbc-ea00-40cd-a877-258cf8644975
                     ID: 0859adbc-ea00-40cd-a877-258cf8644975
@@ -11190,6 +11206,7 @@ paths:
                     TotalTax: 0.00
                     Total: 20.00
                     UpdatedDateUTC: /Date(1552428842190+0000)/
+                    UpdatedDateUTCString: 2019-03-12T22:14:02Z
                     CurrencyCode: NZD
                   - OverpaymentID: 687b877f-634a-415d-92b2-74e62977de30
                     ID: 687b877f-634a-415d-92b2-74e62977de30
@@ -11216,6 +11233,7 @@ paths:
                     TotalTax: 0.00
                     Total: 20.00
                     UpdatedDateUTC: /Date(1552428950730+0000)/
+                    UpdatedDateUTCString: 2019-03-12T22:15:50Z
                     CurrencyCode: NZD
   /Overpayments/{OverpaymentID}:
     parameters:
@@ -11332,6 +11350,7 @@ paths:
                     TotalTax: 0.00
                     Total: 3000.00
                     UpdatedDateUTC: /Date(1552428952890+0000)/
+                    UpdatedDateUTCString: 2019-03-12T22:15:52Z
                     CurrencyCode: NZD
   /Overpayments/{OverpaymentID}/Allocations:
     parameters:
@@ -11642,6 +11661,7 @@ paths:
                     PaymentType: ACCRECPAYMENT
                     Status: AUTHORISED
                     UpdatedDateUTC: /Date(1541176592690+0000)/
+                    UpdatedDateUTCString: 2018-11-02T16:36:32Z
                     HasAccount: true
                     IsReconciled: false
                     Account:
@@ -11678,6 +11698,7 @@ paths:
                     PaymentType: ARCREDITPAYMENT
                     Status: AUTHORISED
                     UpdatedDateUTC: /Date(1551812346173+0000)/
+                    UpdatedDateUTCString: 2019-03-05T18:59:06Z
                     HasAccount: true
                     IsReconciled: false
                     Account:
@@ -11823,6 +11844,7 @@ paths:
                     PaymentType: ACCRECPAYMENT
                     Status: AUTHORISED
                     UpdatedDateUTC: /Date(1552432238623+0000)/
+                    UpdatedDateUTCString: 2019-03-12T23:10:38Z
                     HasAccount: true
                     IsReconciled: false
                     Account:
@@ -11868,6 +11890,7 @@ paths:
                       TotalTax: 30.00
                       Total: 230.00
                       UpdatedDateUTC: /Date(1552432238623+0000)/
+                      UpdatedDateUTCString: 2019-03-12T23:10:38Z
                       CurrencyCode: NZD
                     HasValidationErrors: true
                     ValidationErrors:
@@ -12007,6 +12030,7 @@ paths:
                     PaymentType: ACCRECPAYMENT
                     Status: AUTHORISED
                     UpdatedDateUTC: /Date(1552432238623+0000)/
+                    UpdatedDateUTCString: 2019-03-12T23:10:38Z
                     HasAccount: true
                     IsReconciled: false
                     Account:
@@ -12052,6 +12076,7 @@ paths:
                       TotalTax: 30.00
                       Total: 230.00
                       UpdatedDateUTC: /Date(1552432238623+0000)/
+                      UpdatedDateUTCString: 2019-03-12T23:10:38Z
                       CurrencyCode: NZD
                     HasValidationErrors: true
                     ValidationErrors:
@@ -12120,6 +12145,7 @@ paths:
                     PaymentType: ACCRECPAYMENT
                     Status: AUTHORISED
                     UpdatedDateUTC: /Date(1541176592690+0000)/
+                    UpdatedDateUTCString: 2018-11-02T16:36:32Z
                     HasAccount: true
                     IsReconciled: false
                     Account:
@@ -12172,6 +12198,7 @@ paths:
                       TotalTax: 6.00
                       Total: 46.00
                       UpdatedDateUTC: /Date(1541176592690+0000)/
+                      UpdatedDateUTCString: 2018-11-02T16:36:32Z
                       CurrencyCode: NZD
                       FullyPaidOnDate: /Date(1543449600000+0000)/
                     HasValidationErrors: false
@@ -12220,6 +12247,7 @@ paths:
                     PaymentType: APCREDITPAYMENT
                     Status: DELETED
                     UpdatedDateUTC: /Date(1583945852373+0000)/
+                    UpdatedDateUTCString: 2020-03-11T16:57:32Z
                     HasAccount: true
                     IsReconciled: false
                     Account:
@@ -12262,6 +12290,7 @@ paths:
                       TotalTax: 2.00
                       Total: 22.00
                       UpdatedDateUTC: /Date(1583945852363+0000)/
+                      UpdatedDateUTCString: 2020-03-11T16:57:32Z
                       CurrencyCode: AUD
                     HasValidationErrors: false
         "400":
@@ -12561,6 +12590,7 @@ paths:
                     TotalTax: 450.00
                     Total: 3450.00
                     UpdatedDateUTC: /Date(1552489187730+0000)/
+                    UpdatedDateUTCString: 2019-03-13T14:59:47Z
                     CurrencyCode: NZD
   /Prepayments/{PrepaymentID}:
     parameters:
@@ -12676,6 +12706,7 @@ paths:
                     TotalTax: 450.00
                     Total: 3450.00
                     UpdatedDateUTC: /Date(1552522424850+0000)/
+                    UpdatedDateUTCString: 2019-03-14T00:13:44Z
                     CurrencyCode: NZD
   /Prepayments/{PrepaymentID}/Allocations:
     parameters:
@@ -21626,6 +21657,12 @@ components:
           x-is-msdate-time: true
           example: /Date(1573755038314)/
           readOnly: true
+        UpdatedDateUTCString:
+          description: Last modified date ISO-8601 UTC format
+          type: string
+          format: date-time
+          example: 2019-11-14T18:10:38Z
+          readOnly: true
         CurrencyCode:
           description: The specified currency code
           $ref: "#/components/schemas/CurrencyCode"
@@ -22462,6 +22499,12 @@ components:
           type: string
           x-is-msdate-time: true
           example: /Date(1573755038314)/
+          readOnly: true
+        UpdatedDateUTCString:
+          description: Last modified date ISO-8601 UTC format
+          type: string
+          format: date-time
+          example: 2019-11-14T18:10:38Z
           readOnly: true
         CreditNotes:
           description: Details of credit notes that have been applied to an invoice
@@ -23711,6 +23754,12 @@ components:
           x-is-msdate-time: true
           example: /Date(1573755038314)/
           readOnly: true
+        UpdatedDateUTCString:
+          description: Last modified date ISO-8601 UTC format
+          type: string
+          format: date-time
+          example: 2019-11-14T18:10:38Z
+          readOnly: true
         CurrencyCode:
           $ref: "#/components/schemas/CurrencyCode"
           type: string
@@ -23860,6 +23909,12 @@ components:
           x-is-msdate-time: true
           example: /Date(1573755038314)/
           readOnly: true
+        UpdatedDateUTCString:
+          description: Last modified date ISO-8601 UTC format
+          type: string
+          format: date-time
+          example: 2019-11-14T18:10:38Z
+          readOnly: true
         PaymentID:
           description: The Xero identifier for an Payment e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9
           type: string
@@ -23979,6 +24034,12 @@ components:
           type: string
           x-is-msdate-time: true
           example: /Date(1573755038314)/
+          readOnly: true
+        UpdatedDateUTCString:
+          description: Last modified date ISO-8601 UTC format
+          type: string
+          format: date-time
+          example: 2019-11-14T18:10:38Z
           readOnly: true
         CurrencyCode:
           $ref: "#/components/schemas/CurrencyCode"

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -21658,7 +21658,7 @@ components:
           example: /Date(1573755038314)/
           readOnly: true
         UpdatedDateUTCString:
-          description: Last modified date ISO-8601 UTC format
+          description: UTC ISO-8601 formatted timestamp of last update to the credit note 
           type: string
           format: date-time
           example: 2019-11-14T18:10:38Z
@@ -22495,13 +22495,13 @@ components:
           format: double
           x-is-money: true
         UpdatedDateUTC:
-          description: Last modified date UTC format
+          description: UTC timestamp of last update to the invoice
           type: string
           x-is-msdate-time: true
           example: /Date(1573755038314)/
           readOnly: true
         UpdatedDateUTCString:
-          description: Last modified date ISO-8601 UTC format
+          description: UTC ISO-8601 formatted timestamp of last update to the invoice
           type: string
           format: date-time
           example: 2019-11-14T18:10:38Z
@@ -23755,7 +23755,7 @@ components:
           example: /Date(1573755038314)/
           readOnly: true
         UpdatedDateUTCString:
-          description: Last modified date ISO-8601 UTC format
+          description: UTC ISO-8601 formatted timestamp of last update to the overpayment
           type: string
           format: date-time
           example: 2019-11-14T18:10:38Z
@@ -23910,7 +23910,7 @@ components:
           example: /Date(1573755038314)/
           readOnly: true
         UpdatedDateUTCString:
-          description: Last modified date ISO-8601 UTC format
+          description: UTC ISO-8601 formatted timestamp of last update to the payment
           type: string
           format: date-time
           example: 2019-11-14T18:10:38Z
@@ -24036,7 +24036,7 @@ components:
           example: /Date(1573755038314)/
           readOnly: true
         UpdatedDateUTCString:
-          description: Last modified date ISO-8601 UTC format
+          description: UTC ISO-8601 formatted timestamp of last update to the prepayment
           type: string
           format: date-time
           example: 2019-11-14T18:10:38Z

--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -21658,9 +21658,8 @@ components:
           example: /Date(1573755038314)/
           readOnly: true
         UpdatedDateUTCString:
-          description: UTC ISO-8601 formatted timestamp of last update to the credit note 
+          description: UTC ISO-8601 formatted timestamp of last update to the credit note
           type: string
-          format: date-time
           example: 2019-11-14T18:10:38Z
           readOnly: true
         CurrencyCode:
@@ -22503,7 +22502,6 @@ components:
         UpdatedDateUTCString:
           description: UTC ISO-8601 formatted timestamp of last update to the invoice
           type: string
-          format: date-time
           example: 2019-11-14T18:10:38Z
           readOnly: true
         CreditNotes:
@@ -23757,7 +23755,6 @@ components:
         UpdatedDateUTCString:
           description: UTC ISO-8601 formatted timestamp of last update to the overpayment
           type: string
-          format: date-time
           example: 2019-11-14T18:10:38Z
           readOnly: true
         CurrencyCode:
@@ -23912,7 +23909,6 @@ components:
         UpdatedDateUTCString:
           description: UTC ISO-8601 formatted timestamp of last update to the payment
           type: string
-          format: date-time
           example: 2019-11-14T18:10:38Z
           readOnly: true
         PaymentID:
@@ -24038,7 +24034,6 @@ components:
         UpdatedDateUTCString:
           description: UTC ISO-8601 formatted timestamp of last update to the prepayment
           type: string
-          format: date-time
           example: 2019-11-14T18:10:38Z
           readOnly: true
         CurrencyCode:


### PR DESCRIPTION
## Description
Add Open API documentation for the new `UpdatedDateUTCString` attribute to the Accounting API endpoints. 

This attribute returns the same timestamp as UpdatedDateUTC but in ISO-8601 format (e.g. `2025-02-26T08:02:32Z`) instead of the legacy `/Date(...)/` format

Endpoints updated:
- Payments
- Prepayments
- Overpayments
- Credit Notes
- Invoices