### PR TITLE
fix(accounting): remove invalid type from parameter reference

### DIFF
--- a/xero_accounting.yaml
+++ b/xero_accounting.yaml
@@ -14,7 +14,6 @@ paths:
   /Accounts:
     parameters:
       - $ref: "#/components/parameters/requiredHeader"
-        type: string
     get:
       security:
         - OAuth2:


### PR DESCRIPTION
## Description

Good catch by @bhaeussermann: the `/Accounts` path parameter reference includes a sibling `type` property, which is not allowed on an OpenAPI 3.0 Reference Object. Strict validators therefore reject the Accounting specification with an additional-properties error.

This removes only the redundant sibling. The referenced `requiredHeader` parameter remains unchanged.

Fixes #694

### Root cause

The `type: string` constraint was placed next to `$ref` rather than inside a Parameter Object schema. Reference Objects in OpenAPI 3.0 cannot be extended with sibling fields.

### Compatibility

This does not change an endpoint, parameter, or generated SDK type. It makes the existing reference valid for standards-compliant tooling.

### Validation

- `swagger-cli validate xero_accounting.yaml` (failed at `#/paths/~1Accounts/parameters/0` before the fix; passes afterward)
- `uvx yamllint -c .yamllint.yml xero_accounting.yaml`
- `./scripts/api-diff/api-diff.test.sh` (9 tests passed)
- Base-versus-current `oapi-codegen` types comparison (no generated differences)
- `git diff --check`

### Not run

- `./scripts/api-diff/api-diff.sh xero_accounting.yaml` requires Docker, which is unavailable locally. The repository CI workflow will run the diff check.
- A secondary `openapi-spec-validator` pass is blocked on both revisions by a pre-existing string-valued boolean default elsewhere in the Accounting specification.
- Native `oasdiff` comparison is blocked on both revisions by a pre-existing duplicate endpoint declaration.