### PR TITLE
fix(accounting): make CreditNote SentToContact writable

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -21377,7 +21377,6 @@ components:
           type: string
         SentToContact:
           description: Boolean to set whether the credit note in the Xero app should be marked as “sent”. This can be set only on credit notes that have been approved
-          readOnly: true
           type: boolean
         CurrencyRate:
           description: The currency rate for a multicurrency invoice. If no rate is specified, the XE.com day rate is used


### PR DESCRIPTION
## Description

Remove the stale `readOnly: true` marker from `CreditNote.SentToContact`.

The live Accounting API accepts this field when creating or updating approved credit notes, and the wording and examples were updated for that behavior in #616. Leaving the schema marker in place still tells OpenAPI generators to omit or restrict the setter, so official SDK consumers cannot use the supported field through generated models.

This is an additive request-schema correction. It does not change the wire format or existing response behavior.

Fixes #826.

Good catch by @syl222, especially tracing the mismatch back to #616 and confirming both create and update behavior through the API Explorer.

## Validation

- `CreditNote.SentToContact` contract assertion: writable and boolean
- `bash scripts/api-diff/api-diff.test.sh`: 9 tests passed
- `oasdiff v1.23.0 breaking --fail-on WARN`: no breaking changes
- `oasdiff v1.23.0 changelog`: informational changes only, including writable request support for create and update
- `yamllint -c .yamllint.yml xero_accounting.yaml`
- `git diff --check`

Spectral was also attempted with the repository ruleset, but the current ruleset/tool combination crashes on both this branch and unmodified `origin/master` with `Cannot read properties of null (reading 'enum')`.