### PR TITLE
fix(assets): add asset description field

### DIFF
--- a/xero_assets.yaml
+++ b/xero_assets.yaml
@@ -264,6 +264,7 @@ paths:
             example:
               assetName: Computer74863
               assetNumber: "123477544"
+              description: A computer for computing
               purchaseDate: "2020-01-01"
               purchasePrice: 100.0
               disposalPrice: 23.23
@@ -316,6 +317,7 @@ paths:
                 assetId: 68f17094-af97-4f1b-b36b-013b45b6ad3c
                 assetName: Computer47822
                 assetNumber: "123478074"
+                description: A computer for computing
                 purchaseDate: 2020-01-01T00:00:00
                 purchasePrice: 100.0000
                 disposalPrice: 23.0000
@@ -661,6 +663,10 @@ components:
           type: string
           description: Must be unique.
           example: FA-0013
+        description:
+          type: string
+          description: A description of the asset. May be supplied when creating or updating an asset and is returned for individual assets when set; may be omitted from collection responses.
+          example: A computer for computing
         purchaseDate:
           type: string
           format: date


### PR DESCRIPTION
## Description

The Assets API documentation and detailed asset payloads include a `description` field, but the shared OpenAPI `Asset` schema does not currently define it. Generated SDK types therefore cannot expose the value returned by `GET /Assets/{id}` or allow it in create and update payloads.

This change adds `description` as an optional string property and documents its endpoint behavior. It also adds the field to the POST request and single-asset response examples while leaving collection examples unchanged because collection responses may omit it.

This is backward compatible: it only adds an optional request and response property and does not change existing required fields.

Sharp eye, @orangethunder; the individual-asset reproduction made the schema omission clear.

Fixes #621

### Validation

- Parser-backed contract check confirming `description` is an optional string and appears in the detailed examples
- `uvx yamllint -c .yamllint.yml xero_assets.yaml`
- `./scripts/api-diff/api-diff.test.sh`
- `oasdiff breaking --fail-on WARN`: no breaking changes
- `oasdiff changelog`: four informational optional-property additions, zero warnings or errors
- `oapi-codegen`: generated `Asset` gains only optional `Description *string` with `json:"description,omitempty"`
- `git diff --check`

The local Spectral run could not complete because its ruleset crashes on an existing null enum in both `master` and this branch (`Cannot read properties of null (reading 'enum')`).
